### PR TITLE
Genesis migration: bootstrap a new chain from historical Audius data

### DIFF
--- a/cmd/genesis-replay/Makefile
+++ b/cmd/genesis-replay/Makefile
@@ -1,0 +1,40 @@
+BINARY      := genesis-replay
+EXT_DATA_DIR ?= .docker-data
+
+.PHONY: build keygen up down test-integration run verify clean
+
+## build: compile the genesis-replay binary
+build:
+	go build -o $(BINARY) .
+
+## keygen: generate a new genesis migration keypair
+keygen: build
+	./$(BINARY) keygen
+
+## up: start the docker-compose test stack (detached)
+up:
+	docker compose up -d --wait
+
+## down: tear down the stack and remove Docker-managed named volumes
+down:
+	docker compose down -v
+
+## test-integration: run the full end-to-end integration test
+## Prerequisites: stack must be running (make up)
+test-integration:
+	go test -v -tags integration -run TestGenesisReplay -timeout 20m ./...
+
+## run: replay entities from a source DB to a bootstrap chain
+## Required env vars: GENESIS_SRC_DSN, GENESIS_CHAIN_URL, GENESIS_MIGRATION_PRIVATE_KEY
+run: build
+	./$(BINARY) run
+
+## verify: diff entities and plays between two discovery-provider databases
+## Required env vars: GENESIS_SRC_DSN, GENESIS_DEST_DSN
+verify: build
+	./$(BINARY) verify
+
+## clean: remove the compiled binary and data directories under EXT_DATA_DIR (default: .docker-data)
+clean:
+	rm -f $(BINARY)
+	rm -rf "$(EXT_DATA_DIR)/test-validator" "$(EXT_DATA_DIR)/test-pg-data"

--- a/cmd/genesis-replay/README.md
+++ b/cmd/genesis-replay/README.md
@@ -1,0 +1,199 @@
+# genesis-replay
+
+Bootstraps a new Core chain with full historical Audius state by replaying
+synthetic `ManageEntity` and `TrackPlay` transactions sourced from a
+discovery-provider PostgreSQL database.
+
+## How it works
+
+The discovery provider indexes entity data from on-chain `ManageEntity`
+transactions. Because all historical data lives in the DP's postgres DB rather
+than on-chain, a new chain starts empty — `genesis-replay` bridges the gap by
+re-submitting every entity as a genesis migration transaction signed by a
+dedicated keypair. The DP treats transactions from `genesis_migration_address`
+as trusted and indexes them without wallet ownership checks.
+
+## Commands
+
+### `keygen`
+
+Generates a new Ethereum keypair for use as the genesis migration identity.
+
+```
+genesis-replay keygen
+```
+
+Prints the address and private key. Set the address as `genesis_migration_address`
+in the chain's genesis JSON (`pkg/core/config/genesis/prod-v2.json`), then pass
+the private key to `genesis-replay run`.
+
+---
+
+### `run`
+
+Reads every current, non-deleted entity from the source DB and submits it to
+the bootstrap chain as a `ManageEntity` transaction.
+
+```
+genesis-replay run \
+  --src-dsn     <postgres_dsn>   \
+  --chain-url   <bootstrap_url>  \
+  --private-key <hex_privkey>    \
+  [--network    prod|stage|dev]  \
+  [--concurrency 500]            \
+  [--batch-size  1000]           \
+  [--skip-users] [--skip-tracks] [--skip-playlists] [--skip-social] [--skip-plays]
+```
+
+All flags can also be set via environment variables:
+
+| Flag | Env var | Default | Description |
+|------|---------|---------|-------------|
+| `--src-dsn` | `GENESIS_SRC_DSN` | — | Source PostgreSQL DSN |
+| `--chain-url` | `GENESIS_CHAIN_URL` | `http://localhost:50051` | Bootstrap chain URL |
+| `--private-key` | `GENESIS_MIGRATION_PRIVATE_KEY` | — | Genesis migration private key (hex) |
+| `--network` | `NETWORK` | `prod` | EIP-712 signing domain (`prod`, `stage`, `dev`) |
+| `--concurrency` | `GENESIS_CONCURRENCY` | `500` | Concurrent transaction submissions |
+| `--batch-size` | `GENESIS_BATCH_SIZE` | `1000` | Rows fetched per DB query |
+| `--skip-users` | `GENESIS_SKIP_USERS` | false | Skip user replay |
+| `--skip-tracks` | `GENESIS_SKIP_TRACKS` | false | Skip track replay |
+| `--skip-playlists` | `GENESIS_SKIP_PLAYLISTS` | false | Skip playlist replay |
+| `--skip-social` | `GENESIS_SKIP_SOCIAL` | false | Skip follows/saves/reposts replay |
+| `--skip-plays` | `GENESIS_SKIP_PLAYS` | false | Skip play replay |
+
+Entities are replayed in dependency order: users → tracks → playlists → social → plays.
+
+For maximum throughput, point `--chain-url` directly at the node's gRPC port (`http://host:50051`)
+rather than the HTTPS ingress. This bypasses nginx and TLS, roughly tripling the submission rate.
+
+---
+
+### `verify`
+
+Streams two discovery-provider databases in sorted order and performs a
+merge comparison to detect missing, extra, or changed rows.
+
+```
+genesis-replay verify \
+  --src <postgres_dsn>   \
+  --dst <postgres_dsn>   \
+  [--max-samples 10]     \
+  [--skip-plays]
+```
+
+| Flag | Env var | Default | Description |
+|------|---------|---------|-------------|
+| `--src` | `GENESIS_SRC_DSN` | — | Source (reference) database |
+| `--dst` | `GENESIS_DEST_DSN` | — | Destination database |
+| `--max-samples` | `GENESIS_MAX_SAMPLES` | `10` | Mismatch rows to print per entity type |
+| `--skip-plays` | `GENESIS_SKIP_PLAYS` | false | Skip play-count verification |
+
+Produces a summary table:
+
+```
+entity     src       dst       missing  extra  different  status
+------     ---       ---       -------  -----  ---------  ------
+users      1234567   1234567   0        0      0          OK
+tracks     4567890   4567890   0        0      0          OK
+plays      890123    890123    0        0      0          OK
+```
+
+**Exit codes**: `0` = all checks pass, `1` = mismatches found, `2` = fatal error.
+
+Plays are compared as per-track aggregate counts (`GROUP BY play_item_id`) so the
+command is safe to run against a full production dataset with billions of play rows.
+Memory usage is O(1) — only two rows are held in memory at any time.
+
+---
+
+## Discovery provider patches
+
+The DP must be rebuilt from source with the following env var set to relax
+validation rules that are incompatible with historical data:
+
+```
+AUDIUS_GENESIS_MIGRATION_MODE=true
+```
+
+This disables, for `CREATE` actions only:
+- Entity ID minimum offset checks (historical IDs are below the DP's offset thresholds)
+- User wallet uniqueness checks (one signing key is used for all entities)
+- Handle/name bad word filtering (historical handles may trip false positives)
+- Bio/name character limit enforcement
+- Signer ownership validation
+
+From the `apps` repo root:
+
+```bash
+docker build -t audius-discovery-provider:latest \
+  -f packages/discovery-provider/Dockerfile.prod \
+  packages/discovery-provider
+```
+
+The docker-compose stack sets `AUDIUS_GENESIS_MIGRATION_MODE=true` automatically.
+
+---
+
+## Local development
+
+The docker-compose stack in this directory provides everything needed to run the
+integration test locally: a postgres instance pre-seeded with both the source
+data and the discovery-provider schema, a local Core node, and a
+discovery-provider service.
+
+```bash
+# Start the stack using Docker-managed volumes (default)
+make up
+
+# Start the stack with data on an external drive
+EXT_DATA_DIR="/Volumes/T7 Shield" make up
+
+# Run the integration test (stack must be running)
+make test-integration
+
+# Tear down (leaves external data intact if EXT_DATA_DIR was set)
+make down
+
+# Remove external data directories
+EXT_DATA_DIR="/Volumes/T7 Shield" make clean
+```
+
+By default, `EXT_DATA_DIR` falls back to `.docker-data/` in the current directory.
+Data directories created under `EXT_DATA_DIR`:
+
+| Directory | Contents |
+|-----------|----------|
+| `test-validator/` | Core node chain data |
+| `test-pg-data/` | PostgreSQL data |
+
+### Stack requirements
+
+- `openaudio/go-openaudio:dev` — build with `make docker-dev` from the repo root
+- `audius-discovery-provider:latest` — build from `apps` repo with genesis mode patch (see above)
+
+### Ports
+
+| Service | Host port |
+|---------|-----------|
+| PostgreSQL | `5434` |
+| Core node (gRPC) | `50051` |
+| Ingress (HTTPS) | `443` |
+
+### Monitoring DP errors
+
+```bash
+docker logs genesis-replay-discovery-provider-1 2>&1 \
+  | grep -v "index_spl_token\|index_rewards_manager\|solders\|ParseError\|Traceback\|File \"/audius\|transactions_history\|AttributeError" \
+  | grep -i "error\|critical" \
+  | sed 's/.*"msg": "\([^"]*\)".*/\1/' \
+  | sort | uniq -c | sort -rn \
+  | head -20
+```
+
+---
+
+## Known limitations
+
+- `is_verified` (ETH-verified artist badge) is controlled by on-chain Ethereum
+  verification and cannot be set via `ManageEntity`. Replayed users will have
+  `is_verified = false` regardless of source data.

--- a/cmd/genesis-replay/docker-compose.yml
+++ b/cmd/genesis-replay/docker-compose.yml
@@ -1,0 +1,155 @@
+name: genesis-replay
+
+# Minimal stack for genesis replay testing.
+# All paths are relative to the repo root.
+#
+# Usage (from repo root):
+#   docker compose -f cmd/genesis-replay/docker-compose.yml up -d
+#   go run ./cmd/genesis-replay/... --src postgres://... --dst https://node1.oap.devnet
+#   docker compose -f cmd/genesis-replay/docker-compose.yml down -v
+
+services:
+
+  eth-ganache:
+    image: audius/eth-ganache:latest
+    pull_policy: always
+    stop_grace_period: 0s
+    # Run ganache directly against the pre-built contract DB — no blockscout wait needed.
+    command: >
+      npx ganache
+        --server.host 0.0.0.0
+        --wallet.deterministic
+        --wallet.totalAccounts 50
+        --database.dbPath /usr/db
+        --chain.networkId 12345
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          node -e "require('http').request({port:8545,method:'POST',headers:{'Content-Type':'application/json'}},
+          r=>{let d='';r.on('data',c=>d+=c);r.on('end',()=>process.exit(JSON.parse(d).result?0:1))}).end(JSON.stringify({jsonrpc:'2.0',method:'eth_blockNumber',params:[],id:1}))"
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  openaudio-1:
+    image: ${OPENAUDIO_IMAGE:-openaudio/go-openaudio:dev}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "curl -fsk https://localhost/health-check | grep -v 'core service not ready'"
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    environment:
+      NETWORK: dev
+      OPENAUDIO_ENV: dev
+      OPENAUDIO_GENESIS: dev-v2
+      OPENAUDIO_TLS_SELF_SIGNED: "true"
+      OPENAUDIO_GENESIS_MIGRATION: "true"
+      nodeEndpoint: https://node1.oap.devnet
+      delegatePrivateKey: d09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8
+      archive: "true"
+      stateSyncServeSnapshots: "true"
+      stateSyncEnable: "false"
+      audius_core_root_dir: /data/core
+      uptimeDataDir: /data/bolt
+      OPENAUDIO_PGALL: "true"
+    extra_hosts:
+      - "node1.oap.devnet:host-gateway"
+    volumes:
+      - ${EXT_DATA_DIR}/test-validator:/data
+    ports:
+      - "50051:50051"
+    depends_on:
+      eth-ganache:
+        condition: service_healthy
+
+  ingress:
+    image: nginx:latest
+    volumes:
+      - ../../dev/nginx.conf:/etc/nginx/conf.d/vhost.conf:ro
+      - ../../dev/tls/cert.pem:/etc/nginx/ssl/cert.pem:ro
+      - ../../dev/tls/key.pem:/etc/nginx/ssl/key.pem:ro
+    extra_hosts:
+      - "node1.oap.devnet:host-gateway"
+    ports:
+      - "80:80"
+      - "443:443"
+
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: discovery_provider_1
+    volumes:
+      - ../../cmd/genesis-replay/testdata/dp_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ../../cmd/genesis-replay/testdata/dp_seed.sql:/docker-entrypoint-initdb.d/02_seed.sql:ro
+      - ../../cmd/genesis-replay/testdata/source_init.sh:/docker-entrypoint-initdb.d/03_source_init.sh:ro
+      - ../../cmd/genesis-replay/testdata/seed.sql:/tmp/source_seed.sql:ro
+      - ${EXT_DATA_DIR}/test-pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "5434:5432"
+
+  redis:
+    image: redis:7.0
+    command: redis-server
+    healthcheck:
+      test: ["CMD", "redis-cli", "PING"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  discovery-provider:
+    image: audius-discovery-provider:latest
+    command: scripts/start.sh
+    environment:
+      # Database / cache
+      audius_db_url: postgresql://postgres:postgres@db:5432/discovery_provider_1
+      audius_db_url_read_replica: postgresql://postgres:postgres@db:5432/discovery_provider_1
+      audius_redis_url: redis://redis:6379/00
+
+      # ETH
+      audius_web3_eth_provider_url: http://eth-ganache:8545
+      audius_eth_contracts_registry: "0xABbfF712977dB51f9f212B85e8A4904c818C2b63"
+      audius_eth_contracts_token: "0xdcB2fC9469808630DD0744b0adf97C0003fC29B2"
+
+      # POA (entity manager / legacy contracts)
+      audius_web3_host: http://eth-ganache:8545
+      audius_contracts_registry: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      audius_contracts_entity_manager_address: "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
+
+      # Identity
+      audius_discprov_url: http://discovery-provider:5000
+      audius_delegate_owner_wallet: "0x73EB6d82CFB20bA669e9c178b718d770C49BB52f"
+      audius_delegate_private_key: d09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8
+
+      # Dev flags
+      audius_db_run_migrations: "false"
+      audius_discprov_dev_mode: "true"
+      AUDIUS_GENESIS_MIGRATION_MODE: "true"
+      audius_discprov_loglevel: info
+      audius_enable_rsyslog: "false"
+      PYTHONPYCACHEPREFIX: /tmp/pycache
+
+      # Stub Solana — point to ganache so the process starts without a live validator
+      audius_solana_endpoint: http://eth-ganache:8545
+    extra_hosts:
+      - "node1.oap.devnet:host-gateway"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      eth-ganache:
+        condition: service_healthy
+      openaudio-1:
+        condition: service_healthy
+

--- a/cmd/genesis-replay/integration_test.go
+++ b/cmd/genesis-replay/integration_test.go
@@ -1,0 +1,403 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// testMigrationPrivKey is the private key for the genesis_migration_address
+// configured in pkg/core/config/genesis/prod-v2.json.
+// Address: 0xF7Bd9D733fAD4e2f0594bb88180cef8D8D03dEbB
+// FOR LOCAL TESTING ONLY — this key has no value on any real network.
+const testMigrationPrivKey = "fc972c220946cde07bf3c6be380cc956c3d5680a2d7b225c660866e450cf1299"
+
+// TestGenesisReplay is a full end-to-end integration test.
+//
+// Prerequisites (all provided by docker-compose up in cmd/genesis-replay/):
+//   - genesis_replay_source postgres DB seeded with testdata/seed.sql
+//   - discovery_provider_1 postgres DB (empty except genesis block row)
+//   - openaudio-1 node running at GENESIS_CHAIN_URL (default: https://node1.oap.devnet)
+//   - discovery-provider service indexing the chain
+//
+// Optional env (defaults match docker-compose):
+//
+//	GENESIS_SRC_DSN    source DB DSN  (default: postgres://postgres:postgres@localhost:5432/genesis_replay_source)
+//	GENESIS_DEST_DSN   dest DB DSN    (default: postgres://postgres:postgres@localhost:5432/discovery_provider_1)
+//	GENESIS_CHAIN_URL  chain URL      (default: https://node1.oap.devnet)
+//
+// Run with:
+//
+//	go test -v -tags integration -run TestGenesisReplay -timeout 20m ./cmd/genesis-replay/...
+func TestGenesisReplay(t *testing.T) {
+	srcDSN := envOrDefault("GENESIS_SRC_DSN", "postgres://postgres:postgres@localhost:5434/genesis_replay_source?sslmode=disable")
+	dstDSN := envOrDefault("GENESIS_DEST_DSN", "postgres://postgres:postgres@localhost:5434/discovery_provider_1?sslmode=disable")
+	chainURL := envOrDefault("GENESIS_CHAIN_URL", "https://node1.oap.devnet")
+
+	privKey, err := parsePrivKey(testMigrationPrivKey)
+	require.NoError(t, err, "parse private key")
+
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	// 1. Connect to source DB and snapshot expected state.
+	srcPool, err := pgxpool.New(ctx, srcDSN)
+	require.NoError(t, err)
+	defer srcPool.Close()
+	require.NoError(t, srcPool.Ping(ctx), "ping source DB")
+
+	expected := snapshotSource(t, ctx, srcPool)
+	t.Logf("source snapshot: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts",
+		len(expected.users), len(expected.tracks), len(expected.playlists),
+		len(expected.follows), len(expected.saves), len(expected.reposts))
+
+	// 2. Run the replayer.
+	cfg := &ReplayConfig{
+		SrcDSN:      srcDSN,
+		ChainURL:    chainURL,
+		PrivKey:     privKey,
+		Network:     "dev",
+		Concurrency: 20,
+		BatchSize:   100,
+	}
+	r, err := NewReplayer(cfg, logger)
+	require.NoError(t, err, "init replayer")
+	defer r.Close()
+
+	require.NoError(t, r.Run(ctx), "run replayer")
+	t.Log("replay submitted, waiting for discovery provider to index...")
+
+	// 3. Connect to dest DB and wait for all replayed entity types to be indexed.
+	dstPool, err := pgxpool.New(ctx, dstDSN)
+	require.NoError(t, err)
+	defer dstPool.Close()
+	require.NoError(t, dstPool.Ping(ctx), "ping dest DB")
+
+	waitForCounts(t, ctx, dstPool, expected)
+
+	// 4. Compare source to indexed destination.
+	t.Log("indexing converged, comparing data...")
+	compareUsers(t, ctx, dstPool, expected.users)
+	compareTracks(t, ctx, dstPool, expected.tracks)
+	comparePlaylists(t, ctx, dstPool, expected.playlists)
+	compareFollows(t, ctx, dstPool, expected.follows)
+	compareSaves(t, ctx, dstPool, expected.saves)
+	compareReposts(t, ctx, dstPool, expected.reposts)
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// ---- source snapshot --------------------------------------------------------
+
+type sourceSnapshot struct {
+	users     []snapshotUser
+	tracks    []snapshotTrack
+	playlists []snapshotPlaylist
+	follows   []followPair
+	saves     []saveTuple
+	reposts   []repostTuple
+}
+
+type snapshotUser struct {
+	UserID   int64
+	Handle   string
+	Name     string
+	Bio      string
+	Location string
+	// IsVerified is omitted: set by on-chain ETH verification, not replayable via entity manager.
+}
+
+type snapshotTrack struct {
+	TrackID int64
+	OwnerID int64
+	Title   string
+	Genre   string
+}
+
+type snapshotPlaylist struct {
+	PlaylistID      int64
+	PlaylistOwnerID int64
+	PlaylistName    string
+	IsAlbum         bool
+}
+
+type followPair struct{ Follower, Followee int64 }
+
+type saveTuple struct {
+	UserID   int64
+	ItemID   int64
+	SaveType string
+}
+
+type repostTuple struct {
+	UserID     int64
+	ItemID     int64
+	RepostType string
+}
+
+func snapshotSource(t *testing.T, ctx context.Context, db *pgxpool.Pool) sourceSnapshot {
+	t.Helper()
+	var s sourceSnapshot
+
+	s.users = queryUsers(t, ctx, db)
+	s.tracks = queryTracks(t, ctx, db)
+	s.playlists = queryPlaylists(t, ctx, db)
+	s.follows = queryFollows(t, ctx, db)
+	s.saves = querySaves(t, ctx, db)
+	s.reposts = queryReposts(t, ctx, db)
+	return s
+}
+
+func queryUsers(t *testing.T, ctx context.Context, db *pgxpool.Pool) []snapshotUser {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT user_id,
+		       COALESCE(handle, ''), COALESCE(name, ''),
+		       COALESCE(bio, ''), COALESCE(location, '')
+		FROM users
+		WHERE is_current = true AND is_deactivated = false AND is_available = true
+		ORDER BY user_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []snapshotUser
+	for rows.Next() {
+		var u snapshotUser
+		require.NoError(t, rows.Scan(&u.UserID, &u.Handle, &u.Name, &u.Bio, &u.Location))
+		out = append(out, u)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func queryTracks(t *testing.T, ctx context.Context, db *pgxpool.Pool) []snapshotTrack {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT track_id, owner_id, COALESCE(title, ''), COALESCE(genre, '')
+		FROM tracks
+		WHERE is_current = true AND is_delete = false AND is_available = true
+		ORDER BY track_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []snapshotTrack
+	for rows.Next() {
+		var tr snapshotTrack
+		require.NoError(t, rows.Scan(&tr.TrackID, &tr.OwnerID, &tr.Title, &tr.Genre))
+		out = append(out, tr)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func queryPlaylists(t *testing.T, ctx context.Context, db *pgxpool.Pool) []snapshotPlaylist {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT playlist_id, playlist_owner_id, COALESCE(playlist_name, ''), is_album
+		FROM playlists
+		WHERE is_current = true AND is_delete = false
+		ORDER BY playlist_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []snapshotPlaylist
+	for rows.Next() {
+		var p snapshotPlaylist
+		require.NoError(t, rows.Scan(&p.PlaylistID, &p.PlaylistOwnerID, &p.PlaylistName, &p.IsAlbum))
+		out = append(out, p)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func queryFollows(t *testing.T, ctx context.Context, db *pgxpool.Pool) []followPair {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT follower_user_id, followee_user_id
+		FROM follows
+		WHERE is_current = true AND is_delete = false
+		ORDER BY follower_user_id, followee_user_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []followPair
+	for rows.Next() {
+		var f followPair
+		require.NoError(t, rows.Scan(&f.Follower, &f.Followee))
+		out = append(out, f)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func querySaves(t *testing.T, ctx context.Context, db *pgxpool.Pool) []saveTuple {
+	t.Helper()
+	// The DP normalizes save_type 'album' → 'playlist'; match that here.
+	rows, err := db.Query(ctx, `
+		SELECT user_id, save_item_id,
+		       CASE save_type WHEN 'album' THEN 'playlist' ELSE save_type END
+		FROM saves
+		WHERE is_current = true AND is_delete = false
+		ORDER BY user_id, save_item_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []saveTuple
+	for rows.Next() {
+		var s saveTuple
+		require.NoError(t, rows.Scan(&s.UserID, &s.ItemID, &s.SaveType))
+		out = append(out, s)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func queryReposts(t *testing.T, ctx context.Context, db *pgxpool.Pool) []repostTuple {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT user_id, repost_item_id, repost_type
+		FROM reposts
+		WHERE is_current = true AND is_delete = false
+		ORDER BY user_id, repost_item_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []repostTuple
+	for rows.Next() {
+		var rp repostTuple
+		require.NoError(t, rows.Scan(&rp.UserID, &rp.ItemID, &rp.RepostType))
+		out = append(out, rp)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// ---- indexing wait ----------------------------------------------------------
+
+// waitForCounts polls the destination DB until all entity counts reach the
+// expected values, or until the context deadline.
+func waitForCounts(t *testing.T, ctx context.Context, db *pgxpool.Pool, exp sourceSnapshot) {
+	t.Helper()
+	type check struct {
+		name  string
+		want  int
+		query string
+	}
+	checks := []check{
+		{
+			"users",
+			len(exp.users),
+			`SELECT count(*) FROM users WHERE is_current=true AND is_deactivated=false AND is_available=true`,
+		},
+		{
+			"tracks",
+			len(exp.tracks),
+			`SELECT count(*) FROM tracks WHERE is_current=true AND is_delete=false AND is_available=true`,
+		},
+		{
+			"playlists",
+			len(exp.playlists),
+			`SELECT count(*) FROM playlists WHERE is_current=true AND is_delete=false`,
+		},
+		{
+			"follows",
+			len(exp.follows),
+			`SELECT count(*) FROM follows WHERE is_current=true AND is_delete=false`,
+		},
+		{
+			"saves",
+			len(exp.saves),
+			`SELECT count(*) FROM saves WHERE is_current=true AND is_delete=false`,
+		},
+		{
+			"reposts",
+			len(exp.reposts),
+			`SELECT count(*) FROM reposts WHERE is_current=true AND is_delete=false`,
+		},
+	}
+
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		if ctx.Err() != nil {
+			t.Fatal("context cancelled while waiting for indexing")
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for discovery provider indexing to converge")
+		}
+
+		allDone := true
+		for _, c := range checks {
+			var got int
+			if err := db.QueryRow(ctx, c.query).Scan(&got); err != nil {
+				t.Logf("poll %s: query error: %v", c.name, err)
+				allDone = false
+				continue
+			}
+			if got < c.want {
+				t.Logf("poll %s: %d / %d", c.name, got, c.want)
+				allDone = false
+			}
+		}
+		if allDone {
+			t.Log("all counts reached expected values")
+			return
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// ---- comparisons ------------------------------------------------------------
+
+func compareUsers(t *testing.T, ctx context.Context, db *pgxpool.Pool, expected []snapshotUser) {
+	t.Helper()
+	got := queryUsers(t, ctx, db)
+	assert.Equal(t, expected, got, "users mismatch")
+}
+
+func compareTracks(t *testing.T, ctx context.Context, db *pgxpool.Pool, expected []snapshotTrack) {
+	t.Helper()
+	got := queryTracks(t, ctx, db)
+	assert.Equal(t, expected, got, "tracks mismatch")
+}
+
+func comparePlaylists(t *testing.T, ctx context.Context, db *pgxpool.Pool, expected []snapshotPlaylist) {
+	t.Helper()
+	got := queryPlaylists(t, ctx, db)
+	assert.Equal(t, expected, got, "playlists mismatch")
+}
+
+func compareFollows(t *testing.T, ctx context.Context, db *pgxpool.Pool, expected []followPair) {
+	t.Helper()
+	got := queryFollows(t, ctx, db)
+	assert.Equal(t, expected, got, "follows mismatch")
+}
+
+func compareSaves(t *testing.T, ctx context.Context, db *pgxpool.Pool, expected []saveTuple) {
+	t.Helper()
+	got := querySaves(t, ctx, db)
+	assert.Equal(t, expected, got, "saves mismatch")
+}
+
+func compareReposts(t *testing.T, ctx context.Context, db *pgxpool.Pool, expected []repostTuple) {
+	t.Helper()
+	got := queryReposts(t, ctx, db)
+	assert.Equal(t, expected, got, "reposts mismatch")
+}

--- a/cmd/genesis-replay/main.go
+++ b/cmd/genesis-replay/main.go
@@ -1,0 +1,160 @@
+// cmd/genesis-replay: submits synthetic ManageEntity and TrackPlay transactions
+// to a bootstrap chain to seed it with the full historical Audius state.
+//
+// Usage:
+//
+//	genesis-replay keygen
+//	  Generates a new Ethereum keypair and prints the address and private key.
+//	  Set the printed address as genesis_migration_address in prod-v2.json.
+//
+//	genesis-replay run --src-dsn <postgres_dsn> --chain-url <url> --private-key <hex>
+//	  Replays all entities from the source database to the bootstrap chain.
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+)
+
+func main() {
+	app := &cli.App{
+		Name:  "genesis-replay",
+		Usage: "Seed a bootstrap Core chain with historical Audius state",
+		Commands: []*cli.Command{
+			keygenCmd(),
+			runCmd(),
+			verifyCmd(),
+		},
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func keygenCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "keygen",
+		Usage: "Generate a genesis migration keypair",
+		Action: func(c *cli.Context) error {
+			privKey, err := crypto.GenerateKey()
+			if err != nil {
+				return fmt.Errorf("generate key: %w", err)
+			}
+			addr := crypto.PubkeyToAddress(privKey.PublicKey)
+			privBytes := privKey.D.Bytes()
+			// pad to 32 bytes
+			padded := make([]byte, 32)
+			copy(padded[32-len(privBytes):], privBytes)
+			fmt.Printf("Address:     %s\n", addr.Hex())
+			fmt.Printf("PrivateKey:  0x%s\n", hex.EncodeToString(padded))
+			fmt.Println()
+			fmt.Println("Set genesis_migration_address in pkg/core/config/genesis/prod-v2.json to the address above.")
+			fmt.Println("Pass the private key to 'genesis-replay run --private-key <hex>'.")
+			return nil
+		},
+	}
+}
+
+func runCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "run",
+		Usage: "Replay entities from source DB to bootstrap chain",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "src-dsn",
+				Usage:    "Source PostgreSQL DSN (the DB dump)",
+				EnvVars:  []string{"GENESIS_SRC_DSN"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "chain-url",
+				Usage:   "Bootstrap chain URL (e.g. http://localhost:50051 for direct gRPC, https://node1.oap.devnet for HTTPS)",
+				EnvVars: []string{"GENESIS_CHAIN_URL"},
+				Value:   "http://localhost:50051",
+			},
+			&cli.StringFlag{
+				Name:     "private-key",
+				Usage:    "Genesis migration private key (hex, with or without 0x prefix)",
+				EnvVars:  []string{"GENESIS_MIGRATION_PRIVATE_KEY"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "network",
+				Usage:   "Network environment: prod, stage, dev",
+				EnvVars: []string{"NETWORK"},
+				Value:   "prod",
+			},
+			&cli.IntFlag{
+				Name:    "concurrency",
+				Usage:   "Number of concurrent transaction submissions",
+				EnvVars: []string{"GENESIS_CONCURRENCY"},
+				Value:   500,
+			},
+			&cli.IntFlag{
+				Name:    "batch-size",
+				Usage:   "Rows fetched from source DB per batch",
+				EnvVars: []string{"GENESIS_BATCH_SIZE"},
+				Value:   1000,
+			},
+			&cli.BoolFlag{Name: "skip-users", EnvVars: []string{"GENESIS_SKIP_USERS"}},
+			&cli.BoolFlag{Name: "skip-tracks", EnvVars: []string{"GENESIS_SKIP_TRACKS"}},
+			&cli.BoolFlag{Name: "skip-playlists", EnvVars: []string{"GENESIS_SKIP_PLAYLISTS"}},
+			&cli.BoolFlag{Name: "skip-social", EnvVars: []string{"GENESIS_SKIP_SOCIAL"}},
+			&cli.BoolFlag{Name: "skip-plays", EnvVars: []string{"GENESIS_SKIP_PLAYS"}},
+		},
+		Action: func(c *cli.Context) error {
+			privKey, err := parsePrivKey(c.String("private-key"))
+			if err != nil {
+				return fmt.Errorf("parse private key: %w", err)
+			}
+
+			logger, _ := zap.NewProduction()
+			defer logger.Sync()
+
+			cfg := &ReplayConfig{
+				SrcDSN:        c.String("src-dsn"),
+				ChainURL:      c.String("chain-url"),
+				PrivKey:       privKey,
+				Network:       c.String("network"),
+				Concurrency:   c.Int("concurrency"),
+				BatchSize:     c.Int("batch-size"),
+				SkipUsers:     c.Bool("skip-users"),
+				SkipTracks:    c.Bool("skip-tracks"),
+				SkipPlaylists: c.Bool("skip-playlists"),
+				SkipSocial:    c.Bool("skip-social"),
+				SkipPlays:     c.Bool("skip-plays"),
+			}
+
+			r, err := NewReplayer(cfg, logger)
+			if err != nil {
+				return fmt.Errorf("init replayer: %w", err)
+			}
+			defer r.Close()
+
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			return r.Run(ctx)
+		},
+	}
+}
+
+func parsePrivKey(s string) (*ecdsa.PrivateKey, error) {
+	s = strings.TrimPrefix(s, "0x")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.ToECDSA(b)
+}

--- a/cmd/genesis-replay/playlists.go
+++ b/cmd/genesis-replay/playlists.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+type playlistMetadataWrapper struct {
+	CID  string                `json:"cid"`
+	Data playlistMetadataInner `json:"data"`
+}
+
+type playlistMetadataInner struct {
+	PlaylistName              string      `json:"playlist_name"`
+	Description               string      `json:"description,omitempty"`
+	IsAlbum                   bool        `json:"is_album,omitempty"`
+	IsPrivate                 bool        `json:"is_private,omitempty"`
+	PlaylistImageSizesHash    string      `json:"playlist_image_sizes_multihash,omitempty"`
+	PlaylistContents          interface{} `json:"playlist_contents,omitempty"`
+	ReleaseDate               string      `json:"release_date,omitempty"`
+	IsStreamGated             bool        `json:"is_stream_gated,omitempty"`
+	StreamConditions          interface{} `json:"stream_conditions,omitempty"`
+	UPC                       string      `json:"upc,omitempty"`
+}
+
+type sourcePlaylist struct {
+	PlaylistID          int64
+	PlaylistOwnerID     int64
+	PlaylistName        *string
+	Description         *string
+	IsAlbum             bool
+	IsPrivate           bool
+	MetadataMultihash   *string
+	ImageSizesMultihash *string
+	PlaylistContents    []byte // JSONB
+	ReleaseDate         *string
+	IsStreamGated       bool
+	StreamConditions    []byte // JSONB
+}
+
+func (r *Replayer) replayPlaylists(ctx context.Context) error {
+	const countQ = `SELECT count(*) FROM playlists WHERE is_current = true AND is_delete = false`
+	const selectQ = `
+		SELECT
+			playlist_id, playlist_owner_id, playlist_name, description,
+			is_album, is_private,
+			metadata_multihash, playlist_image_sizes_multihash, playlist_contents,
+			release_date::text, is_stream_gated, stream_conditions
+		FROM playlists
+		WHERE is_current = true AND is_delete = false
+		ORDER BY playlist_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count playlists: %w", err)
+	}
+	r.logger.Info("replaying playlists", zap.Int64("total", total))
+
+	sem := make(chan struct{}, r.cfg.Concurrency)
+	batchStart := time.Now()
+	var processed int64
+
+	for offset := int64(0); offset < total; offset += int64(r.cfg.BatchSize) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		rows, err := r.srcDB.Query(ctx, selectQ, r.cfg.BatchSize, offset)
+		if err != nil {
+			return fmt.Errorf("query playlists at offset %d: %w", offset, err)
+		}
+
+		playlists, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (sourcePlaylist, error) {
+			var p sourcePlaylist
+			err := row.Scan(
+				&p.PlaylistID, &p.PlaylistOwnerID, &p.PlaylistName, &p.Description,
+				&p.IsAlbum, &p.IsPrivate,
+				&p.MetadataMultihash, &p.ImageSizesMultihash, &p.PlaylistContents,
+				&p.ReleaseDate, &p.IsStreamGated, &p.StreamConditions,
+			)
+			return p, err
+		})
+		if err != nil {
+			return fmt.Errorf("scan playlists: %w", err)
+		}
+
+		for _, p := range playlists {
+			if ctx.Err() != nil {
+				break
+			}
+			p := p
+
+			sem <- struct{}{}
+			go func() {
+				defer func() { <-sem }()
+				if err := r.submitPlaylist(ctx, p); err != nil {
+					if ctx.Err() == nil {
+						r.logger.Warn("playlist tx error", zap.Int64("playlist_id", p.PlaylistID), zap.Error(err))
+						r.stats["playlists"].Errors++
+					}
+				} else {
+					r.stats["playlists"].Submitted++
+				}
+			}()
+
+			processed++
+		}
+
+		if processed%10000 == 0 {
+			r.logProgress("playlists", processed, total, batchStart)
+		}
+	}
+
+	for i := 0; i < r.cfg.Concurrency; i++ {
+		sem <- struct{}{}
+	}
+
+	r.logProgress("playlists", processed, total, batchStart)
+	return nil
+}
+
+func (r *Replayer) submitPlaylist(ctx context.Context, p sourcePlaylist) error {
+	inner := playlistMetadataInner{
+		IsAlbum:       p.IsAlbum,
+		IsPrivate:     p.IsPrivate,
+		IsStreamGated: p.IsStreamGated,
+	}
+	if p.PlaylistName != nil {
+		inner.PlaylistName = *p.PlaylistName
+	}
+	if p.Description != nil {
+		inner.Description = *p.Description
+	}
+	if p.ImageSizesMultihash != nil {
+		inner.PlaylistImageSizesHash = *p.ImageSizesMultihash
+	}
+	if p.ReleaseDate != nil {
+		inner.ReleaseDate = *p.ReleaseDate
+	}
+	if len(p.PlaylistContents) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(p.PlaylistContents, &v); err == nil {
+			inner.PlaylistContents = v
+		}
+	}
+	if len(p.StreamConditions) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(p.StreamConditions, &v); err == nil {
+			inner.StreamConditions = v
+		}
+	}
+
+	cid := "genesis-import"
+	if p.MetadataMultihash != nil && *p.MetadataMultihash != "" {
+		cid = *p.MetadataMultihash
+	}
+
+	wrapper := playlistMetadataWrapper{CID: cid, Data: inner}
+	metaJSON, err := json.Marshal(wrapper)
+	if err != nil {
+		return fmt.Errorf("marshal playlist metadata: %w", err)
+	}
+
+	return r.submitManageEntity(ctx, &corev1.ManageEntityLegacy{
+		UserId:     p.PlaylistOwnerID,
+		EntityType: "Playlist",
+		EntityId:   p.PlaylistID,
+		Action:     "Create",
+		Metadata:   string(metaJSON),
+	})
+}

--- a/cmd/genesis-replay/plays.go
+++ b/cmd/genesis-replay/plays.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type sourcePlay struct {
+	UserID    *string
+	TrackID   string
+	CreatedAt time.Time
+	City      *string
+	Region    *string
+	Country   *string
+}
+
+// replayPlays replays individual play events as TrackPlay transactions.
+// For large datasets, use --skip-plays and handle plays separately.
+// Plays are batched into TrackPlays messages (up to playsPerBatch per tx).
+func (r *Replayer) replayPlays(ctx context.Context) error {
+	const playsPerBatch = 100
+
+	const countQ = `SELECT count(*) FROM plays`
+	const selectQ = `
+		SELECT
+			user_id::text, play_item_id::text, created_at,
+			city, region, country
+		FROM plays
+		ORDER BY created_at, play_item_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count plays: %w", err)
+	}
+	r.logger.Info("replaying plays", zap.Int64("total", total))
+
+	batchStart := time.Now()
+	var processed int64
+
+	// Outer pagination over the plays table.
+	for offset := int64(0); offset < total; offset += int64(r.cfg.BatchSize) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		rows, err := r.srcDB.Query(ctx, selectQ, r.cfg.BatchSize, offset)
+		if err != nil {
+			return fmt.Errorf("query plays at offset %d: %w", offset, err)
+		}
+
+		var plays []sourcePlay
+		for rows.Next() {
+			var p sourcePlay
+			if err := rows.Scan(&p.UserID, &p.TrackID, &p.CreatedAt, &p.City, &p.Region, &p.Country); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan play: %w", err)
+			}
+			plays = append(plays, p)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("plays rows error: %w", err)
+		}
+
+		// Chunk into TrackPlays messages.
+		for i := 0; i < len(plays); i += playsPerBatch {
+			if ctx.Err() != nil {
+				break
+			}
+
+			end := i + playsPerBatch
+			if end > len(plays) {
+				end = len(plays)
+			}
+			chunk := plays[i:end]
+
+			trackPlays := make([]*corev1.TrackPlay, 0, len(chunk))
+			for _, p := range chunk {
+				tp := &corev1.TrackPlay{
+					TrackId:   p.TrackID,
+					Timestamp: timestamppb.New(p.CreatedAt),
+				}
+				if p.UserID != nil {
+					tp.UserId = *p.UserID
+				}
+				if p.City != nil {
+					tp.City = *p.City
+				}
+				if p.Region != nil {
+					tp.Region = *p.Region
+				}
+				if p.Country != nil {
+					tp.Country = *p.Country
+				}
+				trackPlays = append(trackPlays, tp)
+			}
+
+			req := &corev1.ForwardTransactionRequest{
+				Transaction: &corev1.SignedTransaction{
+					RequestId: uuid.NewString(),
+					Transaction: &corev1.SignedTransaction_Plays{
+						Plays: &corev1.TrackPlays{
+							Plays: trackPlays,
+						},
+					},
+				},
+			}
+
+			if err := r.forwardWithRetry(ctx, req); err != nil {
+				if ctx.Err() == nil {
+					r.logger.Warn("plays tx error", zap.Int("chunk_size", len(chunk)), zap.Error(err))
+					r.stats["plays"].Errors += int64(len(chunk))
+				}
+			} else {
+				r.stats["plays"].Submitted += int64(len(chunk))
+			}
+
+			processed += int64(len(chunk))
+		}
+
+		if processed%1000000 == 0 && processed > 0 {
+			r.logProgress("plays", processed, total, batchStart)
+		}
+	}
+
+	r.logProgress("plays", processed, total, batchStart)
+	return nil
+}

--- a/cmd/genesis-replay/replayer.go
+++ b/cmd/genesis-replay/replayer.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"connectrpc.com/connect"
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	corev1connect "github.com/OpenAudio/go-openaudio/pkg/api/core/v1/v1connect"
+	"github.com/OpenAudio/go-openaudio/pkg/core/config"
+	"github.com/OpenAudio/go-openaudio/pkg/core/server"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap"
+)
+
+// ReplayConfig holds configuration for the replay tool.
+type ReplayConfig struct {
+	SrcDSN        string
+	ChainURL      string
+	PrivKey       *ecdsa.PrivateKey
+	Network       string
+	Concurrency   int
+	BatchSize     int
+	SkipUsers     bool
+	SkipTracks    bool
+	SkipPlaylists bool
+	SkipSocial    bool
+	SkipPlays     bool
+}
+
+// EntityStats tracks progress per entity type.
+type EntityStats struct {
+	Submitted int64
+	Errors    int64
+}
+
+// Replayer orchestrates the genesis replay.
+type Replayer struct {
+	cfg        *ReplayConfig
+	srcDB      *pgxpool.Pool
+	chain      corev1connect.CoreServiceClient
+	sigConfig  *config.Config
+	privKey    *ecdsa.PrivateKey
+	signerAddr string
+	nonce      atomic.Uint64
+	logger     *zap.Logger
+	stats      map[string]*EntityStats
+}
+
+// NewReplayer creates and connects a Replayer.
+func NewReplayer(cfg *ReplayConfig, logger *zap.Logger) (*Replayer, error) {
+	srcDB, err := pgxpool.New(context.Background(), cfg.SrcDSN)
+	if err != nil {
+		return nil, fmt.Errorf("connect src db: %w", err)
+	}
+	if err := srcDB.Ping(context.Background()); err != nil {
+		return nil, fmt.Errorf("ping src db: %w", err)
+	}
+
+	chainURL := cfg.ChainURL
+	if !strings.HasPrefix(chainURL, "http://") && !strings.HasPrefix(chainURL, "https://") {
+		chainURL = "https://" + chainURL
+	}
+
+	var httpClient *http.Client
+	if strings.HasPrefix(chainURL, "http://") {
+		// h2c: plain HTTP/2 without TLS, used to bypass nginx and talk directly to gRPC port
+		httpClient = &http.Client{
+			Transport: &http2.Transport{
+				AllowHTTP: true,
+				DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+					return net.Dial(network, addr)
+				},
+			},
+			Timeout: 60 * time.Second,
+		}
+	} else {
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+			Timeout: 60 * time.Second,
+		}
+	}
+	chain := corev1connect.NewCoreServiceClient(httpClient, chainURL)
+
+	sigCfg := signingConfig(cfg.Network)
+
+	addr := crypto.PubkeyToAddress(cfg.PrivKey.PublicKey)
+	logger.Info("genesis migration keypair loaded",
+		zap.String("address", addr.Hex()),
+		zap.String("network", cfg.Network),
+		zap.String("acdc_address", sigCfg.AcdcEntityManagerAddress),
+		zap.Uint("acdc_chain_id", uint(sigCfg.AcdcChainID)),
+	)
+
+	r := &Replayer{
+		cfg:        cfg,
+		srcDB:      srcDB,
+		chain:      chain,
+		sigConfig:  sigCfg,
+		privKey:    cfg.PrivKey,
+		signerAddr: addr.Hex(),
+		logger:     logger,
+		stats:      map[string]*EntityStats{},
+	}
+	for _, et := range []string{"users", "tracks", "playlists", "follows", "saves", "reposts", "plays"} {
+		r.stats[et] = &EntityStats{}
+	}
+	return r, nil
+}
+
+// Close releases resources.
+func (r *Replayer) Close() {
+	r.srcDB.Close()
+}
+
+// Run executes the full replay in dependency order.
+func (r *Replayer) Run(ctx context.Context) error {
+	start := time.Now()
+	r.logger.Info("starting genesis replay")
+
+	steps := []struct {
+		name string
+		skip bool
+		fn   func(context.Context) error
+	}{
+		{"users", r.cfg.SkipUsers, r.replayUsers},
+		{"tracks", r.cfg.SkipTracks, r.replayTracks},
+		{"playlists", r.cfg.SkipPlaylists, r.replayPlaylists},
+		{"social (follows/saves/reposts)", r.cfg.SkipSocial, r.replaySocial},
+		{"plays", r.cfg.SkipPlays, r.replayPlays},
+	}
+
+	for _, step := range steps {
+		if step.skip {
+			r.logger.Info("skipping", zap.String("step", step.name))
+			continue
+		}
+		r.logger.Info("replaying", zap.String("step", step.name))
+		if err := step.fn(ctx); err != nil {
+			if ctx.Err() != nil {
+				r.logger.Info("replay interrupted by signal")
+				break
+			}
+			return fmt.Errorf("replay %s: %w", step.name, err)
+		}
+	}
+
+	r.printSummary(time.Since(start))
+	return nil
+}
+
+// submitManageEntity signs and forwards a ManageEntityLegacy transaction.
+// Retries once with backoff on mempool-full errors.
+func (r *Replayer) submitManageEntity(ctx context.Context, me *corev1.ManageEntityLegacy) error {
+	me.Nonce = r.nextNonce()
+
+	if err := server.SignManageEntity(r.sigConfig, me, r.privKey); err != nil {
+		return fmt.Errorf("sign: %w", err)
+	}
+
+	req := &corev1.ForwardTransactionRequest{
+		Transaction: &corev1.SignedTransaction{
+			RequestId: uuid.NewString(),
+			Transaction: &corev1.SignedTransaction_ManageEntity{
+				ManageEntity: me,
+			},
+		},
+	}
+
+	return r.forwardWithRetry(ctx, req)
+}
+
+// forwardWithRetry submits a transaction, retrying on mempool-full with backoff.
+func (r *Replayer) forwardWithRetry(ctx context.Context, req *corev1.ForwardTransactionRequest) error {
+	for attempt := 0; attempt < 5; attempt++ {
+		_, err := r.chain.ForwardTransaction(ctx, connect.NewRequest(req))
+		if err == nil {
+			return nil
+		}
+		if !strings.Contains(err.Error(), "mempool full") {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(500*(attempt+1)) * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("mempool full after retries")
+}
+
+// nextNonce returns a unique 32-byte hex-encoded nonce.
+func (r *Replayer) nextNonce() string {
+	n := r.nonce.Add(1)
+	b := make([]byte, 32)
+	b[24] = byte(n >> 56)
+	b[25] = byte(n >> 48)
+	b[26] = byte(n >> 40)
+	b[27] = byte(n >> 32)
+	b[28] = byte(n >> 24)
+	b[29] = byte(n >> 16)
+	b[30] = byte(n >> 8)
+	b[31] = byte(n)
+	return "0x" + hex.EncodeToString(b)
+}
+
+// signingConfig returns the EIP712 signing config for the given network.
+func signingConfig(network string) *config.Config {
+	switch network {
+	case "prod", "production", "mainnet":
+		return &config.Config{
+			AcdcEntityManagerAddress: config.ProdAcdcAddress,
+			AcdcChainID:              config.ProdAcdcChainID,
+		}
+	case "stage", "staging":
+		return &config.Config{
+			AcdcEntityManagerAddress: config.StageAcdcAddress,
+			AcdcChainID:              config.StageAcdcChainID,
+		}
+	default:
+		return &config.Config{
+			AcdcEntityManagerAddress: config.DevAcdcAddress,
+			AcdcChainID:              config.DevAcdcChainID,
+		}
+	}
+}
+
+// withConcurrency processes items concurrently up to r.cfg.Concurrency.
+// work is a function that receives a semaphore-style token; caller must call
+// release() when done. errors are logged and counted; the function does not stop on error.
+func (r *Replayer) withConcurrency(ctx context.Context, entityType string, work func(ctx context.Context) error) func() {
+	sem := make(chan struct{}, r.cfg.Concurrency)
+	return func() {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+		go func() {
+			defer func() { <-sem }()
+			if err := work(ctx); err != nil {
+				if ctx.Err() == nil {
+					r.logger.Warn("tx error", zap.String("type", entityType), zap.Error(err))
+					atomic.AddInt64(&r.stats[entityType].Errors, 1)
+				}
+			} else {
+				atomic.AddInt64(&r.stats[entityType].Submitted, 1)
+			}
+		}()
+	}
+}
+
+// drainSemaphore waits for all in-flight goroutines to finish.
+func drainSemaphore(sem chan struct{}, concurrency int) {
+	for i := 0; i < concurrency; i++ {
+		sem <- struct{}{}
+	}
+}
+
+// logProgress logs periodic progress for a batch.
+func (r *Replayer) logProgress(entityType string, processed, total int64, batchStart time.Time) {
+	elapsed := time.Since(batchStart).Seconds()
+	rate := float64(processed) / elapsed
+	r.logger.Info("progress",
+		zap.String("type", entityType),
+		zap.Int64("processed", processed),
+		zap.Int64("total", total),
+		zap.String("rate", fmt.Sprintf("%.0f/s", rate)),
+	)
+}
+
+func (r *Replayer) printSummary(elapsed time.Duration) {
+	r.logger.Info("replay complete", zap.Duration("elapsed", elapsed))
+	for entityType, s := range r.stats {
+		r.logger.Info("stats",
+			zap.String("type", entityType),
+			zap.Int64("submitted", s.Submitted),
+			zap.Int64("errors", s.Errors),
+		)
+	}
+}

--- a/cmd/genesis-replay/social.go
+++ b/cmd/genesis-replay/social.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"go.uber.org/zap"
+)
+
+func (r *Replayer) replaySocial(ctx context.Context) error {
+	if err := r.replayFollows(ctx); err != nil {
+		return fmt.Errorf("follows: %w", err)
+	}
+	if err := r.replaySaves(ctx); err != nil {
+		return fmt.Errorf("saves: %w", err)
+	}
+	if err := r.replayReposts(ctx); err != nil {
+		return fmt.Errorf("reposts: %w", err)
+	}
+	return nil
+}
+
+// --- Follows ---
+
+func (r *Replayer) replayFollows(ctx context.Context) error {
+	const countQ = `SELECT count(*) FROM follows WHERE is_current = true AND is_delete = false`
+	const selectQ = `
+		SELECT follower_user_id, followee_user_id
+		FROM follows
+		WHERE is_current = true AND is_delete = false
+		ORDER BY follower_user_id, followee_user_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count: %w", err)
+	}
+	r.logger.Info("replaying follows", zap.Int64("total", total))
+
+	type follow struct{ follower, followee int64 }
+	return r.replayTable(ctx, "follows", total, selectQ,
+		func(scan func(...any) error) (any, error) {
+			var f follow
+			return f, scan(&f.follower, &f.followee)
+		},
+		func(ctx context.Context, item any) error {
+			f := item.(follow)
+			return r.submitManageEntity(ctx, &corev1.ManageEntityLegacy{
+				UserId:     f.follower,
+				EntityType: "User",
+				EntityId:   f.followee,
+				Action:     "Follow",
+				Metadata:   "",
+			})
+		},
+	)
+}
+
+// --- Saves ---
+
+func (r *Replayer) replaySaves(ctx context.Context) error {
+	const countQ = `SELECT count(*) FROM saves WHERE is_current = true AND is_delete = false`
+	const selectQ = `
+		SELECT user_id, save_item_id, save_type
+		FROM saves
+		WHERE is_current = true AND is_delete = false
+		ORDER BY user_id, save_item_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count: %w", err)
+	}
+	r.logger.Info("replaying saves", zap.Int64("total", total))
+
+	type save struct {
+		userID, itemID int64
+		saveType       string
+	}
+	return r.replayTable(ctx, "saves", total, selectQ,
+		func(scan func(...any) error) (any, error) {
+			var s save
+			return s, scan(&s.userID, &s.itemID, &s.saveType)
+		},
+		func(ctx context.Context, item any) error {
+			s := item.(save)
+			return r.submitManageEntity(ctx, &corev1.ManageEntityLegacy{
+				UserId:     s.userID,
+				EntityType: saveRepostEntityType(s.saveType),
+				EntityId:   s.itemID,
+				Action:     "Save",
+				Metadata:   "",
+			})
+		},
+	)
+}
+
+// --- Reposts ---
+
+func (r *Replayer) replayReposts(ctx context.Context) error {
+	const countQ = `SELECT count(*) FROM reposts WHERE is_current = true AND is_delete = false`
+	const selectQ = `
+		SELECT user_id, repost_item_id, repost_type
+		FROM reposts
+		WHERE is_current = true AND is_delete = false
+		ORDER BY user_id, repost_item_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count: %w", err)
+	}
+	r.logger.Info("replaying reposts", zap.Int64("total", total))
+
+	type repost struct {
+		userID, itemID int64
+		repostType     string
+	}
+	return r.replayTable(ctx, "reposts", total, selectQ,
+		func(scan func(...any) error) (any, error) {
+			var rp repost
+			return rp, scan(&rp.userID, &rp.itemID, &rp.repostType)
+		},
+		func(ctx context.Context, item any) error {
+			rp := item.(repost)
+			return r.submitManageEntity(ctx, &corev1.ManageEntityLegacy{
+				UserId:     rp.userID,
+				EntityType: saveRepostEntityType(rp.repostType),
+				EntityId:   rp.itemID,
+				Action:     "Repost",
+				Metadata:   "",
+			})
+		},
+	)
+}
+
+// saveRepostEntityType maps save_type / repost_type strings to DP entity type names.
+func saveRepostEntityType(t string) string {
+	switch t {
+	case "track":
+		return "Track"
+	case "playlist", "album":
+		return "Playlist"
+	default:
+		return "Track"
+	}
+}
+
+// replayTable is a generic paginated table replayer.
+// scanFn scans a row into an item; submitFn submits that item to the chain.
+func (r *Replayer) replayTable(
+	ctx context.Context,
+	entityType string,
+	total int64,
+	selectQ string,
+	scanFn func(scan func(...any) error) (any, error),
+	submitFn func(ctx context.Context, item any) error,
+) error {
+	sem := make(chan struct{}, r.cfg.Concurrency)
+	batchStart := time.Now()
+	var processed int64
+
+	for offset := int64(0); offset < total; offset += int64(r.cfg.BatchSize) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		rows, err := r.srcDB.Query(ctx, selectQ, r.cfg.BatchSize, offset)
+		if err != nil {
+			return fmt.Errorf("query at offset %d: %w", offset, err)
+		}
+
+		// Collect all rows before dispatching goroutines to avoid shared cursor.
+		var items []any
+		for rows.Next() {
+			item, err := scanFn(rows.Scan)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("scan: %w", err)
+			}
+			items = append(items, item)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("rows error: %w", err)
+		}
+
+		for _, item := range items {
+			if ctx.Err() != nil {
+				break
+			}
+			item := item
+
+			sem <- struct{}{}
+			go func() {
+				defer func() { <-sem }()
+				if err := submitFn(ctx, item); err != nil {
+					if ctx.Err() == nil {
+						r.logger.Warn("tx error",
+							zap.String("type", entityType),
+							zap.Error(err),
+						)
+						r.stats[entityType].Errors++
+					}
+				} else {
+					r.stats[entityType].Submitted++
+				}
+			}()
+
+			processed++
+		}
+
+		if processed%100000 == 0 && processed > 0 {
+			r.logProgress(entityType, processed, total, batchStart)
+		}
+	}
+
+	// Drain semaphore.
+	for i := 0; i < r.cfg.Concurrency; i++ {
+		sem <- struct{}{}
+	}
+
+	r.logProgress(entityType, processed, total, batchStart)
+	return nil
+}

--- a/cmd/genesis-replay/testdata/dp_schema.sql
+++ b/cmd/genesis-replay/testdata/dp_schema.sql
@@ -1,0 +1,12797 @@
+--
+-- PostgreSQL database dump
+--
+
+
+-- Dumped from database version 17.7 (Debian 17.7-3.pgdg13+1)
+-- Dumped by pg_dump version 17.7 (Debian 17.7-3.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: hashids; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA hashids;
+
+
+--
+-- Name: amcheck; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS amcheck WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION amcheck; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION amcheck IS 'functions for verifying relation integrity';
+
+
+--
+-- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
+
+
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
+--
+-- Name: tsm_system_rows; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS tsm_system_rows WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION tsm_system_rows; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION tsm_system_rows IS 'TABLESAMPLE method which accepts number of rows as a limit';
+
+
+--
+-- Name: challengetype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.challengetype AS ENUM (
+    'boolean',
+    'numeric',
+    'aggregate',
+    'trending'
+);
+
+
+--
+-- Name: delist_entity; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.delist_entity AS ENUM (
+    'TRACKS',
+    'USERS'
+);
+
+
+--
+-- Name: delist_track_reason; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.delist_track_reason AS ENUM (
+    'DMCA',
+    'ACR',
+    'MANUAL',
+    'ACR_COUNTER_NOTICE',
+    'DMCA_RETRACTION',
+    'DMCA_COUNTER_NOTICE',
+    'DMCA_AND_ACR_COUNTER_NOTICE'
+);
+
+
+--
+-- Name: delist_user_reason; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.delist_user_reason AS ENUM (
+    'STRIKE_THRESHOLD',
+    'COPYRIGHT_SCHOOL',
+    'MANUAL'
+);
+
+
+--
+-- Name: event_entity_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.event_entity_type AS ENUM (
+    'track',
+    'collection',
+    'user'
+);
+
+
+--
+-- Name: event_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.event_type AS ENUM (
+    'remix_contest',
+    'live_event',
+    'new_release'
+);
+
+
+--
+-- Name: parental_warning_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.parental_warning_type AS ENUM (
+    'explicit',
+    'explicit_content_edited',
+    'not_explicit',
+    'no_advice_available'
+);
+
+
+--
+-- Name: profile_type_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.profile_type_enum AS ENUM (
+    'label'
+);
+
+
+--
+-- Name: reposttype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.reposttype AS ENUM (
+    'track',
+    'playlist',
+    'album'
+);
+
+
+--
+-- Name: savetype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.savetype AS ENUM (
+    'track',
+    'playlist',
+    'album'
+);
+
+
+--
+-- Name: sharetype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.sharetype AS ENUM (
+    'track',
+    'playlist'
+);
+
+
+--
+-- Name: skippedtransactionlevel; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.skippedtransactionlevel AS ENUM (
+    'node',
+    'network'
+);
+
+
+--
+-- Name: usdc_purchase_access_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.usdc_purchase_access_type AS ENUM (
+    'stream',
+    'download'
+);
+
+
+--
+-- Name: usdc_purchase_content_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.usdc_purchase_content_type AS ENUM (
+    'track',
+    'playlist',
+    'album'
+);
+
+
+--
+-- Name: wallet_chain; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.wallet_chain AS ENUM (
+    'eth',
+    'sol'
+);
+
+
+--
+-- Name: clean_alphabet_from_seps(text, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.clean_alphabet_from_seps(p_seps text, p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_seps ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    v_split_seps text[] := regexp_split_to_array(p_seps, '');
+    v_split_alphabet text[] := regexp_split_to_array(p_alphabet, '');
+    v_i integer := 1;
+    v_length integer := length(p_alphabet);
+    v_ret text := '';
+BEGIN
+	-- had to add this function because doing this:
+	-- p_alphabet := array_to_string(ARRAY( select chars.cha from (select unnest(regexp_split_to_array(p_alphabet, '')) as cha EXCEPT select unnest(regexp_split_to_array(p_seps, '')) as cha) as chars  ), '');
+	-- doesn't preserve the order of the input
+
+	for v_i in 1..v_length loop
+		--raise notice 'v_split_alphabet[%]: % != %', v_i, v_split_alphabet[v_i], v_split_alphabet[v_i] <> all (v_split_seps);
+		if (v_split_alphabet[v_i] <> all (v_split_seps)) then
+			v_ret = v_ret || v_split_alphabet[v_i];
+		end if;
+	end loop;
+
+	-- raise notice 'v_ret: %', v_ret;
+	return v_ret;
+END;
+$_$;
+
+
+--
+-- Name: clean_seps_from_alphabet(text, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.clean_seps_from_alphabet(p_seps text, p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_seps ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    v_split_seps text[] := regexp_split_to_array(p_seps, '');
+    v_split_alphabet text[] := regexp_split_to_array(p_alphabet, '');
+    v_i integer := 1;
+    v_length integer := length(p_seps);
+    v_ret text := '';
+BEGIN
+	-- had to add this function because doing this:
+	-- p_seps := array_to_string(ARRAY(select chars.cha from (select unnest(regexp_split_to_array(p_seps, '')) as cha intersect select unnest(regexp_split_to_array(p_alphabet, '')) as cha ) as chars order by ascii(cha) desc), '');
+	-- doesn't preserve the order of the input
+
+	for v_i in 1..v_length loop
+		-- raise notice 'v_split_seps[%]: %  == %', v_i, v_split_seps[v_i], v_split_seps[v_i] = any (v_split_alphabet);
+		if (v_split_seps[v_i] = any (v_split_alphabet)) then
+			v_ret = v_ret || v_split_seps[v_i];
+		end if;
+	end loop;
+
+	-- raise notice 'v_ret: %', v_ret;
+	return v_ret;
+END;
+$_$;
+
+
+--
+-- Name: consistent_shuffle(text, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.consistent_shuffle(p_alphabet text, p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE p_alphabet ALIAS FOR $1;
+	p_salt ALIAS FOR $2;
+	v_ls int;
+	v_i int;
+	v_v int := 0;
+	v_p int := 0;
+	v_n int := 0;
+	v_j int := 0;
+	v_temp char(1);
+BEGIN
+
+	-- Null or Whitespace?
+	IF p_salt IS NULL OR length(LTRIM(RTRIM(p_salt))) = 0 THEN
+		RETURN p_alphabet;
+	END IF;
+
+	v_ls := length(p_salt);
+	v_i := length(p_alphabet) - 1;
+
+	WHILE v_i > 0 LOOP
+
+		v_v := v_v % v_ls;
+		v_n := ascii(SUBSTRING(p_salt, v_v + 1, 1)); -- need some investigation to see if +1 here is because of 1 based arrays in sql ... this isn't in the reference JS or .net code.
+		v_p := v_p + v_n;
+		v_j := (v_n + v_v + v_p) % v_i;
+		v_temp := SUBSTRING(p_alphabet, v_j + 1, 1);
+		p_alphabet :=
+				SUBSTRING(p_alphabet, 1, v_j) ||
+				SUBSTRING(p_alphabet, v_i + 1, 1) ||
+				SUBSTRING(p_alphabet, v_j + 2, 255);
+		p_alphabet :=  SUBSTRING(p_alphabet, 1, v_i) || v_temp || SUBSTRING(p_alphabet, v_i + 2, 255);
+		v_i := v_i - 1;
+		v_v := v_v + 1;
+
+	END LOOP; -- WHILE
+
+	RETURN p_alphabet;
+
+END;
+$_$;
+
+
+--
+-- Name: decode(text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.decode(p_hash text) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt text := ''; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: decode(text, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: decode(text, text, integer); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length ALIAS for $3; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: decode(text, text, integer, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer, p_alphabet text) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length ALIAS for $3; -- default
+        p_alphabet ALIAS for $4; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: decode(text, text, integer, text, boolean); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_hash ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3;
+    p_alphabet ALIAS for $4;
+    p_zero_offset ALIAS for $5; -- adding an offset so that this can work with values from a zero based array language
+
+    v_seps text;
+    v_guards text;
+    v_alphabet text := p_alphabet;
+    v_lottery char(1);
+
+    v_hashBreakdown varchar(255);
+    v_hashArray text[];
+    v_index integer := 1;
+    v_j integer := 1;
+    v_hashArrayLength integer;
+    v_subHash varchar;
+    v_buffer varchar(255);
+    v_encodeCheck varchar(255);
+    v_ret_temp bigint;
+    v_ret bigint[];
+BEGIN
+
+    select * from hashids.setup_alphabet(p_salt, v_alphabet) into v_alphabet, v_seps, v_guards;
+    --raise notice 'v_seps: %', v_seps;
+    --raise notice 'v_alphabet: %', v_alphabet;
+    --raise notice 'v_guards: %', v_guards;
+
+    v_hashBreakdown := regexp_replace(p_hash, '[' || v_guards || ']', ' ');
+    v_hashArray := regexp_split_to_array(p_hash, '[' || v_guards || ']');
+
+    -- take the guards and replace with space,
+    -- split on space
+    -- if length is 3 or 2, set index to 1 else start at zero
+
+    -- if first index in idBreakDown isn't default
+
+    if ((array_length(v_hashArray, 1) = 3) or (array_length(v_hashArray, 1) = 2)) then
+        v_index := 2; -- in the example code (C# and js) it is 1 here, but postgresql arrays start at 1, so switching to 2
+    END IF;
+    --raise notice '%', v_hashArray;
+
+    v_hashBreakdown := v_hashArray[v_index];
+    --raise notice 'v_hashArray[%] %', v_index, v_hashBreakdown;
+    if (left(v_hashBreakdown, 1) <> '') IS NOT false then
+        v_lottery := left(v_hashBreakdown, 1);
+        --raise notice 'v_lottery %', v_lottery;
+        --raise notice 'SUBSTRING(%, 2, % - 1) %', v_hashBreakdown, length(v_hashBreakdown), SUBSTRING(v_hashBreakdown, 2);
+
+        v_hashBreakdown := SUBSTRING(v_hashBreakdown, 2);
+        v_hashArray := regexp_split_to_array(v_hashBreakdown, '[' || v_seps || ']');
+        --raise notice 'v_hashArray % -- %', v_hashArray, array_length(v_hashArray, 1);
+        v_hashArrayLength := array_length(v_hashArray, 1);
+        for v_j in 1..v_hashArrayLength LOOP
+            v_subHash := v_hashArray[v_j];
+            --raise notice 'v_subHash %', v_subHash;
+            v_buffer := v_lottery || p_salt || v_alphabet;
+            --raise notice 'v_buffer %', v_buffer;
+            --raise notice 'v_alphabet: hashids.consistent_shuffle(%, %) == %', v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)), hashids.consistent_shuffle(v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)));
+            v_alphabet := hashids.consistent_shuffle(v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)));
+            v_ret_temp := hashids.unhash(v_subHash, v_alphabet, p_zero_offset);
+            --raise notice 'v_ret_temp: %', v_ret_temp;
+            v_ret := array_append(v_ret, v_ret_temp);
+        END LOOP;
+        v_encodeCheck := hashids.encode_list(v_ret, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+        IF (v_encodeCheck <> p_hash) then
+            raise notice 'hashids.encodeList(%): % <> %', v_ret, v_encodeCheck, p_hash;
+            return ARRAY[]::bigint[];
+        end if;
+    end if;
+
+    RETURN v_ret;
+END;
+$_$;
+
+
+--
+-- Name: distinct_alphabet(text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.distinct_alphabet(p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_alphabet ALIAS for $1;
+    v_split_alphabet text[] := regexp_split_to_array(p_alphabet, '');
+    v_i integer := 2;
+    v_length integer := length(p_alphabet);
+    v_ret_array text[];
+BEGIN
+	-- had to add this function because doing this:
+	-- p_alphabet := string_agg(distinct chars.split_chars, '') from (select unnest(regexp_split_to_array(p_alphabet, '')) as split_chars) as chars;
+	-- doesn't preserve the order of the input, which was causing issues
+	if (v_length = 0) then
+		RAISE EXCEPTION 'alphabet must contain at least 1 char' USING HINT = 'Please check your alphabet';
+	end if;
+	v_ret_array := array_append(v_ret_array, v_split_alphabet[1]);
+
+	-- starting at 2 because already appended 1 to it.
+	for v_i in 2..v_length loop
+		-- raise notice 'v_split_alphabet[%]: % != %', v_i, v_split_alphabet[v_i], v_split_alphabet[v_i] <> all (v_ret_array);
+
+		if (v_split_alphabet[v_i] <> all (v_ret_array)) then
+			v_ret_array := array_append(v_ret_array, v_split_alphabet[v_i]);
+		end if;
+	end loop;
+
+	-- raise notice 'v_ret_array: %', array_to_string(v_ret_array, '');
+	return array_to_string(v_ret_array, '');
+END;
+$_$;
+
+
+--
+-- Name: encode(bigint); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt text := ''; -- default
+    p_min_hash_length integer := 0; -- default
+    p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode(bigint, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length integer := 0; -- default
+    p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode(bigint, text, integer); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3; -- default
+    p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode(bigint, text, integer, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer, p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3; -- default
+    p_alphabet ALIAS for $4; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode(bigint, text, integer, text, boolean); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3; -- default
+    p_alphabet ALIAS for $4; -- default
+    p_zero_offset ALIAS for $5 ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode_list(bigint[]); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[]) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+-- Options Data - generated by hashids-tsql
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt text := ''; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(p_numbers, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode_list(bigint[], text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+-- Options Data - generated by hashids-tsql
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(p_numbers, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode_list(bigint[], text, integer); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text, p_min_hash_length integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+-- Options Data - generated by hashids-tsql
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length ALIAS for $3; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(p_numbers, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+--
+-- Name: encode_list(bigint[], text, integer, text, boolean); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 350
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2;
+        p_min_hash_length ALIAS for $3;
+        p_alphabet ALIAS for $4;
+        p_zero_offset integer := case when $5 = true then 1 else 0 end ; -- adding an offset so that this can work with values from a zero based array language
+        v_seps text;
+        v_guards text;
+
+        -- Working Data
+        v_alphabet text := p_alphabet;
+        v_numbersHashInt int = 0;
+        v_lottery char(1);
+        v_buffer varchar(255);
+        v_last varchar(255);
+        v_ret varchar(255);
+        v_sepsIndex int;
+        v_lastId int;
+        v_count int = array_length(p_numbers, 1);
+        v_i int = 0;
+        v_id int = 0;
+        v_number int;
+        v_guardIndex int;
+        v_guard char(1);
+        v_halfLength int;
+        v_excess int;
+BEGIN
+
+    select * from hashids.setup_alphabet(p_salt, p_alphabet) into v_alphabet, v_seps, v_guards;
+    --raise notice 'v_seps: %', v_seps;
+    --raise notice 'v_alphabet: %', v_alphabet;
+    --raise notice 'v_guards: %', v_guards;
+
+    -- Calculate numbersHashInt
+    for v_lastId in 1..v_count LOOP
+        v_numbersHashInt := v_numbersHashInt + (p_numbers[v_lastId] % ((v_lastId-p_zero_offset) + 100));
+    END LOOP;
+
+    -- Choose lottery
+    v_lottery := SUBSTRING(v_alphabet, (v_numbersHashInt % length(v_alphabet)) + 1, 1); -- is this a +1 because of sql 1 based index, need to double check to see if can be replaced with param.
+    v_ret := v_lottery;
+
+    -- Encode many
+    v_i := 0;
+    v_id := 0;
+    for v_i in 1..v_count LOOP
+        v_number := p_numbers[v_i];
+        -- raise notice '%[%]: % for %', p_numbers, v_i, v_number, v_count;
+
+        v_buffer := v_lottery || p_salt || v_alphabet;
+        v_alphabet := hashids.consistent_shuffle(v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)));
+        v_last := hashids.hash(v_number, v_alphabet, cast(p_zero_offset as boolean));
+        v_ret := v_ret || v_last;
+        --raise notice 'v_ret: %', v_ret;
+        --raise notice '(v_i < v_count: % < % == %', v_i, v_count, (v_i < v_count);
+        IF (v_i) < v_count THEN
+            --raise notice 'v_sepsIndex:  % mod (% + %) == %', v_number, ascii(SUBSTRING(v_last, 1, 1)), v_i, (v_number % (ascii(SUBSTRING(v_last, 1, 1)) + v_i));
+            v_sepsIndex := v_number % (ascii(SUBSTRING(v_last, 1, 1)) + (v_i-p_zero_offset)); -- since this is 1 base vs 0 based bringing the number back down so that the mod is the same for zero based records
+            v_sepsIndex := v_sepsIndex % length(v_seps);
+            v_ret := v_ret || SUBSTRING(v_seps, v_sepsIndex+1, 1);
+        END IF;
+
+    END LOOP;
+
+    ----------------------------------------------------------------------------
+    -- Enforce minHashLength
+    ----------------------------------------------------------------------------
+    IF length(v_ret) < p_min_hash_length THEN
+
+        ------------------------------------------------------------------------
+        -- Add first 2 guard characters
+        ------------------------------------------------------------------------
+        v_guardIndex := (v_numbersHashInt + ascii(SUBSTRING(v_ret, 1, 1))) % length(v_guards);
+        v_guard := SUBSTRING(v_guards, v_guardIndex + 1, 1);
+        --raise notice '% || % is %', v_guard, v_ret, v_guard || v_ret;
+        v_ret := v_guard || v_ret;
+        IF length(v_ret) < p_min_hash_length THEN
+            v_guardIndex := (v_numbersHashInt + ascii(SUBSTRING(v_ret, 3, 1))) % length(v_guards);
+            v_guard := SUBSTRING(v_guards, v_guardIndex + 1, 1);
+            v_ret := v_ret || v_guard;
+        END IF;
+        ------------------------------------------------------------------------
+        -- Add the rest
+        ------------------------------------------------------------------------
+        WHILE length(v_ret) < p_min_hash_length LOOP
+            v_halfLength := COALESCE(v_halfLength, CAST((length(v_alphabet) / 2) as int));
+            v_alphabet := hashids.consistent_shuffle(v_alphabet, v_alphabet);
+            v_ret := SUBSTRING(v_alphabet, v_halfLength + 1, 255) || v_ret || SUBSTRING(v_alphabet, 1, v_halfLength);
+            v_excess := length(v_ret) - p_min_hash_length;
+            IF v_excess > 0 THEN
+                v_ret := SUBSTRING(v_ret, CAST((v_excess / 2) as int) + 1, p_min_hash_length);
+            END IF;
+        END LOOP;
+    END IF;
+    RETURN v_ret;
+END;
+$_$;
+
+
+--
+-- Name: hash(bigint, text, boolean); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.hash(p_input bigint, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 250
+    AS $_$
+DECLARE
+    p_input ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    p_zero_offset integer := case when $3 = true then 1 else 0 end ; -- adding an offset so that this can work with values from a zero based array language
+    v_hash varchar(255) := '';
+    v_alphabet_length integer := length($2);
+    v_pos integer;
+BEGIN
+
+    WHILE 1 = 1 LOOP
+        v_pos := (p_input % v_alphabet_length) + p_zero_offset; -- have to add one, because SUBSTRING in SQL starts at 1 instead of 0 (like it does in other languages)
+        --raise notice '% mod % == %', p_input, v_alphabet_length, v_pos;
+        --raise notice 'SUBSTRING(%, %, 1): %', p_alphabet, v_pos, (SUBSTRING(p_alphabet, v_pos, 1));
+        --raise notice '% || % == %', SUBSTRING(p_alphabet, v_pos, 1), v_hash, SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
+        v_hash := SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
+        p_input := CAST((p_input / v_alphabet_length) as int);
+        --raise notice 'p_input %', p_input;
+        IF p_input <= 0 THEN
+            EXIT;
+        END IF;
+    END LOOP;
+
+    RETURN v_hash;
+END;
+$_$;
+
+
+--
+-- Name: setup_alphabet(text, text); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.setup_alphabet(p_salt text DEFAULT ''::text, INOUT p_alphabet text DEFAULT 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'::text, OUT p_seps text, OUT p_guards text) RETURNS record
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_salt ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    p_seps ALIAS for $3;
+    p_guards ALIAS for $4;
+    v_sep_div float := 3.5;
+    v_guard_div float := 12.0;
+    v_guard_count integer;
+    v_seps_length integer;
+    v_seps_diff integer;
+BEGIN
+    p_seps := 'cfhistuCFHISTU';
+    -- p_alphabet := string_agg(distinct chars.split_chars, '') from (select unnest(regexp_split_to_array(p_alphabet, '')) as split_chars) as chars;
+		-- this also doesn't preserve the order of alphabet, but it doesn't appear to matter, never mind on that
+		p_alphabet := hashids.distinct_alphabet(p_alphabet);
+
+
+    if length(p_alphabet) < 16 then
+        RAISE EXCEPTION 'alphabet must contain 16 unique characters, it is: %', length(p_alphabet) USING HINT = 'Please check your alphabet';
+    end if;
+
+    -- seps should only contain character present in the passed alphabet
+    -- p_seps := array_to_string(ARRAY(select chars.cha from (select unnest(regexp_split_to_array(p_seps, '')) as cha intersect select unnest(regexp_split_to_array(p_alphabet, '')) as cha ) as chars order by ascii(cha) desc), '');
+    -- this doesn't preserve the input order, which is bad
+    p_seps := hashids.clean_seps_from_alphabet(p_seps, p_alphabet);
+
+    -- alphabet should not contain seps.
+    -- p_alphabet := array_to_string(ARRAY( select chars.cha from (select unnest(regexp_split_to_array(p_alphabet, '')) as cha EXCEPT select unnest(regexp_split_to_array(p_seps, '')) as cha) as chars  ), '');
+    -- this also doesn't prevserve the order
+    p_alphabet := hashids.clean_alphabet_from_seps(p_seps, p_alphabet);
+
+
+	p_seps := hashids.consistent_shuffle(p_seps, p_salt);
+
+	if (length(p_seps) = 0) or ((length(p_alphabet) / length(p_seps)) > v_sep_div) then
+		v_seps_length := cast( ceil( length(p_alphabet)/v_sep_div ) as integer);
+		if v_seps_length = 1 then
+			v_seps_length := 2;
+		end if;
+		if v_seps_length > length(p_seps) then
+			v_seps_diff := v_seps_length - length(p_seps);
+			p_seps := p_seps || SUBSTRING(p_alphabet, 1, v_seps_diff);
+			p_alphabet := SUBSTRING(p_alphabet, v_seps_diff + 1);
+		else
+			p_seps := SUBSTRING(p_seps, 1, v_seps_length + 1);
+		end if;
+	end if;
+
+	p_alphabet := hashids.consistent_shuffle(p_alphabet, p_salt);
+
+	v_guard_count := cast(ceil(length(p_alphabet) / v_guard_div ) as integer);
+
+	if length(p_alphabet) < 3 then
+		p_guards := SUBSTRING(p_seps, 1, v_guard_count);
+		p_seps := SUBSTRING(p_seps, v_guard_count + 1);
+	else
+		p_guards := SUBSTRING(p_alphabet, 1, v_guard_count);
+		p_alphabet := SUBSTRING(p_alphabet, v_guard_count + 1);
+	end if;
+
+END;
+$_$;
+
+
+--
+-- Name: unhash(text, text, boolean); Type: FUNCTION; Schema: hashids; Owner: -
+--
+
+CREATE FUNCTION hashids.unhash(p_input text, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS bigint
+    LANGUAGE plpgsql IMMUTABLE
+    AS $_$
+DECLARE
+    p_input ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    p_zero_offset integer := case when $3 = true then 1 else 0 end ; -- adding an offset so that this can work with values from a zero based array language
+    v_input_length integer := length($1);
+    v_alphabet_length integer := length($2);
+    v_ret bigint := 0;
+    v_input_char char(1);
+    v_pos integer;
+    v_i integer := 1;
+BEGIN
+    for v_i in 1..v_input_length loop
+        v_input_char := SUBSTRING(p_input, (v_i), 1);
+        v_pos := POSITION(v_input_char in p_alphabet) - p_zero_offset; -- have to remove one to interface with .net because it is a zero based index
+        --raise notice '%[%] is % to position % in %', p_input, v_i, v_input_char, v_pos, p_alphabet;
+        --raise notice '  % + (% * power(%, % - % - 1)) == %', v_ret, v_pos, v_alphabet_length, v_input_length, (v_i - 1), v_ret + (v_pos * power(v_alphabet_length, v_input_length - (v_i-1) - 1));
+        v_ret := v_ret + (v_pos * power(v_alphabet_length, v_input_length - (v_i-p_zero_offset) - 1));
+    end loop;
+
+    RETURN v_ret;
+END;
+$_$;
+
+
+--
+-- Name: add_fk_constraints(text[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.add_fk_constraints(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      -- Logging the action
+      RAISE NOTICE 'Adding foreign key constraint to table %', _table_name;
+
+      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (blocknumber) REFERENCES blocks (number) ON DELETE CASCADE',
+                     quote_ident(_table_name),
+                     quote_ident(_table_name || '_blocknumber_fkey'));
+
+   END LOOP;
+END
+$$;
+
+
+--
+-- Name: calculate_artist_coin_fee_earnings(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.calculate_artist_coin_fee_earnings(artist_coin_mint text) RETURNS TABLE(unclaimed_fees numeric, total_fees numeric)
+    LANGUAGE sql
+    AS $$
+    WITH
+    artist_positions AS (
+        SELECT
+            first_position AS position,
+            damm_v2_pool AS pool,
+            base_mint AS mint
+        FROM sol_meteora_dbc_migrations
+        WHERE base_mint = artist_coin_mint
+
+        UNION ALL
+
+        SELECT
+            position,
+            pool,
+            token_a_mint AS mint
+        FROM sol_meteora_damm_v2_initialize_custom_pool_instructions
+        WHERE token_a_mint = artist_coin_mint
+    ),
+    damm_v2_fees AS (
+        -- fee = totalLiquidity * feePerTokenStore
+        -- precision: (totalLiquidity * feePerTokenStore) >> 128
+        -- See: https://github.com/MeteoraAg/damm-v2-sdk/blob/70d1af59689039a1dc700dee8f741db48024d02d/src/helpers/utils.ts#L190-L191
+        SELECT
+            pool.token_a_mint AS mint,
+            (
+                pool.fee_b_per_liquidity
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS total,
+            (
+                (pool.fee_b_per_liquidity - position.fee_b_per_token_checkpoint)
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS unclaimed
+        FROM sol_meteora_damm_v2_pools pool
+        JOIN artist_positions p ON pool.account = p.pool
+        JOIN sol_meteora_damm_v2_positions position ON p.position = position.account
+        WHERE pool.token_a_mint = artist_coin_mint
+    ),
+    dbc_fees AS (
+        SELECT
+            base_mint AS mint,
+            total_trading_quote_fee / 2 AS total,
+            creator_quote_fee AS unclaimed
+        FROM artist_coin_pools
+        WHERE base_mint = artist_coin_mint
+    ),
+    all_fees AS (
+        SELECT * FROM damm_v2_fees
+        UNION ALL
+        SELECT * FROM dbc_fees
+    )
+    SELECT
+        COALESCE(FLOOR(SUM(unclaimed)), 0) AS unclaimed_fees,
+        COALESCE(FLOOR(SUM(total)), 0) AS total_fees
+    FROM artist_coins
+    LEFT JOIN all_fees USING (mint)
+    WHERE artist_coins.mint = artist_coin_mint;
+$$;
+
+
+--
+-- Name: calculate_artist_coin_fees(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.calculate_artist_coin_fees(artist_coin_mint text) RETURNS TABLE(unclaimed_dbc_fees numeric, total_dbc_fees numeric, unclaimed_damm_v2_fees numeric, total_damm_v2_fees numeric, unclaimed_fees numeric, total_fees numeric)
+    LANGUAGE sql
+    AS $$
+    WITH
+    damm_fees AS (
+        -- fee = totalLiquidity * feePerTokenStore
+        -- precision: (totalLiquidity * feePerTokenStore) >> 128
+        -- See: https://github.com/MeteoraAg/damm-v2-sdk/blob/70d1af59689039a1dc700dee8f741db48024d02d/src/helpers/utils.ts#L190-L191
+        SELECT
+            pool.token_a_mint AS mint,
+            (
+                pool.fee_b_per_liquidity
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS total_damm_v2_fees,
+            (
+                (pool.fee_b_per_liquidity - position.fee_b_per_token_checkpoint)
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS unclaimed_damm_v2_fees
+        FROM sol_meteora_damm_v2_pools pool
+        JOIN sol_meteora_dbc_migrations migration ON migration.base_mint = pool.token_a_mint
+        JOIN sol_meteora_damm_v2_positions position ON position.account = migration.first_position
+        WHERE pool.token_a_mint = artist_coin_mint
+    ),
+    dbc_fees AS (
+        SELECT
+            base_mint AS mint,
+            total_trading_quote_fee / 2 AS total_dbc_fees,
+            creator_quote_fee AS unclaimed_dbc_fees
+        FROM artist_coin_pools
+        WHERE base_mint = artist_coin_mint
+    )
+    SELECT
+        FLOOR(COALESCE(dbc_fees.unclaimed_dbc_fees, 0)) AS unclaimed_dbc_fees,
+        FLOOR(COALESCE(dbc_fees.total_dbc_fees, 0)) AS total_dbc_fees,
+        FLOOR(COALESCE(damm_fees.unclaimed_damm_v2_fees, 0)) AS unclaimed_damm_v2_fees,
+        FLOOR(COALESCE(damm_fees.total_damm_v2_fees, 0)) AS total_damm_v2_fees,
+        FLOOR(COALESCE(dbc_fees.unclaimed_dbc_fees, 0) + COALESCE(damm_fees.unclaimed_damm_v2_fees, 0)) AS unclaimed_fees,
+        FLOOR(COALESCE(dbc_fees.total_dbc_fees, 0) + COALESCE(damm_fees.total_damm_v2_fees, 0)) AS total_fees
+    FROM artist_coins
+    LEFT JOIN dbc_fees USING (mint)
+    FULL OUTER JOIN damm_fees USING (mint)
+    WHERE artist_coins.mint = artist_coin_mint;
+$$;
+
+
+--
+-- Name: calculate_artist_coin_locker(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.calculate_artist_coin_locker(artist_coin_mint text) RETURNS TABLE(address text, unlocked bigint, locked bigint, claimable bigint)
+    LANGUAGE sql
+    AS $$
+    WITH escrow AS (
+        SELECT
+            account,
+            amount_per_period,
+            number_of_period,
+            total_claimed_amount,
+            cliff_unlock_amount,
+            CASE WHEN to_timestamp(cliff_time) < NOW() THEN 0 ELSE cliff_unlock_amount END AS cliff_unlocked_amount,
+            LEAST(
+                FLOOR(
+                    (EXTRACT(EPOCH FROM NOW()) - vesting_start_time) / frequency
+                ),
+                number_of_period
+            ) AS periods_completed
+        FROM sol_locker_vesting_escrows
+        WHERE token_mint = artist_coin_mint
+    )
+    SELECT
+        account AS address,
+        cliff_unlocked_amount + periods_completed * amount_per_period AS unlocked,
+        cliff_unlock_amount - cliff_unlocked_amount + (number_of_period - periods_completed) * amount_per_period AS locked,
+        cliff_unlocked_amount + periods_completed * amount_per_period - total_claimed_amount AS claimable
+    FROM escrow;
+$$;
+
+
+--
+-- Name: chat_allowed(integer, integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.chat_allowed(from_user_id integer, to_user_id integer) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  can_message BOOLEAN;
+  permission_row chat_permissions%ROWTYPE;
+BEGIN
+
+  -- explicit block
+  IF EXISTS (
+    SELECT 1
+    FROM chat_blocked_users
+    WHERE
+      -- don't allow blockee to message blocker
+      (blocker_user_id = to_user_id AND blockee_user_id = from_user_id)
+      -- also don't allower blocker to message blockee (prohibit one way send)
+      OR (blocker_user_id = from_user_id AND blockee_user_id = to_user_id)
+  ) THEN
+    RETURN FALSE;
+  END IF;
+
+  -- no permissions set... assume ok
+  SELECT COUNT(*) = 0 INTO can_message
+  FROM chat_permissions
+  WHERE user_id = to_user_id;
+
+  IF can_message THEN
+    RETURN TRUE;
+  END IF;
+
+  -- existing chat takes priority over permissions
+  SELECT COUNT(*) > 0 INTO can_message
+  FROM chat_member member_a
+  JOIN chat_member member_b USING (chat_id)
+  JOIN chat_message USING (chat_id)
+  WHERE member_a.user_id = from_user_id
+    AND member_b.user_id = to_user_id
+    AND (member_b.cleared_history_at IS NULL OR chat_message.created_at > member_b.cleared_history_at)
+  ;
+
+  IF can_message THEN
+    RETURN TRUE;
+  END IF;
+
+
+  -- check permissions in turn:
+  FOR permission_row IN select * from chat_permissions WHERE user_id = to_user_id AND allowed = TRUE
+  LOOP
+    CASE permission_row.permits
+
+      WHEN 'followees' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM follows
+          WHERE followee_user_id = from_user_id
+          AND follower_user_id = to_user_id
+          AND is_delete = false
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'followers' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM follows
+          WHERE follower_user_id = from_user_id
+          AND followee_user_id = to_user_id
+          AND is_delete = false
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'tippees' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM user_tips tip
+          WHERE receiver_user_id = from_user_id
+          AND sender_user_id = to_user_id
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'tippers' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM user_tips tip
+          WHERE receiver_user_id = to_user_id
+          AND sender_user_id = from_user_id
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'verified' THEN
+        IF EXISTS (
+          SELECT 1 FROM USERS WHERE user_id = from_user_id AND is_verified = TRUE
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'none' THEN
+        RETURN FALSE;
+
+      WHEN 'all' THEN
+        RETURN TRUE;
+
+      ELSE
+        RAISE WARNING 'unknown permits: %s', permission_row.permits;
+    END CASE;
+  END LOOP;
+
+  RETURN FALSE;
+
+END;
+$$;
+
+
+--
+-- Name: chat_blast_audience(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.chat_blast_audience(blast_id_param text) RETURNS TABLE(blast_id text, to_user_id integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+
+  RETURN QUERY
+  -- follower_audience
+  SELECT chat_blast.blast_id, follower_user_id AS to_user_id
+  FROM follows
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'follower_audience'
+    AND follows.followee_user_id = chat_blast.from_user_id
+    AND follows.is_delete = false
+    AND follows.created_at < chat_blast.created_at
+
+  UNION
+
+  -- tipper_audience
+  SELECT chat_blast.blast_id, sender_user_id AS to_user_id
+  FROM user_tips tip
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'tipper_audience'
+    AND receiver_user_id = chat_blast.from_user_id
+    AND tip.created_at < chat_blast.created_at
+
+  UNION
+
+  -- remixer_audience (exclude tracks with access_authorities / programmable distribution)
+  SELECT chat_blast.blast_id, t.owner_id AS to_user_id
+  FROM tracks t
+  JOIN remixes ON remixes.child_track_id = t.track_id
+  JOIN tracks og ON remixes.parent_track_id = og.track_id
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'remixer_audience'
+    AND og.owner_id = chat_blast.from_user_id
+    AND t.owner_id != chat_blast.from_user_id
+    AND t.access_authorities IS NULL
+    AND og.access_authorities IS NULL
+    AND (
+      chat_blast.audience_content_id IS NULL
+      OR (
+        chat_blast.audience_content_type = 'track'
+        AND chat_blast.audience_content_id = og.track_id
+      )
+    )
+
+  UNION
+
+  -- customer_audience
+  SELECT chat_blast.blast_id, buyer_user_id AS to_user_id
+  FROM usdc_purchases p
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'customer_audience'
+    AND p.seller_user_id = chat_blast.from_user_id
+    AND (
+      chat_blast.audience_content_id IS NULL
+      OR (
+        chat_blast.audience_content_type = p.content_type::text
+        AND chat_blast.audience_content_id = p.content_id
+      )
+    )
+
+  UNION
+
+  -- coin_holder_audience
+  SELECT chat_blast.blast_id, sol_user_balances.user_id AS to_user_id
+  FROM chat_blast
+  JOIN artist_coins
+    ON artist_coins.user_id = chat_blast.from_user_id
+    -- Initial list of coin holders to check, filtered below to ensure they had coins at the time the blast was created
+  JOIN sol_user_balances
+    ON sol_user_balances.mint = artist_coins.mint
+  WHERE chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'coin_holder_audience'
+    AND sol_user_balances.user_id != chat_blast.from_user_id
+    AND user_mint_balance_at(
+      sol_user_balances.user_id,
+      artist_coins.mint,
+      chat_blast.created_at
+    ) >= POWER(10, artist_coins.decimals);
+
+END;
+$$;
+
+
+--
+-- Name: clear_user_records(integer[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.clear_user_records(user_ids integer[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+begin
+
+  delete from "user_bank_accounts" where "ethereum_address" in (select "wallet" from "users" where "user_id" = any(user_ids));
+  delete from "usdc_user_bank_accounts" where "ethereum_address" in (select "wallet" from "users" where "user_id" = any(user_ids));
+
+  delete from "users" where "user_id" = any(user_ids);
+  delete from "aggregate_user" where "user_id" = any(user_ids);
+  delete from "aggregate_user_tips" where "sender_user_id" = any(user_ids);
+  delete from "aggregate_user_tips" where "receiver_user_id" = any(user_ids);
+  delete from "user_tips" where "sender_user_id" = any(user_ids);
+  delete from "user_tips" where "receiver_user_id" = any(user_ids);
+  delete from "user_challenges" where "user_id" = any(user_ids);
+  delete from "follows" where "follower_user_id" = any(user_ids);
+  delete from "follows" where "followee_user_id" = any(user_ids);
+  delete from "user_pubkeys" where "user_id" = any(user_ids);
+  delete from "user_events" where "user_id" = any(user_ids);
+  delete from "saves" where "user_id" = any(user_ids);
+  delete from "challenge_disbursements" where "user_id" = any(user_ids);
+  delete from "challenge_profile_completion" where "user_id" = any(user_ids);
+  delete from "subscriptions" where "subscriber_id" = any(user_ids);
+  delete from "associated_wallets" where "user_id" = any(user_ids);
+  delete from "plays" where "user_id" = any(user_ids);
+  delete from "related_artists" where "user_id" = any(user_ids);
+  delete from "trending_results" where "user_id" = any(user_ids);
+  delete from "supporter_rank_ups" where "sender_user_id" = any(user_ids);
+  delete from "supporter_rank_ups" where "receiver_user_id" = any(user_ids);
+  delete from "user_balance_changes" where "user_id" = any(user_ids);
+  delete from "user_listening_history" where "user_id" = any(user_ids);
+  delete from "challenge_listen_streak" where "user_id" = any(user_ids);
+  delete from "user_balances" where "user_id" = any(user_ids);
+  delete from "chat_permissions" where "user_id" = any(user_ids);
+  delete from "chat_message_reactions" where "user_id" = any(user_ids);
+  delete from "playlist_seen" where "user_id" = any(user_ids);
+  delete from "chat_ban" where "user_id" = any(user_ids);
+  delete from "chat_blocked_users" where "blocker_user_id" = any(user_ids);
+  delete from "chat_blocked_users" where "blockee_user_id" = any(user_ids);
+  delete from "chat_member" where "user_id" = any(user_ids);
+  delete from "chat_message" where "user_id" = any(user_ids);
+  delete from "user_delist_statuses" where "user_id" = any(user_ids);
+  delete from "grants" where "user_id" = any(user_ids);
+  delete from "notification_seen" where "user_id" = any(user_ids);
+  delete from "developer_apps" where "user_id" = any(user_ids);
+  delete from "reposts" where "user_id" = any(user_ids);
+  delete from "playlists" where "playlist_owner_id" = any(user_ids);
+  delete from "playlist_routes" where "owner_id" = any(user_ids);
+  delete from "track_delist_statuses" where "owner_id" = any(user_ids);
+  delete from "track_routes" where "owner_id" = any(user_ids);
+  delete from "tracks" where "owner_id" = any(user_ids);
+  delete from "usdc_purchases" where "buyer_user_id" = any(user_ids);
+  delete from "usdc_purchases" where "seller_user_id" = any(user_ids);
+
+end;
+$$;
+
+
+--
+-- Name: compute_user_score(bigint, bigint, bigint, bigint, bigint, boolean, boolean, bigint, bigint); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.compute_user_score(play_count bigint, follower_count bigint, challenge_count bigint, chat_block_count bigint, following_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, distinct_tracks_played bigint, karma bigint) RETURNS bigint
+    LANGUAGE sql IMMUTABLE
+    AS $$
+select (play_count / 2) + follower_count - challenge_count - (chat_block_count * 100) + karma + case
+        when following_count < 5 then -1
+        else 0
+    end + case
+        when is_audius_impersonator then -1000
+        else 0
+    end + case
+        when distinct_tracks_played <= 3 then -10
+        else 0
+    end + case
+        when not has_profile_picture then -100
+        else 0
+    end $$;
+
+
+--
+-- Name: country_to_iso_alpha2(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.country_to_iso_alpha2(country_name text) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    iso2_code TEXT;
+BEGIN
+    SELECT INTO iso2_code
+    CASE
+        -- standards
+        WHEN country_name ILIKE 'Andorra' THEN 'AD'
+        WHEN country_name ILIKE 'United Arab Emirates' THEN 'AE'
+        WHEN country_name ILIKE 'Afghanistan' THEN 'AF'
+        WHEN country_name ILIKE 'Antigua and Barbuda' THEN 'AG'
+        WHEN country_name ILIKE 'Anguilla' THEN 'AI'
+        WHEN country_name ILIKE 'Albania' THEN 'AL'
+        WHEN country_name ILIKE 'Armenia' THEN 'AM'
+        WHEN country_name ILIKE 'Netherlands Antilles' THEN 'AN'
+        WHEN country_name ILIKE 'Angola' THEN 'AO'
+        WHEN country_name ILIKE 'Antarctica' THEN 'AQ'
+        WHEN country_name ILIKE 'Argentina' THEN 'AR'
+        WHEN country_name ILIKE 'American Samoa' THEN 'AS'
+        WHEN country_name ILIKE 'Austria' THEN 'AT'
+        WHEN country_name ILIKE 'Australia' THEN 'AU'
+        WHEN country_name ILIKE 'Aruba' THEN 'AW'
+        WHEN country_name ILIKE 'Åland' THEN 'AX'
+        WHEN country_name ILIKE 'Azerbaijan' THEN 'AZ'
+        WHEN country_name ILIKE 'Bosnia and Herzegovina' THEN 'BA'
+        WHEN country_name ILIKE 'Barbados' THEN 'BB'
+        WHEN country_name ILIKE 'Bangladesh' THEN 'BD'
+        WHEN country_name ILIKE 'Belgium' THEN 'BE'
+        WHEN country_name ILIKE 'Burkina Faso' THEN 'BF'
+        WHEN country_name ILIKE 'Bulgaria' THEN 'BG'
+        WHEN country_name ILIKE 'Bahrain' THEN 'BH'
+        WHEN country_name ILIKE 'Burundi' THEN 'BI'
+        WHEN country_name ILIKE 'Benin' THEN 'BJ'
+        WHEN country_name ILIKE 'Saint Barthélemy' THEN 'BL'
+        WHEN country_name ILIKE 'Bermuda' THEN 'BM'
+        WHEN country_name ILIKE 'Brunei Darussalam' THEN 'BN'
+        WHEN country_name ILIKE 'Bolivia' THEN 'BO'
+        WHEN country_name ILIKE 'Brazil' THEN 'BR'
+        WHEN country_name ILIKE 'Bahamas' THEN 'BS'
+        WHEN country_name ILIKE 'Bhutan' THEN 'BT'
+        WHEN country_name ILIKE 'Bouvet Island' THEN 'BV'
+        WHEN country_name ILIKE 'Botswana' THEN 'BW'
+        WHEN country_name ILIKE 'Belarus' THEN 'BY'
+        WHEN country_name ILIKE 'Belize' THEN 'BZ'
+        WHEN country_name ILIKE 'Canada' THEN 'CA'
+        WHEN country_name ILIKE 'Cocos (Keeling) Islands' THEN 'CC'
+        WHEN country_name ILIKE 'Congo (Kinshasa)' THEN 'CD'
+        WHEN country_name ILIKE 'Central African Republic' THEN 'CF'
+        WHEN country_name ILIKE 'Congo (Brazzaville)' THEN 'CG'
+        WHEN country_name ILIKE 'Switzerland' THEN 'CH'
+        WHEN country_name ILIKE 'Côte d''Ivoire' THEN 'CI'
+        WHEN country_name ILIKE 'Cook Islands' THEN 'CK'
+        WHEN country_name ILIKE 'Chile' THEN 'CL'
+        WHEN country_name ILIKE 'Cameroon' THEN 'CM'
+        WHEN country_name ILIKE 'China' THEN 'CN'
+        WHEN country_name ILIKE 'Colombia' THEN 'CO'
+        WHEN country_name ILIKE 'Costa Rica' THEN 'CR'
+        WHEN country_name ILIKE 'Cuba' THEN 'CU'
+        WHEN country_name ILIKE 'Cape Verde' THEN 'CV'
+        WHEN country_name ILIKE 'Christmas Island' THEN 'CX'
+        WHEN country_name ILIKE 'Cyprus' THEN 'CY'
+        WHEN country_name ILIKE 'Czech Republic' THEN 'CZ'
+        WHEN country_name ILIKE 'Germany' THEN 'DE'
+        WHEN country_name ILIKE 'Djibouti' THEN 'DJ'
+        WHEN country_name ILIKE 'Denmark' THEN 'DK'
+        WHEN country_name ILIKE 'Dominica' THEN 'DM'
+        WHEN country_name ILIKE 'Dominican Republic' THEN 'DO'
+        WHEN country_name ILIKE 'Algeria' THEN 'DZ'
+        WHEN country_name ILIKE 'Ecuador' THEN 'EC'
+        WHEN country_name ILIKE 'Estonia' THEN 'EE'
+        WHEN country_name ILIKE 'Egypt' THEN 'EG'
+        WHEN country_name ILIKE 'Western Sahara' THEN 'EH'
+        WHEN country_name ILIKE 'Eritrea' THEN 'ER'
+        WHEN country_name ILIKE 'Spain' THEN 'ES'
+        WHEN country_name ILIKE 'Ethiopia' THEN 'ET'
+        WHEN country_name ILIKE 'Finland' THEN 'FI'
+        WHEN country_name ILIKE 'Fiji' THEN 'FJ'
+        WHEN country_name ILIKE 'Falkland Islands' THEN 'FK'
+        WHEN country_name ILIKE 'Micronesia' THEN 'FM'
+        WHEN country_name ILIKE 'Faroe Islands' THEN 'FO'
+        WHEN country_name ILIKE 'France' THEN 'FR'
+        WHEN country_name ILIKE 'Gabon' THEN 'GA'
+        WHEN country_name ILIKE 'United Kingdom' THEN 'GB'
+        WHEN country_name ILIKE 'Grenada' THEN 'GD'
+        WHEN country_name ILIKE 'Georgia' THEN 'GE'
+        WHEN country_name ILIKE 'French Guiana' THEN 'GF'
+        WHEN country_name ILIKE 'Guernsey' THEN 'GG'
+        WHEN country_name ILIKE 'Ghana' THEN 'GH'
+        WHEN country_name ILIKE 'Gibraltar' THEN 'GI'
+        WHEN country_name ILIKE 'Greenland' THEN 'GL'
+        WHEN country_name ILIKE 'Gambia' THEN 'GM'
+        WHEN country_name ILIKE 'Guinea' THEN 'GN'
+        WHEN country_name ILIKE 'Guadeloupe' THEN 'GP'
+        WHEN country_name ILIKE 'Equatorial Guinea' THEN 'GQ'
+        WHEN country_name ILIKE 'Greece' THEN 'GR'
+        WHEN country_name ILIKE 'South Georgia and South Sandwich Islands' THEN 'GS'
+        WHEN country_name ILIKE 'Guatemala' THEN 'GT'
+        WHEN country_name ILIKE 'Guam' THEN 'GU'
+        WHEN country_name ILIKE 'Guinea-Bissau' THEN 'GW'
+        WHEN country_name ILIKE 'Guyana' THEN 'GY'
+        WHEN country_name ILIKE 'Hong Kong' THEN 'HK'
+        WHEN country_name ILIKE 'Heard and McDonald Islands' THEN 'HM'
+        WHEN country_name ILIKE 'Honduras' THEN 'HN'
+        WHEN country_name ILIKE 'Croatia' THEN 'HR'
+        WHEN country_name ILIKE 'Haiti' THEN 'HT'
+        WHEN country_name ILIKE 'Hungary' THEN 'HU'
+        WHEN country_name ILIKE 'Indonesia' THEN 'ID'
+        WHEN country_name ILIKE 'Ireland' THEN 'IE'
+        WHEN country_name ILIKE 'Israel' THEN 'IL'
+        WHEN country_name ILIKE 'Isle of Man' THEN 'IM'
+        WHEN country_name ILIKE 'India' THEN 'IN'
+        WHEN country_name ILIKE 'British Indian Ocean Territory' THEN 'IO'
+        WHEN country_name ILIKE 'Iraq' THEN 'IQ'
+        WHEN country_name ILIKE 'Iran' THEN 'IR'
+        WHEN country_name ILIKE 'Iceland' THEN 'IS'
+        WHEN country_name ILIKE 'Italy' THEN 'IT'
+        WHEN country_name ILIKE 'Jersey' THEN 'JE'
+        WHEN country_name ILIKE 'Jamaica' THEN 'JM'
+        WHEN country_name ILIKE 'Jordan' THEN 'JO'
+        WHEN country_name ILIKE 'Japan' THEN 'JP'
+        WHEN country_name ILIKE 'Kenya' THEN 'KE'
+        WHEN country_name ILIKE 'Kyrgyzstan' THEN 'KG'
+        WHEN country_name ILIKE 'Cambodia' THEN 'KH'
+        WHEN country_name ILIKE 'Kiribati' THEN 'KI'
+        WHEN country_name ILIKE 'Comoros' THEN 'KM'
+        WHEN country_name ILIKE 'Saint Kitts and Nevis' THEN 'KN'
+        WHEN country_name ILIKE 'Korea, North' THEN 'KP'
+        WHEN country_name ILIKE 'Korea, South' THEN 'KR'
+        WHEN country_name ILIKE 'Kuwait' THEN 'KW'
+        WHEN country_name ILIKE 'Cayman Islands' THEN 'KY'
+        WHEN country_name ILIKE 'Kazakhstan' THEN 'KZ'
+        WHEN country_name ILIKE 'Laos' THEN 'LA'
+        WHEN country_name ILIKE 'Lebanon' THEN 'LB'
+        WHEN country_name ILIKE 'Saint Lucia' THEN 'LC'
+        WHEN country_name ILIKE 'Liechtenstein' THEN 'LI'
+        WHEN country_name ILIKE 'Sri Lanka' THEN 'LK'
+        WHEN country_name ILIKE 'Liberia' THEN 'LR'
+        WHEN country_name ILIKE 'Lesotho' THEN 'LS'
+        WHEN country_name ILIKE 'Lithuania' THEN 'LT'
+        WHEN country_name ILIKE 'Luxembourg' THEN 'LU'
+        WHEN country_name ILIKE 'Latvia' THEN 'LV'
+        WHEN country_name ILIKE 'Libya' THEN 'LY'
+        WHEN country_name ILIKE 'Morocco' THEN 'MA'
+        WHEN country_name ILIKE 'Monaco' THEN 'MC'
+        WHEN country_name ILIKE 'Moldova' THEN 'MD'
+        WHEN country_name ILIKE 'Montenegro' THEN 'ME'
+        WHEN country_name ILIKE 'Saint Martin (French part)' THEN 'MF'
+        WHEN country_name ILIKE 'Madagascar' THEN 'MG'
+        WHEN country_name ILIKE 'Marshall Islands' THEN 'MH'
+        WHEN country_name ILIKE 'Macedonia' THEN 'MK'
+        WHEN country_name ILIKE 'Mali' THEN 'ML'
+        WHEN country_name ILIKE 'Myanmar' THEN 'MM'
+        WHEN country_name ILIKE 'Mongolia' THEN 'MN'
+        WHEN country_name ILIKE 'Macau' THEN 'MO'
+        WHEN country_name ILIKE 'Northern Mariana Islands' THEN 'MP'
+        WHEN country_name ILIKE 'Martinique' THEN 'MQ'
+        WHEN country_name ILIKE 'Mauritania' THEN 'MR'
+        WHEN country_name ILIKE 'Montserrat' THEN 'MS'
+        WHEN country_name ILIKE 'Malta' THEN 'MT'
+        WHEN country_name ILIKE 'Mauritius' THEN 'MU'
+        WHEN country_name ILIKE 'Maldives' THEN 'MV'
+        WHEN country_name ILIKE 'Malawi' THEN 'MW'
+        WHEN country_name ILIKE 'Mexico' THEN 'MX'
+        WHEN country_name ILIKE 'Malaysia' THEN 'MY'
+        WHEN country_name ILIKE 'Mozambique' THEN 'MZ'
+        WHEN country_name ILIKE 'Namibia' THEN 'NA'
+        WHEN country_name ILIKE 'New Caledonia' THEN 'NC'
+        WHEN country_name ILIKE 'Niger' THEN 'NE'
+        WHEN country_name ILIKE 'Norfolk Island' THEN 'NF'
+        WHEN country_name ILIKE 'Nigeria' THEN 'NG'
+        WHEN country_name ILIKE 'Nicaragua' THEN 'NI'
+        WHEN country_name ILIKE 'Netherlands' THEN 'NL'
+        WHEN country_name ILIKE 'Norway' THEN 'NO'
+        WHEN country_name ILIKE 'Nepal' THEN 'NP'
+        WHEN country_name ILIKE 'Nauru' THEN 'NR'
+        WHEN country_name ILIKE 'Niue' THEN 'NU'
+        WHEN country_name ILIKE 'New Zealand' THEN 'NZ'
+        WHEN country_name ILIKE 'Oman' THEN 'OM'
+        WHEN country_name ILIKE 'Panama' THEN 'PA'
+        WHEN country_name ILIKE 'Peru' THEN 'PE'
+        WHEN country_name ILIKE 'French Polynesia' THEN 'PF'
+        WHEN country_name ILIKE 'Papua New Guinea' THEN 'PG'
+        WHEN country_name ILIKE 'Philippines' THEN 'PH'
+        WHEN country_name ILIKE 'Pakistan' THEN 'PK'
+        WHEN country_name ILIKE 'Poland' THEN 'PL'
+        WHEN country_name ILIKE 'Saint Pierre and Miquelon' THEN 'PM'
+        WHEN country_name ILIKE 'Pitcairn' THEN 'PN'
+        WHEN country_name ILIKE 'Puerto Rico' THEN 'PR'
+        WHEN country_name ILIKE 'Palestine' THEN 'PS'
+        WHEN country_name ILIKE 'Portugal' THEN 'PT'
+        WHEN country_name ILIKE 'Palau' THEN 'PW'
+        WHEN country_name ILIKE 'Paraguay' THEN 'PY'
+        WHEN country_name ILIKE 'Qatar' THEN 'QA'
+        WHEN country_name ILIKE 'Reunion' THEN 'RE'
+        WHEN country_name ILIKE 'Romania' THEN 'RO'
+        WHEN country_name ILIKE 'Serbia' THEN 'RS'
+        WHEN country_name ILIKE 'Russian Federation' THEN 'RU'
+        WHEN country_name ILIKE 'Rwanda' THEN 'RW'
+        WHEN country_name ILIKE 'Saudi Arabia' THEN 'SA'
+        WHEN country_name ILIKE 'Solomon Islands' THEN 'SB'
+        WHEN country_name ILIKE 'Seychelles' THEN 'SC'
+        WHEN country_name ILIKE 'Sudan' THEN 'SD'
+        WHEN country_name ILIKE 'Sweden' THEN 'SE'
+        WHEN country_name ILIKE 'Singapore' THEN 'SG'
+        WHEN country_name ILIKE 'Saint Helena' THEN 'SH'
+        WHEN country_name ILIKE 'Slovenia' THEN 'SI'
+        WHEN country_name ILIKE 'Svalbard and Jan Mayen Islands' THEN 'SJ'
+        WHEN country_name ILIKE 'Slovakia' THEN 'SK'
+        WHEN country_name ILIKE 'Sierra Leone' THEN 'SL'
+        WHEN country_name ILIKE 'San Marino' THEN 'SM'
+        WHEN country_name ILIKE 'Senegal' THEN 'SN'
+        WHEN country_name ILIKE 'Somalia' THEN 'SO'
+        WHEN country_name ILIKE 'Suriname' THEN 'SR'
+        WHEN country_name ILIKE 'Sao Tome and Principe' THEN 'ST'
+        WHEN country_name ILIKE 'El Salvador' THEN 'SV'
+        WHEN country_name ILIKE 'Syria' THEN 'SY'
+        WHEN country_name ILIKE 'Swaziland' THEN 'SZ'
+        WHEN country_name ILIKE 'Turks and Caicos Islands' THEN 'TC'
+        WHEN country_name ILIKE 'Chad' THEN 'TD'
+        WHEN country_name ILIKE 'French Southern Lands' THEN 'TF'
+        WHEN country_name ILIKE 'Togo' THEN 'TG'
+        WHEN country_name ILIKE 'Thailand' THEN 'TH'
+        WHEN country_name ILIKE 'Tajikistan' THEN 'TJ'
+        WHEN country_name ILIKE 'Tokelau' THEN 'TK'
+        WHEN country_name ILIKE 'Timor-Leste' THEN 'TL'
+        WHEN country_name ILIKE 'Turkmenistan' THEN 'TM'
+        WHEN country_name ILIKE 'Tunisia' THEN 'TN'
+        WHEN country_name ILIKE 'Tonga' THEN 'TO'
+        WHEN country_name ILIKE 'Turkey' THEN 'TR'
+        WHEN country_name ILIKE 'Trinidad and Tobago' THEN 'TT'
+        WHEN country_name ILIKE 'Tuvalu' THEN 'TV'
+        WHEN country_name ILIKE 'Taiwan' THEN 'TW'
+        WHEN country_name ILIKE 'Tanzania' THEN 'TZ'
+        WHEN country_name ILIKE 'Ukraine' THEN 'UA'
+        WHEN country_name ILIKE 'Uganda' THEN 'UG'
+        WHEN country_name ILIKE 'United States Minor Outlying Islands' THEN 'UM'
+        WHEN country_name ILIKE 'United States of America' THEN 'US'
+        WHEN country_name ILIKE 'Uruguay' THEN 'UY'
+        WHEN country_name ILIKE 'Uzbekistan' THEN 'UZ'
+        WHEN country_name ILIKE 'Vatican City' THEN 'VA'
+        WHEN country_name ILIKE 'Saint Vincent and the Grenadines' THEN 'VC'
+        WHEN country_name ILIKE 'Venezuela' THEN 'VE'
+        WHEN country_name ILIKE 'Virgin Islands, British' THEN 'VG'
+        WHEN country_name ILIKE 'Virgin Islands, U.S.' THEN 'VI'
+        WHEN country_name ILIKE 'Vietnam' THEN 'VN'
+        WHEN country_name ILIKE 'Vanuatu' THEN 'VU'
+        WHEN country_name ILIKE 'Wallis and Futuna Islands' THEN 'WF'
+        WHEN country_name ILIKE 'Samoa' THEN 'WS'
+        WHEN country_name ILIKE 'Yemen' THEN 'YE'
+        WHEN country_name ILIKE 'Mayotte' THEN 'YT'
+        WHEN country_name ILIKE 'South Africa' THEN 'ZA'
+        WHEN country_name ILIKE 'Zambia' THEN 'ZM'
+        WHEN country_name ILIKE 'Zimbabwe' THEN 'ZW'
+        WHEN country_name ILIKE 'Bonaire' THEN 'BQ'
+        WHEN country_name ILIKE 'Curaçao' THEN 'CW'
+        WHEN country_name ILIKE 'South Sudan' THEN 'SS'
+        WHEN country_name ILIKE 'Sint Maarten' THEN 'SX'
+        WHEN country_name ILIKE 'Kosovo' THEN 'XK'
+        -- audius exceptions
+        WHEN country_name ILIKE 'Aland Islands' THEN 'AX'
+        WHEN country_name ILIKE 'Bonaire, Saint Eustatius and Saba ' THEN 'BQ'
+        WHEN country_name ILIKE 'British Virgin Islands' THEN 'VG'
+        WHEN country_name ILIKE 'Brunei' THEN 'BN'
+        WHEN country_name ILIKE 'Cabo Verde' THEN 'CV'
+        WHEN country_name ILIKE 'Cocos Islands' THEN 'CC'
+        WHEN country_name ILIKE 'Curacao' THEN 'CW'
+        WHEN country_name ILIKE 'Czechia' THEN 'CZ'
+        WHEN country_name ILIKE 'Democratic Republic of the Congo' THEN 'CD'
+        WHEN country_name ILIKE 'Eswatini' THEN 'SZ'
+        WHEN country_name ILIKE 'Ivory Coast' THEN 'CI'
+        WHEN country_name ILIKE 'Macao' THEN 'MO'
+        WHEN country_name ILIKE 'North Macedonia' THEN 'MK'
+        WHEN country_name ILIKE 'Palestinian Territory' THEN 'PS'
+        WHEN country_name ILIKE 'Republic of the Congo' THEN 'CG'
+        WHEN country_name ILIKE 'Russia' THEN 'RU'
+        WHEN country_name ILIKE 'Saint Barthelemy' THEN 'BL'
+        WHEN country_name ILIKE 'Saint Martin' THEN 'MF'
+        WHEN country_name ILIKE 'South Korea' THEN 'KR'
+        WHEN country_name ILIKE 'The Netherlands' THEN 'NL'
+        WHEN country_name ILIKE 'Timor Leste' THEN 'TL'
+        WHEN country_name ILIKE 'U.S. Virgin Islands' THEN 'VI'
+        WHEN country_name ILIKE 'Wallis and Futuna' THEN 'WF'
+        WHEN country_name ILIKE 'United States' THEN 'US'
+        ELSE NULL
+    END;
+
+    RETURN iso2_code;
+END;
+$$;
+
+
+--
+-- Name: delete_constraints_referencing_blocks(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.delete_constraints_referencing_blocks() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    constraint_record RECORD;
+BEGIN
+    FOR constraint_record IN (
+        SELECT
+            c.conname AS constraint_name,
+            conrelid::regclass AS referencing_table
+        FROM
+            pg_constraint c
+        JOIN
+            pg_attribute a ON a.attnum = ANY(c.conkey)
+        WHERE
+            confrelid = 'blocks'::regclass
+            AND contype = 'f'
+            AND pg_get_constraintdef(c.oid) NOT LIKE '%ON DELETE CASCADE%'
+        GROUP BY
+            c.conname, conrelid::regclass
+    )
+    LOOP
+        -- Drop the foreign key constraint
+        EXECUTE 'ALTER TABLE ' || constraint_record.referencing_table || ' DROP CONSTRAINT ' || constraint_record.constraint_name;
+    END LOOP;
+END;
+$$;
+
+
+--
+-- Name: delete_is_current_false_rows(text[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.delete_is_current_false_rows(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      -- Logging the deletion
+      RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
+
+      EXECUTE format('DELETE FROM %s WHERE is_current = false',
+                     quote_ident(_table_name));
+
+   END LOOP;
+END
+$$;
+
+
+--
+-- Name: delete_rows(text[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.delete_rows(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
+
+      EXECUTE format('DELETE FROM %s WHERE is_current = false',
+                     quote_ident(_table_name));
+
+   END LOOP;
+END
+$$;
+
+
+--
+-- Name: drop_fk_constraints(text[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.drop_fk_constraints(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      RAISE NOTICE 'Dropping foreign key constraint to table %', _table_name;
+      EXECUTE format('LOCK TABLE %s IN ACCESS EXCLUSIVE MODE',
+                     quote_ident(_table_name));
+
+      EXECUTE format('ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s',
+                     quote_ident(_table_name),
+                     quote_ident(_table_name || '_blocknumber_fkey'));
+
+   END LOOP;
+END
+$$;
+
+
+--
+-- Name: find_track(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.find_track(url text) RETURNS TABLE(user_id integer, track_id integer)
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    segments text[];
+    v_handle text;
+    v_slug text;
+BEGIN
+    -- Split the URL into path segments
+    segments := string_to_array(regexp_replace(url, '^.+://[^/]+', ''), '/');
+
+    -- Remove empty segments
+    segments := segments[array_length(segments, 1) - array_upper(segments, 1) + 1:];
+
+    -- Retrieve the last two segments
+    v_slug := segments[array_upper(segments, 1)];
+    v_handle := segments[array_upper(segments, 1) - 1];
+
+    select u.user_id into user_id from users u where handle_lc = lower(v_handle);
+
+    select r.track_id
+    into track_id
+    from track_routes r
+    where r.slug = v_slug
+      and owner_id = user_id
+    order by is_current desc
+    limit 1;
+
+    return next;
+END;
+$$;
+
+
+--
+-- Name: get_user_score(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_user_score(target_user_id integer) RETURNS TABLE(user_id integer, handle_lc text, play_count bigint, distinct_tracks_played bigint, challenge_count bigint, following_count bigint, follower_count bigint, chat_block_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, karma bigint, score bigint)
+    LANGUAGE sql
+    AS $$ with play_activity as (
+        select p.user_id,
+            count(distinct date_trunc('day', p.created_at)) as play_count,
+            count(distinct p.play_item_id) as distinct_tracks_played
+        from plays p
+        where p.user_id = target_user_id
+        group by p.user_id
+    ),
+    fast_challenge_completion as (
+        select u.user_id,
+            u.handle_lc,
+            u.created_at,
+            count(*) as challenge_count,
+            array_agg(uc.challenge_id) as challenge_ids
+        from users u
+            left join user_challenges uc on u.user_id = uc.user_id
+        where u.user_id = target_user_id
+            and uc.is_complete
+            and uc.completed_at - u.created_at <= interval '3 minutes'
+            and uc.challenge_id not in ('m', 'b')
+        group by u.user_id,
+            u.handle_lc,
+            u.created_at
+    ),
+    chat_blocks as (
+        select c.blockee_user_id as user_id,
+            count(*) as block_count
+        from chat_blocked_users c
+        where c.blockee_user_id = target_user_id
+        group by c.blockee_user_id
+    ),
+    aggregate_scores as (
+        select u.user_id,
+            u.handle_lc,
+            coalesce(p.play_count, 0) as play_count,
+            coalesce(p.distinct_tracks_played, 0) as distinct_tracks_played,
+            coalesce(c.challenge_count, 0) as challenge_count,
+            coalesce(au.following_count, 0) as following_count,
+            coalesce(au.follower_count, 0) as follower_count,
+            coalesce(cb.block_count, 0) as chat_block_count,
+            case
+                when (
+                    u.handle_lc ilike '%audius%'
+                    or lower(u.name) ilike '%audius%'
+                )
+                and u.is_verified = false then true
+                else false
+            end as is_audius_impersonator,
+            (u.profile_picture_sizes is not null) as has_profile_picture,
+            case
+                when (
+                    -- give max karma to users with more than 1000 followers
+                    -- karma is too slow for users with many followers
+                    au.follower_count > 1000
+                ) then 100
+                when (
+                    au.follower_count = 0
+                ) then 0
+                else (
+                    select LEAST(
+                            (sum(fau.follower_count) / 100)::bigint,
+                            100
+                        )
+                    from follows
+                        join aggregate_user fau on follows.follower_user_id = fau.user_id
+                    where follows.followee_user_id = target_user_id
+                        and fau.following_count < 10000 -- ignore users with too many following
+                        and follows.is_delete = false
+                )
+            end as karma
+        from users u
+            left join play_activity p on u.user_id = p.user_id
+            left join fast_challenge_completion c on u.user_id = c.user_id
+            left join chat_blocks cb on u.user_id = cb.user_id
+            left join aggregate_user au on u.user_id = au.user_id
+        where u.user_id = target_user_id
+            and u.handle_lc is not null
+    )
+select a.*,
+    compute_user_score(
+        a.play_count,
+        a.follower_count,
+        a.challenge_count,
+        a.chat_block_count,
+        a.following_count,
+        a.is_audius_impersonator,
+        a.has_profile_picture,
+        a.distinct_tracks_played,
+        a.karma
+    ) as score
+from aggregate_scores a;
+$$;
+
+
+--
+-- Name: get_user_scores(integer[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_user_scores(target_user_ids integer[] DEFAULT NULL::integer[]) RETURNS TABLE(user_id integer, handle_lc text, play_count bigint, distinct_tracks_played bigint, follower_count bigint, following_count bigint, challenge_count bigint, chat_block_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, karma bigint, score bigint)
+    LANGUAGE sql
+    AS $$ with play_activity as (
+        select plays.user_id,
+            count(distinct (date_trunc('hour', plays.created_at))) as play_count,
+            count(distinct(plays.play_item_id)) as distinct_tracks_played
+        from plays
+            join users on plays.user_id = users.user_id
+        where target_user_ids is null
+            or plays.user_id = any(target_user_ids)
+        group by plays.user_id
+    ),
+    fast_challenge_completion as (
+        select users.user_id,
+            handle_lc,
+            users.created_at,
+            count(*) as challenge_count,
+            array_agg(user_challenges.challenge_id) as challenge_ids
+        from users
+            left join user_challenges on users.user_id = user_challenges.user_id
+        where user_challenges.is_complete
+            and user_challenges.completed_at - users.created_at <= interval '3 minutes'
+            and user_challenges.challenge_id not in ('m', 'b')
+            and (
+                target_user_ids is null
+                or users.user_id = any(target_user_ids)
+            )
+        group by users.user_id,
+            users.handle_lc,
+            users.created_at
+    ),
+    chat_blocks as (
+        select chat_blocked_users.blockee_user_id as user_id,
+            count(*) as block_count
+        from chat_blocked_users
+            join users on chat_blocked_users.blockee_user_id = users.user_id
+        where target_user_ids is null
+            or chat_blocked_users.blockee_user_id = any(target_user_ids)
+        group by chat_blocked_users.blockee_user_id
+    ),
+    aggregate_scores as (
+        select users.user_id,
+            users.handle_lc,
+            coalesce(play_activity.play_count, 0) as play_count,
+            coalesce(play_activity.distinct_tracks_played, 0) as distinct_tracks_played,
+            coalesce(aggregate_user.following_count, 0) as following_count,
+            coalesce(aggregate_user.follower_count, 0) as follower_count,
+            coalesce(fast_challenge_completion.challenge_count, 0) as challenge_count,
+            coalesce(chat_blocks.block_count, 0) as chat_block_count,
+            case
+                when (
+                    users.handle_lc ilike '%audius%'
+                    or lower(users.name) ilike '%audius%'
+                )
+                and users.is_verified = false then true
+                else false
+            end as is_audius_impersonator,
+            (users.profile_picture_sizes is not null) as has_profile_picture,
+            case
+                when (
+                    -- give max karma to users with more than 1000 followers
+                    -- karma is too slow for users with many followers
+                    aggregate_user.follower_count > 1000
+                ) then 100
+                when (
+                    aggregate_user.follower_count = 0
+                ) then 0
+                else (
+                    select LEAST(
+                            (sum(fau.follower_count) / 100)::bigint,
+                            100
+                        )
+                    from follows
+                        join aggregate_user fau on follows.follower_user_id = fau.user_id
+                    where follows.followee_user_id = users.user_id
+                        and fau.following_count < 10000 -- ignore users with too many following
+                        and follows.is_delete = false
+                )
+            end as karma
+        from users
+            left join play_activity on users.user_id = play_activity.user_id
+            left join fast_challenge_completion on users.user_id = fast_challenge_completion.user_id
+            left join chat_blocks on users.user_id = chat_blocks.user_id
+            left join aggregate_user on aggregate_user.user_id = users.user_id
+        where users.handle_lc is not null
+            and (
+                target_user_ids is null
+                or users.user_id = any(target_user_ids)
+            )
+    )
+select a.*,
+    compute_user_score(
+        a.play_count,
+        a.follower_count,
+        a.challenge_count,
+        a.chat_block_count,
+        a.following_count,
+        a.is_audius_impersonator,
+        a.has_profile_picture,
+        a.distinct_tracks_played,
+        a.karma
+    ) as score
+from aggregate_scores a;
+$$;
+
+
+--
+-- Name: handle_artist_coins_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_artist_coins_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF (OLD.mint IS NULL AND NEW.mint IS NOT NULL) 
+        OR (OLD.mint IS NOT NULL AND NEW.mint IS NULL)
+        OR OLD.mint != NEW.mint
+    THEN
+        PERFORM pg_notify('artist_coins_mint_changed', JSON_BUILD_OBJECT('new', NEW.mint, 'old', OLD.mint)::TEXT);
+    END IF;
+
+    IF (OLD.damm_v2_pool IS NULL AND NEW.damm_v2_pool IS NOT NULL) 
+        OR (OLD.damm_v2_pool IS NOT NULL AND NEW.damm_v2_pool IS NULL)
+        OR OLD.damm_v2_pool != NEW.damm_v2_pool
+    THEN
+        PERFORM pg_notify('artist_coins_damm_v2_pool_changed', JSON_BUILD_OBJECT('new', NEW.damm_v2_pool, 'old', OLD.damm_v2_pool)::TEXT);
+    END IF;
+    
+    RETURN NEW;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+            RETURN NULL;
+END;
+$$;
+
+
+--
+-- Name: handle_associated_wallets(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_associated_wallets() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_mint varchar;
+BEGIN
+    -- For INSERT, always run
+    IF TG_OP = 'INSERT' THEN
+        FOR v_mint IN
+            SELECT DISTINCT mint FROM sol_token_account_balances WHERE owner = NEW.wallet
+        LOOP
+            PERFORM update_sol_user_balance_mint(NEW.user_id, v_mint);
+        END LOOP;
+    END IF;
+
+    -- For UPDATE, only run if is_delete changed
+    IF TG_OP = 'UPDATE' AND (NEW.is_delete IS DISTINCT FROM OLD.is_delete) THEN
+        FOR v_mint IN
+            SELECT DISTINCT mint FROM sol_token_account_balances WHERE owner = NEW.wallet
+        LOOP
+            PERFORM update_sol_user_balance_mint(NEW.user_id, v_mint);
+        END LOOP;
+    END IF;
+
+    -- For DELETE, always run
+    IF TG_OP = 'DELETE' THEN
+        FOR v_mint IN
+            SELECT DISTINCT mint FROM sol_token_account_balances WHERE owner = OLD.wallet
+        LOOP
+            PERFORM update_sol_user_balance_mint(OLD.user_id, v_mint);
+        END LOOP;
+    END IF;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+--
+-- Name: handle_challenge_disbursement(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_challenge_disbursement() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  reward_manager_tx reward_manager_txs%ROWTYPE;
+	existing_notification integer;
+	reward_code_exists boolean;
+begin
+
+  select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
+
+  if reward_manager_tx is not null then
+		-- check if reward_codes table has an entry where code equals new.challenge_id
+		select exists(select 1 from reward_codes where code = new.challenge_id) into reward_code_exists;
+
+		if not reward_code_exists then
+			select id into existing_notification
+			from notification
+			where
+			type = 'challenge_reward' and
+			new.user_id = any(user_ids) and
+			timestamp >= (new.created_at - interval '1 hour')
+			limit 1;
+
+			if existing_notification is null then
+				-- create a notification for the challenge disbursement
+				insert into notification
+				(slot, user_ids, timestamp, type, group_id, specifier, data)
+				values
+				(
+					new.slot,
+					ARRAY [new.user_id],
+					new.created_at,
+					'challenge_reward',
+					'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+					new.user_id,
+					json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+				)
+				on conflict do nothing;
+			end if;
+		end if;
+  end if;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+
+end;
+$$;
+
+
+--
+-- Name: handle_chat_blast(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_chat_blast() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  PERFORM pg_notify('chat_blast_inserted', json_build_object('blast_id', new.blast_id)::text);
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_chat_message(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_chat_message() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  PERFORM pg_notify('chat_message_inserted', json_build_object('message_id', new.message_id)::text);
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_chat_message_reaction_changed(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_chat_message_reaction_changed() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  message_id text;
+  user_id bigint;
+  reaction text;
+begin
+  -- Get the values from either NEW or OLD record
+  if tg_op = 'DELETE' then
+    message_id := old.message_id;
+    user_id := old.user_id;
+    reaction := null; -- Set reaction to null for deletions
+  else
+    message_id := new.message_id;
+    user_id := new.user_id;
+    reaction := new.reaction;
+  end if;
+
+  PERFORM pg_notify('chat_message_reaction_changed', json_build_object(
+    'message_id', message_id,
+    'user_id', user_id,
+    'reaction', reaction
+  )::text);
+  return coalesce(new, old);
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_comment(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_comment() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  if new.entity_type = 'Track' then
+    insert into aggregate_track (track_id) 
+    values (new.entity_id) 
+    on conflict do nothing;
+  end if;
+
+  -- update agg track
+  if new.entity_type = 'Track' then
+    update aggregate_track 
+    set comment_count = (
+      select count(*)
+      from comments c
+      where
+          c.is_delete is false
+          and c.is_visible is true
+          and c.entity_type = new.entity_type
+          and c.entity_id = new.entity_id
+    )
+    where track_id = new.entity_id;
+  end if;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+--
+-- Name: handle_comms_rpc_log(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_comms_rpc_log() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  -- Send notification with the signature (primary key) of the new rpc_log record
+  PERFORM pg_notify('rpc_log_inserted', json_build_object('sig', new.sig)::text);
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_dbc_pool(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_dbc_pool() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    PERFORM pg_notify('dbc_pools_changed', JSON_BUILD_OBJECT('new', NEW.account)::TEXT);
+    RETURN NEW;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+            RETURN NULL;
+END;
+$$;
+
+
+--
+-- Name: handle_event(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_event() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  notified_user_id int;
+  owner_user_id int;
+  track_is_public boolean;
+begin
+  -- Only proceed if this is a remix contest event
+  if new.event_type = 'remix_contest' and new.is_deleted = false then
+    -- Get the owner of the track and check if it's public
+    select owner_id, not is_unlisted into owner_user_id, track_is_public 
+    from tracks 
+    where is_current and track_id = new.entity_id 
+    limit 1;
+
+    -- Only create notifications if the track is public
+    if track_is_public then
+      -- For each follower of the event creator and each user who favorited the track
+      -- Using UNION to ensure we don't get duplicate user_ids
+      for notified_user_id in
+        select distinct user_id
+        from (
+          -- Get followers
+          select f.follower_user_id as user_id
+          from follows f
+          where f.followee_user_id = new.user_id
+            and f.is_current = true
+            and f.is_delete = false
+          union
+          -- Get users who favorited the track
+          select s.user_id
+          from saves s
+          where s.save_item_id = new.entity_id
+            and s.save_type = 'track'
+            and s.is_current = true
+            and s.is_delete = false
+        ) as users_to_notify
+      loop
+        -- Create a notification for this user
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+          (
+            new.blocknumber,
+            ARRAY[notified_user_id],
+            new.created_at,
+            'fan_remix_contest_started',
+            notified_user_id,
+            'fan_remix_contest_started:' || new.entity_id || ':user:' || new.user_id,
+            json_build_object(
+              'entity_user_id', owner_user_id,
+              'entity_id', new.entity_id
+            )
+          )
+        on conflict do nothing;
+      end loop;
+    end if;
+  end if;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+--
+-- Name: handle_follow(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_follow() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_follower_count int;
+  milestone integer;
+  delta int;
+  is_shadowbanned boolean;
+begin
+  insert into aggregate_user (user_id) values (new.followee_user_id) on conflict do nothing;
+  insert into aggregate_user (user_id) values (new.follower_user_id) on conflict do nothing;
+
+  -- increment or decrement?
+  if new.is_delete then
+    delta := -1;
+  else
+    delta := 1;
+  end if;
+
+  update aggregate_user 
+  set following_count = following_count + delta 
+  where user_id = new.follower_user_id;
+
+  update aggregate_user 
+  set follower_count = follower_count + delta
+  where user_id = new.followee_user_id
+  returning follower_count into new_follower_count;
+
+  -- create a milestone if applicable
+  select new_follower_count into milestone where new_follower_count in (10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000);
+  select score < 0 into is_shadowbanned from aggregate_user where user_id = new.follower_user_id;
+  if milestone is not null and new.is_delete is false and is_shadowbanned = false then
+      insert into milestones 
+        (id, name, threshold, blocknumber, slot, timestamp)
+      values
+        (new.followee_user_id, 'FOLLOWER_COUNT', milestone, new.blocknumber, new.slot, new.created_at)
+      on conflict do nothing;
+      insert into notification
+        (user_ids, type, group_id, specifier, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [new.followee_user_id],
+          'milestone_follower_count',
+          'milestone:FOLLOWER_COUNT:id:' || new.followee_user_id || ':threshold:' || milestone,
+          new.followee_user_id,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', 'FOLLOWER_COUNT', 'user_id', new.followee_user_id, 'threshold', milestone)
+        )
+    on conflict do nothing;
+  end if;
+
+  begin
+    -- create a notification for the followee
+    if new.is_delete is false and is_shadowbanned = false then
+      insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      values
+      (
+        new.blocknumber,
+        ARRAY [new.followee_user_id],
+        new.created_at,
+        'follow',
+        new.follower_user_id,
+        'follow:' || new.followee_user_id,
+        json_build_object('followee_user_id', new.followee_user_id, 'follower_user_id', new.follower_user_id)
+      )
+      on conflict do nothing;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end; 
+$$;
+
+
+--
+-- Name: handle_meteora_dbc_migrations(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_meteora_dbc_migrations() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    PERFORM pg_notify('meteora_dbc_migration', json_build_object('operation', TG_OP)::text);
+    RETURN NEW;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+            RETURN NULL;
+END;
+$$;
+
+
+--
+-- Name: handle_on_user_challenge(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_on_user_challenge() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  cooldown_days integer;
+  existing_notification integer;
+  listen_streak_value integer;
+begin
+    if (new.is_complete = true) then
+        -- attempt to insert a new notification, ignoring conflicts
+        select challenges.cooldown_days into cooldown_days from challenges where id = new.challenge_id;
+
+        if (cooldown_days is null or cooldown_days = 0) then
+            -- Check if there is an existing notification with the same fields in the last 15 minutes
+
+            if new.challenge_id not in ('tt', 'tp', 'tut', 'dvl') then
+                insert into notification
+                (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
+                values
+                (
+                    new.completed_blocknumber,
+                    ARRAY [new.user_id],
+                    new.completed_at,
+                    'claimable_reward',
+                    'claimable_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                    new.specifier,
+                    json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+                )
+                on conflict do nothing;
+            end if;
+
+            if new.challenge_id = 'e' then
+                select listen_streak into listen_streak_value
+                from challenge_listen_streak
+                where user_id = new.user_id
+                limit 1;
+            end if;
+
+            insert into notification
+            (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
+            values
+            (
+                new.completed_blocknumber,
+                ARRAY [new.user_id],
+                new.completed_at,
+                'challenge_reward',
+                'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                new.user_id,
+                case
+                    when new.challenge_id = 'e' then
+                        json_build_object(
+                            'specifier', new.specifier,
+                            'challenge_id', new.challenge_id,
+                            'amount', new.amount::text || '00000000',
+                            'listen_streak', coalesce(listen_streak_value, 0)
+                        )
+                    else
+                        json_build_object(
+                            'specifier', new.specifier,
+                            'challenge_id', new.challenge_id,
+                            'amount', new.amount::text || '00000000'
+                        )
+                end
+            )
+            on conflict do nothing;
+        else
+            -- transactional notifications cover this
+            if (new.challenge_id != 'b' and new.challenge_id != 's') then
+                select id into existing_notification
+                from notification
+                where
+                type = 'reward_in_cooldown' and
+                new.user_id = any(user_ids) and
+                timestamp >= (new.completed_at - interval '1 hour')
+                limit 1;
+
+                if existing_notification is null then
+                    insert into notification
+                    (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
+                    values
+                    (
+                        new.completed_blocknumber,
+                        ARRAY [new.user_id],
+                        new.completed_at,
+                        'reward_in_cooldown',
+                        'reward_in_cooldown:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                        new.specifier,
+                        json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+                    )
+                    on conflict do nothing;
+                end if;
+            end if;
+        end if;
+
+        -- update user fast challenge count
+        INSERT INTO user_score_features (user_id, challenge_count, updated_at)
+        SELECT
+            NEW.user_id,
+            COUNT(*)::int AS challenge_count,
+            now()
+        FROM user_challenges uc
+        JOIN users u
+        ON u.user_id = uc.user_id
+        WHERE uc.user_id = NEW.user_id
+            AND uc.is_complete
+            AND uc.challenge_id NOT IN ('m','b')
+            AND uc.completed_at <= (u.created_at + interval '3 minutes')
+        ON CONFLICT (user_id) DO UPDATE
+            SET challenge_count = EXCLUDED.challenge_count,
+                updated_at      = EXCLUDED.updated_at
+        WHERE user_score_features.challenge_count IS DISTINCT FROM EXCLUDED.challenge_count;
+
+
+    end if;
+
+    return new;
+
+end;
+$$;
+
+
+--
+-- Name: handle_play(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_play() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+    new_listen_count int;
+    milestone int;
+    owner_user_id int;
+begin
+
+    -- update aggregate_plays
+    insert into aggregate_plays (play_item_id, count) values (new.play_item_id, 0) on conflict do nothing;
+
+    update aggregate_plays
+        set count = count + 1
+        where play_item_id = new.play_item_id
+        returning count into new_listen_count;
+
+    -- update aggregate_monthly_plays
+    insert into aggregate_monthly_plays (play_item_id, timestamp, country, count)
+    values (new.play_item_id, date_trunc('month', new.created_at), coalesce(new.country, ''), 0)
+    on conflict do nothing;
+
+    update aggregate_monthly_plays
+        set count = count + 1
+        where play_item_id = new.play_item_id
+        and timestamp = date_trunc('month', new.created_at)
+        and country = coalesce(new.country, '');
+
+    select new_listen_count
+        into milestone
+        where new_listen_count in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
+
+    if milestone is not null then
+        insert into milestones
+            (id, name, threshold, slot, timestamp)
+        values
+            (new.play_item_id, 'LISTEN_COUNT', milestone, new.slot, new.created_at)
+        on conflict do nothing;
+        select tracks.owner_id into owner_user_id from tracks where is_current and track_id = new.play_item_id;
+        if owner_user_id is not null then
+            insert into notification
+                (user_ids, specifier, group_id, type, slot, timestamp, data)
+                values
+                (
+                    array[owner_user_id],
+                    owner_user_id,
+                    'milestone:LISTEN_COUNT:id:' || new.play_item_id || ':threshold:' || milestone,
+                    'milestone',
+                    new.slot,
+                    new.created_at,
+                    json_build_object('type', 'LISTEN_COUNT', 'track_id', new.play_item_id, 'threshold', milestone)
+                )
+            on conflict do nothing;
+        end if;
+    end if;
+
+    -- update listener's aggregates if applicable
+    if new.user_id is not null then
+        -- Insert or update user_distinct_play_hours
+        -- Only increment if the play's hour is newer than the user's last updated hour
+        insert into user_distinct_play_hours (user_id, hours_with_play, updated_at)
+        values (new.user_id, 1, date_trunc('hour', new.created_at))
+        on conflict (user_id) do update set
+            hours_with_play = case
+                when date_trunc('hour', new.created_at) > date_trunc('hour', user_distinct_play_hours.updated_at)
+                then user_distinct_play_hours.hours_with_play + 1
+                else user_distinct_play_hours.hours_with_play
+            end,
+            updated_at = case
+                when date_trunc('hour', new.created_at) > date_trunc('hour', user_distinct_play_hours.updated_at)
+                then new.created_at
+                else user_distinct_play_hours.updated_at
+            end;
+
+        -- update user_distinct_play_tracks
+        -- Only increment if this is the first time this user has played this track
+        insert into user_distinct_play_tracks (user_id, track_count, updated_at)
+        values (new.user_id, 1, new.created_at)
+        on conflict (user_id) do update set
+            track_count = case
+                when not exists (
+                    select 1 from plays p
+                    where p.user_id = new.user_id
+                    and p.play_item_id = new.play_item_id
+                    and p.id != new.id
+                )
+                then user_distinct_play_tracks.track_count + 1
+                else user_distinct_play_tracks.track_count
+            end,
+            updated_at = new.created_at;
+    end if;
+
+    return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_playlist(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_playlist() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  track_owner_id int := 0;
+  track_item json;
+  subscriber_user_ids integer[];
+  old_row RECORD;
+  delta int := 0;
+begin
+
+  insert into aggregate_playlist (playlist_id, is_album) values (new.playlist_id, new.is_album) on conflict do nothing;
+
+  with expanded as (
+      select
+          jsonb_array_elements(prev_records->'playlists') as playlist
+      from
+          revert_blocks
+      where blocknumber = new.blocknumber
+  )
+  select
+      (playlist->>'is_private')::boolean as is_private,
+      (playlist->>'is_delete')::boolean as is_delete
+  into old_row
+  from
+      expanded
+  where
+      (playlist->>'playlist_id')::int = new.playlist_id
+  limit 1;
+
+  delta := 0;
+  if (new.is_delete = true and new.is_current = true) and (old_row.is_delete = false and old_row.is_private = false) then
+    delta := -1;
+  end if;
+
+  if (old_row is null and new.is_private = false) or (old_row.is_private = true and new.is_private = false) then
+    delta := 1;
+  end if;
+
+  if delta != 0 then
+    if new.is_album then
+      update aggregate_user
+      set album_count = album_count + delta
+      where user_id = new.playlist_owner_id;
+    else
+      update aggregate_user
+      set playlist_count = playlist_count + delta
+      where user_id = new.playlist_owner_id;
+    end if;
+  end if;
+  -- Create playlist notification
+  begin
+    if new.is_private = FALSE AND
+    new.is_delete = FALSE AND
+    (
+      new.created_at = new.updated_at OR
+      old_row.is_private = TRUE
+    )
+    then
+      select array(
+        select subscriber_id
+          from subscriptions
+          where is_current and
+          not is_delete and
+          user_id=new.playlist_owner_id
+      ) into subscriber_user_ids;
+      if array_length(subscriber_user_ids, 1)	> 0 then
+        insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          subscriber_user_ids,
+          new.updated_at,
+          'create',
+          new.playlist_owner_id,
+          'create:playlist_id:' || new.playlist_id,
+          json_build_object('playlist_id', new.playlist_id, 'is_album', new.is_album)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  begin
+    if new.is_delete IS FALSE and new.is_private IS FALSE then
+      for track_item IN select jsonb_array_elements from jsonb_array_elements(new.playlist_contents->'track_ids')
+      loop
+        -- Add notification for each track owner
+        if (track_item->>'time')::double precision::int >= extract(epoch from new.updated_at)::int then
+          select owner_id into track_owner_id from tracks where is_current and track_id=(track_item->>'track')::int;
+          if track_owner_id != new.playlist_owner_id then
+            insert into notification
+              (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+              (
+                new.blocknumber,
+                ARRAY [track_owner_id],
+                new.updated_at,
+                'track_added_to_playlist',
+                track_owner_id,
+                'track_added_to_playlist:playlist_id:' || new.playlist_id || ':track_id:' || (track_item->>'track')::int,
+                json_build_object('track_id', (track_item->>'track')::int, 'playlist_id', new.playlist_id, 'playlist_owner_id', new.playlist_owner_id)
+              )
+            on conflict do nothing;
+          end if;
+        end if;
+      end loop;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+end;
+$$;
+
+
+--
+-- Name: handle_playlist_track(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_playlist_track() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  playlist_record RECORD;
+begin
+  select * into playlist_record from playlists where playlist_id = new.playlist_id limit 1;
+
+  -- Add notification for each purchaser
+  if playlist_record.is_stream_gated = true and jsonb_exists(playlist_record.stream_conditions, 'usdc_purchase') then
+    with album_purchasers as (
+      select distinct buyer_user_id
+        from usdc_purchases
+        where content_id = new.playlist_id
+        and content_type = 'album'
+    )
+      insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        select
+          playlist_record.blocknumber,
+          array [album_purchaser.buyer_user_id],
+          new.updated_at,
+          'track_added_to_purchased_album',
+          album_purchaser.buyer_user_id,
+          'track_added_to_purchased_album:playlist_id:' || new.playlist_id || ':track_id:' || new.track_id,
+          json_build_object('track_id', new.track_id, 'playlist_id', new.playlist_id, 'playlist_owner_id', playlist_record.playlist_owner_id)
+        from album_purchasers as album_purchaser;
+  end if;
+  
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_reaction(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_reaction() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  tip_row notification%ROWTYPE;
+  tip_sender_user_id int;
+  tip_receiver_user_id int;
+  tip_amount bigint;
+begin
+
+  raise NOTICE 'start';
+  
+  if new.reaction_type = 'tip' then
+
+    raise NOTICE 'is tip';
+
+    SELECT amount, sender_user_id, receiver_user_id 
+    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id 
+    FROM user_tips ut 
+    WHERE ut.signature = new.reacted_to;
+    
+    raise NOTICE 'did select % %', tip_sender_user_id, tip_receiver_user_id;
+    raise NOTICE 'did select %', new.reacted_to;
+
+    IF tip_sender_user_id IS NOT NULL AND tip_receiver_user_id IS NOT NULL THEN
+      raise NOTICE 'have ids';
+
+      if new.reaction_value != 0 then
+        INSERT INTO notification
+          (user_ids, timestamp, type, specifier, group_id, data)
+        VALUES
+          (
+          ARRAY [tip_sender_user_id],
+          new.timestamp,
+          'reaction',
+          tip_receiver_user_id,
+          'reaction:' || 'reaction_to:' || new.reacted_to || ':reaction_type:' || new.reaction_type || ':reaction_value:' || new.reaction_value,
+          json_build_object(
+            'sender_wallet', new.sender_wallet,
+            'reaction_type', new.reaction_type,
+            'reacted_to', new.reacted_to,
+            'reaction_value', new.reaction_value,
+            'receiver_user_id', tip_receiver_user_id,
+            'sender_user_id', tip_sender_user_id,
+            'tip_amount', tip_amount::varchar(255)
+          )
+        )
+        on conflict do nothing;
+      end if;
+
+      -- find the notification for tip send - update the data to include reaction value
+      UPDATE notification
+      SET data = jsonb_set(data, '{reaction_value}', new.reaction_value::text::jsonb)
+      WHERE notification.group_id = 'tip_receive:user_id:' || tip_receiver_user_id || ':signature:' || new.reacted_to;
+    end if;
+  end if;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+--
+-- Name: handle_repost(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_repost() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_val int;
+  milestone_name text;
+  milestone integer;
+  owner_user_id int;
+  track_remix_of json;
+  is_remix_cosign boolean;
+  is_album boolean;
+  delta int;
+  entity_type text;
+  playlist_row record;
+  is_shadowbanned boolean;
+begin
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  if new.repost_type = 'track' then
+    insert into aggregate_track (track_id) values (new.repost_item_id) on conflict do nothing;
+
+    entity_type := 'track';
+  else
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.repost_item_id
+    and p.is_current
+    on conflict do nothing;
+
+    entity_type := 'playlist';
+
+    select ap.is_album into is_album
+    from aggregate_playlist ap
+    where ap.playlist_id = new.repost_item_id;
+  end if;
+
+  -- increment or decrement?
+  if new.is_delete then
+    delta := -1;
+  else
+    delta := 1;
+  end if;
+
+  -- update agg user
+  update aggregate_user 
+  set repost_count = (
+    select count(*)
+    from reposts r
+    where r.is_current is true
+      and r.is_delete is false
+      and r.user_id = new.user_id
+  )
+  where user_id = new.user_id;
+
+  -- update agg track or playlist
+  if new.repost_type = 'track' then
+    milestone_name := 'TRACK_REPOST_COUNT';
+    update aggregate_track 
+    set repost_count = (
+      select count(*)
+      from reposts r
+      where
+          r.is_current is true
+          and r.is_delete is false
+          and r.repost_type = new.repost_type
+          and r.repost_item_id = new.repost_item_id
+    )
+    where track_id = new.repost_item_id
+    returning repost_count into new_val;
+  	if new.is_delete IS FALSE then
+		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.repost_item_id;
+	  end if;
+  else
+    milestone_name := 'PLAYLIST_REPOST_COUNT';
+    update aggregate_playlist
+    set repost_count = (
+      select count(*)
+      from reposts r
+      where
+          r.is_current is true
+          and r.is_delete is false
+          and r.repost_type = new.repost_type
+          and r.repost_item_id = new.repost_item_id
+    )    
+    where playlist_id = new.repost_item_id
+    returning repost_count into new_val;
+
+  	if new.is_delete IS FALSE then
+		  select playlist_owner_id into owner_user_id from playlists where is_current and playlist_id = new.repost_item_id;
+	  end if;
+  end if;
+
+  -- create a milestone if applicable
+  select new_val into milestone where new_val in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
+  select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
+
+  if new.is_delete = false and milestone is not null and owner_user_id is not null and is_shadowbanned = false then
+    insert into milestones 
+      (id, name, threshold, blocknumber, slot, timestamp)
+    values
+      (new.repost_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
+    on conflict do nothing;
+
+
+    if entity_type = 'track' then
+      insert into notification
+        (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [owner_user_id],
+          'milestone',
+          owner_user_id,
+          'milestone:' || milestone_name  || ':id:' || new.repost_item_id || ':threshold:' || milestone,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', milestone_name, 'track_id', new.repost_item_id, 'threshold', milestone)
+        )
+        on conflict do nothing;
+    else
+      insert into notification
+        (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [owner_user_id],
+          'milestone',
+          owner_user_id,
+          'milestone:' || milestone_name  || ':id:' || new.repost_item_id || ':threshold:' || milestone,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', milestone_name, 'playlist_id', new.repost_item_id, 'threshold', milestone, 'is_album', is_album)
+        )
+        on conflict do nothing;
+    end if;
+  end if;
+
+  begin
+    -- create a notification for the reposted content's owner
+    if new.is_delete is false and is_shadowbanned = false then
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      values
+      (
+        new.blocknumber,
+        ARRAY [owner_user_id],
+        new.created_at,
+        'repost',
+        new.user_id,
+        'repost:' || new.repost_item_id || ':type:'|| new.repost_type,
+        json_build_object('repost_item_id', new.repost_item_id, 'user_id', new.user_id, 'type', new.repost_type)
+      )
+      on conflict do nothing;
+    end if;
+
+	-- notify followees of the reposter who have reposted the same content
+	-- within the last month
+	if new.is_delete is false
+	and new.is_repost_of_repost is true
+  and is_shadowbanned = false then
+	with
+	    followee_repost_of_repost_ids as (
+	        select user_id
+	        from reposts r
+	        where
+	            r.repost_item_id = new.repost_item_id
+	            and new.created_at - INTERVAL '1 month' < r.created_at
+	            and new.created_at > r.created_at
+              and r.is_delete is false
+              and r.is_current is true
+	            and r.user_id in (
+	                select
+	                    followee_user_id
+	                from follows
+	                where
+	                    follower_user_id = new.user_id
+                      and is_delete is false
+                      and is_current is true
+	            )
+	    )
+	insert into notification
+		(blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+		SELECT blocknumber_val, user_ids_val, timestamp_val, type_val, specifier_val, group_id_val, data_val
+		FROM (
+			SELECT new.blocknumber AS blocknumber_val,
+			ARRAY(
+				SELECT user_id
+				FROM
+					followee_repost_of_repost_ids
+			) AS user_ids_val,
+			new.created_at AS timestamp_val,
+			'repost_of_repost' AS type_val,
+			new.user_id AS specifier_val,
+			'repost_of_repost:' || new.repost_item_id || ':type:' || new.repost_type AS group_id_val,
+			json_build_object(
+				'repost_of_repost_item_id',
+				new.repost_item_id,
+				'user_id',
+				new.user_id,
+				'type',
+        case 
+          when is_album then 'album'
+          else new.repost_type
+        end
+			) AS data_val
+		) sub
+		WHERE user_ids_val IS NOT NULL AND array_length(user_ids_val, 1) > 0
+		on conflict do nothing;
+	end if;
+
+    -- create a notification for remix cosign
+    if new.is_delete is false and new.repost_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
+      select
+        case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
+        from tracks
+        where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
+      if is_remix_cosign then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+          values
+          (
+            new.blocknumber,
+            ARRAY [owner_user_id],
+            new.created_at,
+            'cosign',
+            new.user_id,
+            'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.repost_item_id,
+            json_build_object('parent_track_id', (track_remix_of->'tracks'->0->>'parent_track_id')::int, 'track_id', new.repost_item_id, 'track_owner_id', owner_user_id)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+--
+-- Name: handle_save(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_save() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_val int;
+  milestone_name text;
+  milestone integer;
+  owner_user_id int;
+  track_remix_of json;
+  is_remix_cosign boolean;
+  is_album boolean;
+  delta int;
+  entity_type text;
+  is_purchased boolean default false;
+  is_containing_album_purchased boolean default false;
+  is_shadowbanned boolean;
+begin
+
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  if new.save_type = 'track' then
+    insert into aggregate_track (track_id) values (new.save_item_id) on conflict do nothing;
+
+    entity_type := 'track';
+
+    -- check if the track has been purchased
+    select exists (
+        select 1
+        from usdc_purchases
+        where content_type = 'track'
+        and content_id = new.save_item_id
+        and buyer_user_id = new.user_id
+    ) into is_purchased;
+
+    -- check if the track is part of an album that has been purchased
+    select exists (
+      select 1
+      from
+        usdc_purchases
+        join playlist_tracks as pt
+        on content_id = pt.playlist_id
+      where track_id = new.save_item_id
+      and buyer_user_id = new.user_id
+    ) into is_containing_album_purchased;
+
+    is_purchased := is_purchased or is_containing_album_purchased;
+  else
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.save_item_id
+    and p.is_current
+    on conflict do nothing;
+    
+    select ap.is_album into is_album
+    from aggregate_playlist ap
+    where ap.playlist_id = new.save_item_id;
+
+    select exists (
+      select 1
+      from usdc_purchases
+      where content_type = 'album'
+      and content_id = new.save_item_id
+      and buyer_user_id = new.user_id
+    ) into is_purchased;
+  end if;
+
+  -- increment or decrement?
+  if new.is_delete then
+    delta := -1;
+  else
+    delta := 1;
+  end if;
+
+  -- update agg track or playlist
+  if new.save_type = 'track' then
+    milestone_name := 'TRACK_SAVE_COUNT';
+
+    update aggregate_track 
+    set save_count = (
+      select count(*)
+      from saves r
+      where
+          r.is_current is true
+          and r.is_delete is false
+          and r.save_type = new.save_type
+          and r.save_item_id = new.save_item_id
+    )
+    where track_id = new.save_item_id
+    returning save_count into new_val;
+
+    -- update agg user
+    update aggregate_user 
+    set track_save_count = (
+      select count(*)
+      from saves r
+      where r.is_current is true
+        and r.is_delete is false
+        and r.user_id = new.user_id
+        and r.save_type = new.save_type
+    )
+    where user_id = new.user_id;
+    
+  	if new.is_delete IS FALSE then
+		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.save_item_id;
+	  end if;
+  else
+    milestone_name := 'PLAYLIST_SAVE_COUNT';
+
+    update aggregate_playlist
+    set save_count = (
+      select count(*)
+      from saves r
+      where
+          r.is_current is true
+          and r.is_delete is false
+          and r.save_type = new.save_type
+          and r.save_item_id = new.save_item_id
+    )
+    where playlist_id = new.save_item_id
+    returning save_count into new_val;
+
+    if new.is_delete IS FALSE then
+		  select playlists.playlist_owner_id into owner_user_id from playlists where is_current and playlist_id = new.save_item_id;
+	  end if;
+
+  end if;
+
+  -- create a milestone if applicable
+  select new_val into milestone where new_val in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
+  select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
+
+  if new.is_delete = false and milestone is not null and is_shadowbanned = false then
+    insert into milestones 
+      (id, name, threshold, blocknumber, slot, timestamp)
+    values
+      (new.save_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
+    on conflict do nothing;
+
+    if entity_type = 'track' then
+      insert into notification
+      (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+      values
+      (
+        ARRAY [owner_user_id],
+        'milestone',
+        owner_user_id,
+        'milestone:' || milestone_name  || ':id:' || new.save_item_id || ':threshold:' || milestone,
+        new.blocknumber,
+        new.created_at,
+        json_build_object('type', milestone_name, 'track_id', new.save_item_id, 'threshold', milestone)
+      )
+      on conflict do nothing;
+    else
+      insert into notification
+        (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [owner_user_id],
+          'milestone',
+          owner_user_id,
+          'milestone:' || milestone_name  || ':id:' || new.save_item_id || ':threshold:' || milestone,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', milestone_name, 'playlist_id', new.save_item_id, 'threshold', milestone, 'is_album', is_album)
+        )
+        on conflict do nothing;
+    end if;
+  end if;
+
+  begin
+    -- create a notification for the saved content's owner
+    -- skip notification for purchased content as the purchase triggers its own notification
+    if new.is_delete is false and is_purchased is false and is_shadowbanned = false then
+      insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        ( 
+          new.blocknumber,
+          ARRAY [owner_user_id], 
+          new.created_at, 
+          'save',
+          new.user_id,
+          'save:' || new.save_item_id || ':type:'|| new.save_type,
+          json_build_object('save_item_id', new.save_item_id, 'user_id', new.user_id, 'type', new.save_type)
+        )
+      on conflict do nothing;
+    end if;
+
+    -- notify followees of the favoriter who have reposted the same content
+    -- within the last month
+    if new.is_delete is false
+    and new.is_save_of_repost is true
+    -- skip notification for tracks contained within a purchased album
+    -- the favorite of the album itself will still trigger this notification
+    and is_shadowbanned = false
+    and is_containing_album_purchased is false then
+    with
+        followee_save_repost_ids as (
+            select user_id
+            from reposts r
+            where
+                r.repost_item_id = new.save_item_id
+                and new.created_at - INTERVAL '1 month' < r.created_at
+                and new.created_at > r.created_at
+                and r.is_delete is false
+                and r.is_current is true
+                and r.repost_type::text = new.save_type::text
+                and r.user_id in
+                (
+                    select
+                        followee_user_id
+                    from follows
+                    where
+                        follower_user_id = new.user_id
+                        and is_delete is false
+                        and is_current is true
+                )
+        )
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      SELECT blocknumber_val, user_ids_val, timestamp_val, type_val, specifier_val, group_id_val, data_val
+      FROM (
+        SELECT new.blocknumber AS blocknumber_val,
+        ARRAY(
+          SELECT user_id
+          FROM
+            followee_save_repost_ids
+        ) AS user_ids_val,
+        new.created_at AS timestamp_val,
+        'save_of_repost' AS type_val,
+        new.user_id AS specifier_val,
+        'save_of_repost:' || new.save_item_id || ':type:' || new.save_type AS group_id_val,
+        json_build_object(
+          'save_of_repost_item_id',
+          new.save_item_id,
+          'user_id',
+          new.user_id,
+          'type',
+          case 
+            when is_album then 'album'
+            else new.save_type
+          end
+        ) AS data_val
+      ) sub
+      WHERE user_ids_val IS NOT NULL AND array_length(user_ids_val, 1) > 0
+      on conflict do nothing;
+    end if;
+
+    -- create a notification for remix cosign
+    if new.is_delete is false and new.save_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
+      select
+        case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
+        from tracks 
+        where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
+      if is_remix_cosign then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+          values
+          ( 
+            new.blocknumber,
+            ARRAY [owner_user_id], 
+            new.created_at, 
+            'cosign',
+            new.user_id,
+            'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.save_item_id,
+            json_build_object('parent_track_id', (track_remix_of->'tracks'->0->>'parent_track_id')::int, 'track_id', new.save_item_id, 'track_owner_id', owner_user_id)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+  end;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      raise;
+
+end; 
+$$;
+
+
+--
+-- Name: handle_share(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_share() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  -- Ensure aggregate_user exists for this user
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+
+  if new.share_type = 'track' then
+    -- Ensure aggregate_track exists for this track
+    insert into aggregate_track (track_id) values (new.share_item_id) on conflict do nothing;
+  else
+    -- Ensure aggregate_playlist exists for this playlist
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.share_item_id
+    and p.is_current
+    on conflict do nothing;
+  end if;
+
+  -- Update aggregate statistics for tracks
+  if new.share_type = 'track' then
+    update aggregate_track
+    set share_count = (
+      select count(*)
+      from shares s
+      where s.share_type = new.share_type
+        and s.share_item_id = new.share_item_id
+    )
+    where track_id = new.share_item_id;
+
+    -- Update user's track share count
+    update aggregate_user
+    set track_share_count = (
+      select count(*)
+      from shares s
+      where s.user_id = new.user_id
+        and s.share_type = new.share_type
+    )
+    where user_id = new.user_id;
+  else
+    -- Update aggregate statistics for playlists/albums
+    update aggregate_playlist
+    set share_count = (
+      select count(*)
+      from shares s
+      where s.share_type = new.share_type
+        and s.share_item_id = new.share_item_id
+    )
+    where playlist_id = new.share_item_id;
+  end if;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+--
+-- Name: handle_sol_claimable_accounts(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_sol_claimable_accounts() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_user_id int;
+BEGIN
+    FOR v_user_id IN
+        SELECT user_id
+        FROM users
+        WHERE users.wallet = NEW.ethereum_address
+    LOOP
+        PERFORM update_sol_user_balance_mint(v_user_id, NEW.mint);
+    END LOOP;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+--
+-- Name: handle_sol_token_balance_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_sol_token_balance_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_user_id int;
+BEGIN
+    INSERT INTO sol_token_account_balances (account, mint, owner, balance, slot, updated_at)
+    VALUES (NEW.account, NEW.mint, NEW.owner, NEW.balance, NEW.slot, NOW())
+    ON CONFLICT (account)
+    DO UPDATE SET
+        balance = EXCLUDED.balance,
+        slot = EXCLUDED.slot,
+        updated_at = NOW()
+        WHERE sol_token_account_balances.slot < EXCLUDED.slot;
+    
+    FOR v_user_id IN
+        SELECT user_id
+        FROM associated_wallets
+        WHERE wallet = NEW.owner
+          AND chain = 'sol'
+        UNION ALL
+        SELECT user_id
+        FROM users
+        JOIN sol_claimable_accounts ON sol_claimable_accounts.ethereum_address = users.wallet
+        WHERE sol_claimable_accounts.account = NEW.account
+          AND sol_claimable_accounts.mint = NEW.mint
+    LOOP
+        PERFORM update_sol_user_balance_mint(v_user_id, NEW.mint);
+    END LOOP;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+--
+-- Name: handle_supporter_rank_up(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_supporter_rank_up() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  user_bank_tx user_bank_txs%ROWTYPE;
+  dethroned_user_id int;
+begin
+  select * into user_bank_tx from user_bank_txs where user_bank_txs.slot = new.slot limit 1;
+
+  if user_bank_tx is not null then
+    -- create a notification for the sender and receiver
+    insert into notification
+      (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
+    values
+      (
+      -- supporting_rank_up notifs are sent to the sender of the tip
+        new.slot,
+        ARRAY [new.sender_user_id],
+        user_bank_tx.created_at,
+        'supporting_rank_up',
+        new.sender_user_id,
+        'supporting_rank_up:' || new.rank || ':slot:' || new.slot,
+        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank),
+        'supporting_rank_up'
+      ),
+      (
+      -- supporter_rank_up notifs are sent to the receiver of the tip
+        new.slot,
+        ARRAY [new.receiver_user_id],
+        user_bank_tx.created_at,
+        'supporter_rank_up',
+        new.receiver_user_id,
+        'supporter_rank_up:' || new.rank || ':slot:' || new.slot,
+        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank),
+        'supporter_rank_up'
+      )
+    on conflict do nothing;
+
+    if new.rank = 1 then
+      select sender_user_id into dethroned_user_id from supporter_rank_ups where rank=1 and receiver_user_id=new.receiver_user_id and slot < new.slot order by slot desc limit 1;
+      if dethroned_user_id is not NULL then
+        -- create a notification for the sender and receiver
+        insert into notification
+          (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
+        values
+          (
+            new.slot,
+            ARRAY [dethroned_user_id],
+            user_bank_tx.created_at,
+            'supporter_dethroned',
+            new.sender_user_id,
+            'supporter_dethroned:receiver_user_id:' || new.receiver_user_id || ':slot:' || new.slot,
+            json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'dethroned_user_id', dethroned_user_id),
+            'supporter_dethroned'
+          ) on conflict do nothing;
+
+      end if;
+    end if;
+
+  end if;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+--
+-- Name: handle_track(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_track() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  parent_track_owner_id int;
+  subscriber_user_ids int[];
+begin
+  insert into aggregate_track (track_id) values (new.track_id) on conflict do nothing;
+  insert into aggregate_user (user_id) values (new.owner_id) on conflict do nothing;
+
+  update aggregate_user
+  set (track_count, total_track_count) = (
+    select
+      count(*) filter (where t.is_unlisted = false),
+      count(*)
+    from tracks t
+    where t.is_current is true
+      and t.is_delete is false
+      and t.is_available is true
+      and t.stem_of is null
+      and t.access_authorities is null
+      and t.owner_id = new.owner_id
+  )
+  where user_id = new.owner_id
+  ;
+
+  -- If new track or newly unlisted track, create notification
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.is_playlist_upload = FALSE THEN
+      select array(
+        select subscriber_id
+          from subscriptions
+          where is_current and
+          not is_delete and
+          user_id=new.owner_id
+      ) into subscriber_user_ids;
+
+      if array_length(subscriber_user_ids, 1)	> 0 then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          subscriber_user_ids,
+          new.updated_at,
+          'create',
+          new.track_id,
+          'create:track:user_id:' || new.owner_id,
+          json_build_object('track_id', new.track_id)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  -- If new remix or newly unlisted remix, create notification
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.remix_of is not null THEN
+      select owner_id into parent_track_owner_id from tracks where is_current and track_id = (new.remix_of->'tracks'->0->>'parent_track_id')::int limit 1;
+      if parent_track_owner_id is not null then
+        insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          ARRAY [parent_track_owner_id],
+          new.updated_at,
+          'remix',
+          new.owner_id,
+          'remix:track:' || new.track_id || ':parent_track:' || (new.remix_of->'tracks'->0->>'parent_track_id')::int,
+          json_build_object('track_id', new.track_id, 'parent_track_id', (new.remix_of->'tracks'->0->>'parent_track_id')::int)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  -- If new remix is a submission to an active remix contest, check for milestone notifications
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.remix_of is not null THEN
+      declare
+        contest_event_id int;
+        contest_creator_id int;
+        submission_count int;
+        milestone int;
+        parent_track_id int := (new.remix_of->'tracks'->0->>'parent_track_id')::int;
+      begin
+        select event_id, user_id
+        into contest_event_id, contest_creator_id
+        from events
+        where event_type = 'remix_contest'
+          and is_deleted = false
+          and end_date > now()
+          and entity_id = parent_track_id
+        limit 1;
+
+        if contest_event_id is not null then
+          -- Count submissions for this contest (only those after contest start)
+          select count(*) into submission_count
+          from tracks t
+          join events e on e.event_type = 'remix_contest'
+            and e.is_deleted = false
+            and e.entity_id = parent_track_id
+          where t.is_current = true
+            and t.is_delete = false
+            and t.remix_of is not null
+            and (t.remix_of->'tracks'->0->>'parent_track_id')::int = parent_track_id
+            and t.created_at >= e.created_at;
+
+          -- For each milestone, insert notification if this is the Nth submission
+          FOREACH milestone IN ARRAY ARRAY[1, 10, 50] LOOP
+            IF submission_count = milestone THEN
+              insert into notification
+                (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+                (
+                  new.blocknumber,
+                  ARRAY [contest_creator_id],
+                  new.updated_at,
+                  'artist_remix_contest_submissions',
+                  milestone || ':' || contest_event_id,
+                  'artist_remix_contest_submissions:' || contest_event_id || ':' || milestone,
+                  json_build_object(
+                    'event_id', contest_event_id,
+                    'milestone', milestone,
+                    'entity_id', parent_track_id
+                  )
+                )
+              on conflict do nothing;
+            END IF;
+          END LOOP;
+        end if;
+      end;
+    end if;
+    exception
+      when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_usdc_purchase(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_usdc_purchase() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+
+  -- insert seller/artist notification
+  INSERT INTO notification
+          (slot, user_ids, timestamp, type, specifier, group_id, data)
+        VALUES
+          (
+            new.slot,
+            ARRAY [new.seller_user_id],
+            new.created_at,
+            'usdc_purchase_seller',
+            new.buyer_user_id,
+            'usdc_purchase_seller:' || 'seller_user_id:' || new.seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+            json_build_object(
+                'content_type', new.content_type,
+                'buyer_user_id', new.buyer_user_id,
+                'seller_user_id', new.seller_user_id,
+                'amount', new.amount,
+                'extra_amount', new.extra_amount,
+                'content_id', new.content_id,
+                'vendor', new.vendor
+              )
+          ),
+          (
+            new.slot,
+            ARRAY [new.buyer_user_id],
+            new.created_at,
+            'usdc_purchase_buyer',
+            new.buyer_user_id,
+            'usdc_purchase_buyer:' || 'seller_user_id:' || new.seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+            json_build_object(
+                'content_type', new.content_type,
+                'buyer_user_id', new.buyer_user_id,
+                'seller_user_id', new.seller_user_id,
+                'amount', new.amount,
+                'extra_amount', new.extra_amount,
+                'content_id', new.content_id,
+                'vendor', new.vendor
+            )
+          )
+        on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end; 
+$$;
+
+
+--
+-- Name: handle_usdc_withdrawal(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_usdc_withdrawal() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    users_row users%ROWTYPE;
+    notification_type varchar;
+begin
+
+  if new.transaction_type in ('transfer', 'withdrawal') and new.method = 'send' then
+    notification_type := 'usdc_' || new.transaction_type;
+    -- Fetch the corresponding user based on the wallet
+    select into users_row users.*
+    from users
+    join usdc_user_bank_accounts
+      on users.wallet = usdc_user_bank_accounts.ethereum_address
+    where usdc_user_bank_accounts.bank_account = new.user_bank;
+
+    -- Insert the new notification
+    insert into notification
+      (slot, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      (
+        new.slot,
+        ARRAY [users_row.user_id],
+        new.created_at,
+        notification_type,
+        users_row.user_id,
+        notification_type || ':' || users_row.user_id || ':' || 'signature:' || new.signature,
+        json_build_object(
+          'user_id', users_row.user_id,
+          'user_bank', new.user_bank,
+          'signature', new.signature,
+          'change', new.change,
+          'balance', new.balance,
+          'receiver_account', new.tx_metadata
+        )
+      )
+      on conflict do nothing;
+  end if;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+
+end;
+$$;
+
+
+--
+-- Name: handle_user(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_user() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+--
+-- Name: handle_user_balance_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_user_balance_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_val int;
+  new_tier text;
+  new_tier_value int;
+  previous_tier text;
+  previous_tier_value int;
+begin
+  SELECT label, val into new_tier, new_tier_value
+  FROM (
+    VALUES ('bronze', 10::bigint), ('silver', 100::bigint), ('gold', 1000::bigint), ('platinum', 10000::bigint)
+  ) as tier (label, val)
+  WHERE
+    substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18))::bigint >= tier.val
+  ORDER BY 
+    tier.val DESC
+  limit 1;
+
+  SELECT label, val into previous_tier, previous_tier_value
+  FROM (
+    VALUES ('bronze', 10::bigint), ('silver', 100::bigint), ('gold', 1000::bigint), ('platinum', 10000::bigint)
+  ) as tier (label, val)
+  WHERE
+    substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18))::bigint >= tier.val
+  ORDER BY 
+    tier.val DESC
+  limit 1;
+
+  -- create a notification if the tier changes
+  if new_tier_value > previous_tier_value or (new_tier_value is not NULL and previous_tier_value is NULL) then
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      ( 
+        new.blocknumber,
+        ARRAY [new.user_id], 
+        new.updated_at, 
+        'tier_change',
+        new.user_id,
+        'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
+        json_build_object(
+          'new_tier', new_tier,
+          'new_tier_value', new_tier_value,
+          'current_value', new.current_balance
+        )
+      )
+    on conflict do nothing;
+    return null;
+  end if;
+
+  return null;
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+--
+-- Name: handle_user_tip(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_user_tip() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+
+  -- create a notification for the sender and receiver
+  insert into notification
+    (slot, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    ( 
+      new.slot,
+      ARRAY [new.receiver_user_id], 
+      new.created_at, 
+      'tip_receive',
+      new.receiver_user_id,
+      'tip_receive:user_id:' || new.receiver_user_id || ':signature:' || new.signature,
+      json_build_object(
+        'sender_user_id', new.sender_user_id,
+        'receiver_user_id', new.receiver_user_id,
+        'amount', new.amount,
+        'tx_signature', new.signature
+      )
+    ),
+    ( 
+      new.slot,
+      ARRAY [new.sender_user_id], 
+      new.created_at, 
+      'tip_send',
+      new.sender_user_id,
+      'tip_send:user_id:' || new.sender_user_id || ':signature:' || new.signature,
+      json_build_object(
+        'sender_user_id', new.sender_user_id,
+        'receiver_user_id', new.receiver_user_id,
+        'amount', new.amount,
+        'tx_signature', new.signature
+      )
+    )
+    on conflict do nothing;
+
+return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+
+end;
+$$;
+
+
+--
+-- Name: id_decode(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.id_decode(p_id text) RETURNS integer
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $$
+begin
+  return (hashids.decode(p_id, 'azowernasdfoia', 5))[1]::integer;
+end;
+$$;
+
+
+--
+-- Name: id_encode(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.id_encode(p_id integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $$
+begin
+  return hashids.encode(p_id, 'azowernasdfoia', 5);
+end;
+$$;
+
+
+--
+-- Name: is_country_eur(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.is_country_eur(country text) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN
+        country = 'Afghanistan' OR
+        country = 'Albania' OR
+        country = 'Algeria' OR
+        country = 'American Samoa' OR
+        country = 'Andorra' OR
+        country = 'Angola' OR
+        country = 'Antigua and Barbuda' OR
+        country = 'Arab Emirates' OR
+        country = 'Armenia' OR
+        country = 'Aruba' OR
+        country = 'Australia' OR
+        country = 'Austria' OR
+        country = 'Azerbaijan' OR
+        country = 'Bahamas' OR
+        country = 'Bahrain' OR
+        country = 'Bangladesh' OR
+        country = 'Barbados' OR
+        country = 'Belarus' OR
+        country = 'Belgium' OR
+        country = 'Belize' OR
+        country = 'Benin' OR
+        country = 'Bermuda' OR
+        country = 'Bhutan' OR
+        country = 'Bolivia' OR
+        country = 'Bosnia and Herzegovina' OR
+        country = 'Botswana' OR
+        country = 'Brunei' OR
+        country = 'Bulgaria' OR
+        country = 'Burkina Faso' OR
+        country = 'Burma' OR
+        country = 'Burundi' OR
+        country = 'Cambodia' OR
+        country = 'Cameroon' OR
+        country = 'Cape Verde' OR
+        country = 'Cayman Islands' OR
+        country = 'Central African Republic' OR
+        country = 'Chad' OR
+        country = 'Channel Islands' OR
+        country = 'Chile' OR
+        country = 'China' OR
+        country = 'Colombia' OR
+        country = 'Comoros' OR
+        country = 'Congo' OR
+        country = 'Costa Rica' OR
+        country = 'Cote d''Ivoire' OR
+        country = 'Côte d''Ivoire' OR
+        country = 'Croatia' OR
+        country = 'Cuba' OR
+        country = 'Curacao' OR
+        country = 'Cyprus' OR
+        country = 'Czech Republic' OR
+        country = 'Czechia' OR
+        country = 'Democratic People''s Republic of Korea' OR
+        country = 'Democratic Republic of the Congo' OR
+        country = 'Denmark' OR
+        country = 'Djibouti' OR
+        country = 'Dominica' OR
+        country = 'Dominican Republic' OR
+        country = 'East Timor' OR
+        country = 'Ecuador' OR
+        country = 'Egypt' OR
+        country = 'El Salvador' OR
+        country = 'Equatorial Guinea' OR
+        country = 'Eritrea' OR
+        country = 'Estonia' OR
+        country = 'Eswatini' OR
+        country = 'Ethiopia' OR
+        country = 'Faroe Islands' OR
+        country = 'Fiji' OR
+        country = 'Finland' OR
+        country = 'France' OR
+        country = 'French Polynesia' OR
+        country = 'Gabon' OR
+        country = 'Gambia' OR
+        country = 'Gambia' OR
+        country = 'Georgia' OR
+        country = 'Germany' OR
+        country = 'Ghana' OR
+        country = 'Gibraltar' OR
+        country = 'Greece' OR
+        country = 'Guernsey' OR
+        country = 'Guinea-Bissau' OR
+        country = 'Guinea' OR
+        country = 'Holy See' OR
+        country = 'Hong Kong' OR
+        country = 'Hungary' OR
+        country = 'Iceland' OR
+        country = 'India' OR
+        country = 'Indonesia' OR
+        country = 'Iran' OR
+        country = 'Iraq' OR
+        country = 'Ireland' OR
+        country = 'Israel' OR
+        country = 'Italy' OR
+        country = 'Ivory Coast' OR
+        country = 'Japan' OR
+        country = 'Jersey' OR
+        country = 'Jordan' OR
+        country = 'Kazakhstan' OR
+        country = 'Kenya' OR
+        country = 'Kiribati' OR
+        country = 'Kosovo' OR
+        country = 'Kuwait' OR
+        country = 'Kyrgyzstan' OR
+        country = 'Laos' OR
+        country = 'Latvia' OR
+        country = 'Lebanon' OR
+        country = 'Lesotho' OR
+        country = 'Liberia' OR
+        country = 'Libya' OR
+        country = 'Liechtenstein' OR
+        country = 'Lithuania' OR
+        country = 'Lituania' OR
+        country = 'Luxembourg' OR
+        country = 'Macau' OR
+        country = 'Macedonia' OR
+        country = 'Madagascar' OR
+        country = 'Malawi' OR
+        country = 'Malaysia' OR
+        country = 'Maldives' OR
+        country = 'Mali' OR
+        country = 'Malta' OR
+        country = 'Marshall Islands' OR
+        country = 'Mauritania' OR
+        country = 'Mauritius' OR
+        country = 'Micronesia' OR
+        country = 'Monaco' OR
+        country = 'Mongolia' OR
+        country = 'Montenegro' OR
+        country = 'Morocco' OR
+        country = 'Mozambique' OR
+        country = 'Myanmar' OR
+        country = 'Namibia' OR
+        country = 'Nauru' OR
+        country = 'Nepal' OR
+        country = 'Netherlands' OR
+        country = 'New Zealand' OR
+        country = 'Niger' OR
+        country = 'Nigeria' OR
+        country = 'Niue' OR
+        country = 'North Korea' OR
+        country = 'North Macedonia' OR
+        country = 'Norway' OR
+        country = 'Oman' OR
+        country = 'Pakistan' OR
+        country = 'Palau' OR
+        country = 'Palestine' OR
+        country = 'Palestinian Territory' OR
+        country = 'Papua New Guinea' OR
+        country = 'Paraguay' OR
+        country = 'Peru' OR
+        country = 'Philippines' OR
+        country = 'Poland' OR
+        country = 'Portugal' OR
+        country = 'Qatar' OR
+        country = 'Reunion' OR
+        country = 'Romania' OR
+        country = 'Rwanda' OR
+        country = 'Samoa' OR
+        country = 'San Marino' OR
+        country = 'Sao Tome and Principe' OR
+        country = 'Saudi Arabia' OR
+        country = 'Senegal' OR
+        country = 'Serbia' OR
+        country = 'Seychelles' OR
+        country = 'Sierra Leone' OR
+        country = 'Singapore' OR
+        country = 'Slovakia' OR
+        country = 'Slovenia' OR
+        country = 'Solomon Islands' OR
+        country = 'Somalia' OR
+        country = 'South Africa' OR
+        country = 'South Korea' OR
+        country = 'South Sudan' OR
+        country = 'Spain' OR
+        country = 'Sri Lanka' OR
+        country = 'Sudan' OR
+        country = 'Suriname' OR
+        country = 'Swaziland' OR
+        country = 'Sweden' OR
+        country = 'Switzerland' OR
+        country = 'Syria' OR
+        country = 'Taiwan' OR
+        country = 'Tajikistan' OR
+        country = 'Tanzania' OR
+        country = 'Thailand' OR
+        country = 'Timor Leste' OR
+        country = 'Togo' OR
+        country = 'Tonga' OR
+        country = 'Trinidad and Tobago' OR
+        country = 'Tunisia' OR
+        country = 'Turkey' OR
+        country = 'Turkmenistan' OR
+        country = 'Turks and Caicos Islands' OR
+        country = 'Tuvalu' OR
+        country = 'Uganda' OR
+        country = 'Ukraine' OR
+        country = 'United Arab Emirates' OR
+        country = 'United Kingdom' OR
+        country = 'Uruguay' OR
+        country = 'Uzbekistan' OR
+        country = 'Vanuatu' OR
+        country = 'Vatican City' OR
+        country = 'Venezuela' OR
+        country = 'Vietnam' OR
+        country = 'Virgin Islands' OR
+        country = 'Western Sahara' OR
+        country = 'Yemen' OR
+        country = 'Zambia' OR
+        country = 'Zimbabwe' OR
+
+        -- country codes
+        country = 'AD' OR
+        country = 'AE' OR
+        country = 'AF' OR
+        country = 'AG' OR
+        country = 'AL' OR
+        country = 'AM' OR
+        country = 'AO' OR
+        country = 'AS' OR
+        country = 'AT' OR
+        country = 'AU' OR
+        country = 'AW' OR
+        country = 'AZ' OR
+        country = 'BA' OR
+        country = 'BB' OR
+        country = 'BD' OR
+        country = 'BE' OR
+        country = 'BF' OR
+        country = 'BG' OR
+        country = 'BH' OR
+        country = 'BI' OR
+        country = 'BJ' OR
+        country = 'BM' OR
+        country = 'BN' OR
+        country = 'BO' OR
+        country = 'BS' OR
+        country = 'BT' OR
+        country = 'BW' OR
+        country = 'BY' OR
+        country = 'BZ' OR
+        country = 'CF' OR
+        country = 'CG' OR
+        country = 'CH' OR
+        country = 'CI' OR
+        country = 'CL' OR
+        country = 'CM' OR
+        country = 'CN' OR
+        country = 'CO' OR
+        country = 'CR' OR
+        country = 'CU' OR
+        country = 'CV' OR
+        country = 'CW' OR
+        country = 'CY' OR
+        country = 'CZ' OR
+        country = 'DE' OR
+        country = 'DJ' OR
+        country = 'DK' OR
+        country = 'DM' OR
+        country = 'DO' OR
+        country = 'DZ' OR
+        country = 'EC' OR
+        country = 'EE' OR
+        country = 'EG' OR
+        country = 'EH' OR
+        country = 'ER' OR
+        country = 'ES' OR
+        country = 'ET' OR
+        country = 'FI' OR
+        country = 'FJ' OR
+        country = 'FO' OR
+        country = 'FR' OR
+        country = 'GA' OR
+        country = 'GB' OR
+        country = 'GD' OR
+        country = 'GE' OR
+        country = 'GG' OR
+        country = 'GH' OR
+        country = 'GI' OR
+        country = 'GM' OR
+        country = 'GN' OR
+        country = 'GQ' OR
+        country = 'GR' OR
+        country = 'GT' OR
+        country = 'GU' OR
+        country = 'GW' OR
+        country = 'GY' OR
+        country = 'HK' OR
+        country = 'HN' OR
+        country = 'HR' OR
+        country = 'HT' OR
+        country = 'HU' OR
+        country = 'ID' OR
+        country = 'IE' OR
+        country = 'IL' OR
+        country = 'IM' OR
+        country = 'IN' OR
+        country = 'IQ' OR
+        country = 'IS' OR
+        country = 'IT' OR
+        country = 'JE' OR
+        country = 'JM' OR
+        country = 'JO' OR
+        country = 'JP' OR
+        country = 'KE' OR
+        country = 'KG' OR
+        country = 'KH' OR
+        country = 'KI' OR
+        country = 'KM' OR
+        country = 'KN' OR
+        country = 'KP' OR
+        country = 'KR' OR
+        country = 'KW' OR
+        country = 'KY' OR
+        country = 'KZ' OR
+        country = 'LA' OR
+        country = 'LB' OR
+        country = 'LC' OR
+        country = 'LI' OR
+        country = 'LK' OR
+        country = 'LR' OR
+        country = 'LS' OR
+        country = 'LT' OR
+        country = 'LU' OR
+        country = 'LV' OR
+        country = 'LY' OR
+        country = 'MA' OR
+        country = 'MC' OR
+        country = 'MD' OR
+        country = 'ME' OR
+        country = 'MG' OR
+        country = 'MH' OR
+        country = 'MK' OR
+        country = 'ML' OR
+        country = 'MM' OR
+        country = 'MN' OR
+        country = 'MO' OR
+        country = 'MR' OR
+        country = 'MS' OR
+        country = 'MT' OR
+        country = 'MU' OR
+        country = 'MV' OR
+        country = 'MW' OR
+        country = 'MY' OR
+        country = 'MZ' OR
+        country = 'NA' OR
+        country = 'NE' OR
+        country = 'NG' OR
+        country = 'NI' OR
+        country = 'NL' OR
+        country = 'NO' OR
+        country = 'NP' OR
+        country = 'NR' OR
+        country = 'NU' OR
+        country = 'NZ' OR
+        country = 'OM' OR
+        country = 'PA' OR
+        country = 'PE' OR
+        country = 'PF' OR
+        country = 'PG' OR
+        country = 'PH' OR
+        country = 'PK' OR
+        country = 'PL' OR
+        country = 'PM' OR
+        country = 'PN' OR
+        country = 'PR' OR
+        country = 'PS' OR
+        country = 'PT' OR
+        country = 'PW' OR
+        country = 'PY' OR
+        country = 'QA' OR
+        country = 'RE' OR
+        country = 'RO' OR
+        country = 'RS' OR
+        country = 'RW' OR
+        country = 'SA' OR
+        country = 'SB' OR
+        country = 'SC' OR
+        country = 'SD' OR
+        country = 'SE' OR
+        country = 'SG' OR
+        country = 'SI' OR
+        country = 'SK' OR
+        country = 'SL' OR
+        country = 'SM' OR
+        country = 'SN' OR
+        country = 'SO' OR
+        country = 'SR' OR
+        country = 'SS' OR
+        country = 'ST' OR
+        country = 'SV' OR
+        country = 'SX' OR
+        country = 'SY' OR
+        country = 'SZ' OR
+        country = 'TC' OR
+        country = 'TD' OR
+        country = 'TG' OR
+        country = 'TH' OR
+        country = 'TJ' OR
+        country = 'TK' OR
+        country = 'TL' OR
+        country = 'TM' OR
+        country = 'TN' OR
+        country = 'TO' OR
+        country = 'TR' OR
+        country = 'TT' OR
+        country = 'TV' OR
+        country = 'TW' OR
+        country = 'TZ' OR
+        country = 'UA' OR
+        country = 'UG' OR
+        country = 'UY' OR
+        country = 'UZ' OR
+        country = 'VA' OR
+        country = 'VC' OR
+        country = 'VE' OR
+        country = 'VG' OR
+        country = 'VI' OR
+        country = 'VN' OR
+        country = 'VU' OR
+        country = 'WS' OR
+        country = 'XK' OR
+        country = 'YE' OR
+        country = 'ZA' OR
+        country = 'ZM' OR
+        country = 'ZW'
+        ;
+END;
+$$;
+
+
+--
+-- Name: log_message(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.log_message(message_text text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE '% %', pg_backend_pid(), message_text;
+END;
+$$;
+
+
+--
+-- Name: on_new_row(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.on_new_row() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  case TG_TABLE_NAME
+    when 'tracks' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('track_id', new.track_id, 'updated_at', new.updated_at, 'created_at', new.created_at, 'blocknumber', new.blocknumber)::text);
+    when 'users' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id, 'blocknumber', new.blocknumber)::text);
+    when 'playlists' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('playlist_id', new.playlist_id)::text);
+    else
+      PERFORM pg_notify(TG_TABLE_NAME, to_json(new)::text);
+  end case;
+  return null;
+end;
+$$;
+
+
+--
+-- Name: price_from_sqrt_price(numeric, integer, integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.price_from_sqrt_price(sqrt_price numeric, base_decimals integer, quote_decimals integer DEFAULT 8) RETURNS numeric
+    LANGUAGE sql
+    AS $$
+    SELECT
+        -- See: https://github.com/MeteoraAg/dynamic-bonding-curve-sdk/blob/a5519bf920935a9438fa200e067fffc6c6e40e27/packages/dynamic-bonding-curve/src/helpers/common.ts#L198
+        ((sqrt_price * sqrt_price) * POWER(10, base_decimals - quote_decimals)) / POWER(2, 128) AS price
+$$;
+
+
+--
+-- Name: process_grant_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.process_grant_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+    matched_user_id integer;
+begin
+    -- fetch the user_id where wallet matches grantee_address
+    select user_id into matched_user_id from users where lower(wallet) = lower(NEW.grantee_address);
+    
+    if matched_user_id is not null then
+        -- if the grant is newly created (i.e. the grant is not deleted, is not approved yet, and was just created indicated by created timestamp = last updated timestamp) OR grant went from deleted (revoked) to not deleted and is not approved yet...
+        if (TG_OP = 'INSERT' and NEW.is_revoked = FALSE and NEW.is_approved is null and NEW.created_at = NEW.updated_at or
+            (TG_OP = 'UPDATE' and NEW.is_revoked = FALSE and OLD.is_revoked = TRUE and NEW.is_approved is null))
+        then
+            -- ... create a "request_manager" notification
+            insert into notification
+                    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+                  values
+                    (
+                      new.blocknumber,
+                      array [matched_user_id],
+                      new.updated_at,
+                      'request_manager',
+                      new.user_id,
+                      'request_manager:' || 'grantee_user_id:' || matched_user_id || ':grantee_address:' || new.grantee_address || ':user_id:' || new.user_id || ':updated_at:' || new.updated_at ||
+                      ':created_at:' || new.created_at,
+                      json_build_object(
+                          'grantee_user_id', matched_user_id,
+                          'grantee_address', new.grantee_address,
+                          'user_id', new.user_id
+                        )
+                    )
+                  on conflict do nothing;
+        -- otherwise, if the grant is approved and not deleted (revoked)...
+        elsif (TG_OP = 'INSERT' and NEW.is_approved = TRUE and NEW.is_revoked = FALSE) or
+            (TG_OP = 'UPDATE' and NEW.is_approved = TRUE and (OLD.is_approved != TRUE) and NEW.is_revoked = FALSE)
+        then
+            -- ... create a "approve_manager_request" notification
+            insert into notification
+                    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+                  values
+                    (
+                      new.blocknumber,
+                      array [new.user_id],
+                      new.updated_at,
+                      'approve_manager_request',
+                      matched_user_id,
+                      'approve_manager_request:' || 'grantee_user_id:' || matched_user_id || ':grantee_address:' || new.grantee_address || ':user_id:' || new.user_id || ':created_at:' || new.created_at,
+                      json_build_object(
+                          'grantee_user_id', matched_user_id,
+                          'grantee_address', new.grantee_address,
+                          'user_id', new.user_id
+                        )
+                    )
+                  on conflict do nothing;
+        end if;
+    end if;
+    return null;
+exception
+  when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end; 
+$$;
+
+
+--
+-- Name: recreate_trending_params(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.recreate_trending_params() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    create materialized view public.trending_params as
+    select
+    t.track_id,
+    t.release_date,
+    t.genre,
+    t.owner_id,
+    ap.play_count,
+    au.follower_count as owner_follower_count,
+    coalesce(aggregate_track.repost_count, 0) as repost_count,
+    coalesce(aggregate_track.save_count, 0) as save_count,
+    coalesce(repost_week.repost_count, (0) :: bigint) as repost_week_count,
+    coalesce(repost_month.repost_count, (0) :: bigint) as repost_month_count,
+    coalesce(repost_year.repost_count, (0) :: bigint) as repost_year_count,
+    coalesce(save_week.repost_count, (0) :: bigint) as save_week_count,
+    coalesce(save_month.repost_count, (0) :: bigint) as save_month_count,
+    coalesce(save_year.repost_count, (0) :: bigint) as save_year_count,
+    coalesce(karma.karma, (0) :: numeric) as karma
+    from
+    (
+        (
+            (
+                (
+                (
+                    (
+                        (
+                            (
+                            (
+                                (
+                                    public.tracks t
+                                    left join (
+                                        select
+                                        ap_1.count as play_count,
+                                        ap_1.play_item_id
+                                        from
+                                        public.aggregate_plays ap_1
+                                    ) ap on ((ap.play_item_id = t.track_id))
+                                )
+                                left join (
+                                    select
+                                        au_1.user_id,
+                                        au_1.follower_count
+                                    from
+                                        public.aggregate_user au_1
+                                ) au on ((au.user_id = t.owner_id))
+                            )
+                            left join (
+                                select
+                                    aggregate_track_1.track_id,
+                                    aggregate_track_1.repost_count,
+                                    aggregate_track_1.save_count
+                                from
+                                    public.aggregate_track aggregate_track_1
+                            ) aggregate_track on ((aggregate_track.track_id = t.track_id))
+                            )
+                            left join (
+                            select
+                                r.repost_item_id as track_id,
+                                count(r.repost_item_id) as repost_count
+                            from
+                                public.reposts r
+                            where
+                                (
+                                    (r.is_current is true)
+                                    and (r.repost_type = 'track' :: public.reposttype)
+                                    and (r.is_delete is false)
+                                    and (r.created_at > (now() - '1 year' :: interval))
+                                )
+                            group by
+                                r.repost_item_id
+                            ) repost_year on ((repost_year.track_id = t.track_id))
+                        )
+                        left join (
+                            select
+                            r.repost_item_id as track_id,
+                            count(r.repost_item_id) as repost_count
+                            from
+                            public.reposts r
+                            where
+                            (
+                                (r.is_current is true)
+                                and (r.repost_type = 'track' :: public.reposttype)
+                                and (r.is_delete is false)
+                                and (r.created_at > (now() - '1 mon' :: interval))
+                            )
+                            group by
+                            r.repost_item_id
+                        ) repost_month on ((repost_month.track_id = t.track_id))
+                    )
+                    left join (
+                        select
+                            r.repost_item_id as track_id,
+                            count(r.repost_item_id) as repost_count
+                        from
+                            public.reposts r
+                        where
+                            (
+                            (r.is_current is true)
+                            and (r.repost_type = 'track' :: public.reposttype)
+                            and (r.is_delete is false)
+                            and (r.created_at > (now() - '7 days' :: interval))
+                            )
+                        group by
+                            r.repost_item_id
+                    ) repost_week on ((repost_week.track_id = t.track_id))
+                )
+                left join (
+                    select
+                        r.save_item_id as track_id,
+                        count(r.save_item_id) as repost_count
+                    from
+                        public.saves r
+                    where
+                        (
+                            (r.is_current is true)
+                            and (r.save_type = 'track' :: public.savetype)
+                            and (r.is_delete is false)
+                            and (r.created_at > (now() - '1 year' :: interval))
+                        )
+                    group by
+                        r.save_item_id
+                ) save_year on ((save_year.track_id = t.track_id))
+                )
+                left join (
+                select
+                    r.save_item_id as track_id,
+                    count(r.save_item_id) as repost_count
+                from
+                    public.saves r
+                where
+                    (
+                        (r.is_current is true)
+                        and (r.save_type = 'track' :: public.savetype)
+                        and (r.is_delete is false)
+                        and (r.created_at > (now() - '1 mon' :: interval))
+                    )
+                group by
+                    r.save_item_id
+                ) save_month on ((save_month.track_id = t.track_id))
+            )
+            left join (
+                select
+                r.save_item_id as track_id,
+                count(r.save_item_id) as repost_count
+                from
+                public.saves r
+                where
+                (
+                    (r.is_current is true)
+                    and (r.save_type = 'track' :: public.savetype)
+                    and (r.is_delete is false)
+                    and (r.created_at > (now() - '7 days' :: interval))
+                )
+                group by
+                r.save_item_id
+            ) save_week on ((save_week.track_id = t.track_id))
+        )
+        left join (
+            select
+                save_and_reposts.item_id as track_id,
+                sum(au_1.follower_count) as karma
+            from
+                (
+                (
+                    select
+                        r_and_s.user_id,
+                        r_and_s.item_id
+                    from
+                        (
+                            (
+                            select
+                                reposts.user_id,
+                                reposts.repost_item_id as item_id
+                            from
+                                public.reposts
+                            where
+                                (
+                                    (reposts.is_delete is false)
+                                    and (reposts.is_current is true)
+                                    and (
+                                        reposts.repost_type = 'track' :: public.reposttype
+                                    )
+                                )
+                            union
+                            all
+                            select
+                                saves.user_id,
+                                saves.save_item_id as item_id
+                            from
+                                public.saves
+                            where
+                                (
+                                    (saves.is_delete is false)
+                                    and (saves.is_current is true)
+                                    and (saves.save_type = 'track' :: public.savetype)
+                                )
+                            ) r_and_s
+                            join public.users on ((r_and_s.user_id = users.user_id))
+                        )
+                    where
+                        (
+                            (
+                            (users.cover_photo is not null)
+                            or (users.cover_photo_sizes is not null)
+                            )
+                            and (
+                            (users.profile_picture is not null)
+                            or (users.profile_picture_sizes is not null)
+                            )
+                            and (users.bio is not null)
+                        )
+                ) save_and_reposts
+                join public.aggregate_user au_1 on ((save_and_reposts.user_id = au_1.user_id))
+                )
+            group by
+                save_and_reposts.item_id
+        ) karma on ((karma.track_id = t.track_id))
+    )
+    where
+    (
+        (t.is_current is true)
+        and (t.is_delete is false)
+        and (t.is_unlisted is false)
+        and (t.stem_of is null)
+        and (t.access_authorities is null)
+    ) with no data;
+
+    create index trending_params_track_id_idx on public.trending_params using btree (track_id);
+END;
+$$;
+
+
+--
+-- Name: refresh_all_user_scores(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.refresh_all_user_scores() RETURNS TABLE(acquired boolean, diff_rows bigint, updated_rows bigint)
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_lock_key bigint := hashtext('refresh_all_user_scores');
+  v_diff bigint := 0;
+  v_upd  bigint := 0;
+  v_got  boolean;
+begin
+  v_got := pg_try_advisory_lock(v_lock_key);
+  if not v_got then
+    acquired     := false;
+    diff_rows    := 0;
+    updated_rows := 0;
+    return next;
+    return;
+  end if;
+
+  begin
+    create temp table _scores_new (
+      user_id int primary key,
+      score   int
+    ) on commit drop;
+
+    insert into _scores_new (user_id, score)
+    select s.user_id, s.score
+    from get_user_scores() as s
+    join aggregate_user au using (user_id)
+    where au.score is distinct from s.score;
+
+    get diagnostics v_diff = row_count;
+    create index on _scores_new (user_id);
+
+    update aggregate_user au
+    set score = sn.score
+    from _scores_new sn
+    where au.user_id = sn.user_id;
+
+    get diagnostics v_upd = row_count;
+
+    acquired     := true;
+    diff_rows    := v_diff;
+    updated_rows := v_upd;
+    return next;
+
+  exception when others then
+    perform pg_advisory_unlock(v_lock_key);
+    raise;
+  end;
+
+  perform pg_advisory_unlock(v_lock_key);
+end
+$$;
+
+
+--
+-- Name: table_exists(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.table_exists(text) RETURNS boolean
+    LANGUAGE sql
+    AS $_$
+  SELECT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = $1)
+$_$;
+
+
+--
+-- Name: table_has_column(text, text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.table_has_column(text, text) RETURNS boolean
+    LANGUAGE sql
+    AS $_$
+  SELECT EXISTS (SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND column_name = $2)
+$_$;
+
+
+--
+-- Name: table_has_constraint(text, text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.table_has_constraint(text, text) RETURNS boolean
+    LANGUAGE sql
+    AS $_$
+  SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = $1::regclass AND conname = $2)
+$_$;
+
+
+--
+-- Name: to_date_safe(character varying, character varying); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.to_date_safe(p_date character varying, p_format character varying) RETURNS date
+    LANGUAGE plpgsql
+    AS $$
+        DECLARE
+            ret_date DATE;
+        BEGIN
+            IF p_date = '' THEN
+                RETURN NULL;
+            END IF;
+            RETURN to_date( p_date, p_format );
+        EXCEPTION
+        WHEN others THEN
+            RETURN null;
+        END;
+        $$;
+
+
+--
+-- Name: to_timestamp_safe(character varying, character varying); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.to_timestamp_safe(p_timestamp character varying, p_format character varying) RETURNS timestamp without time zone
+    LANGUAGE plpgsql
+    AS $$
+  DECLARE
+      ret_timestamp TIMESTAMP;
+  BEGIN
+      IF p_timestamp = '' THEN
+          RETURN NULL;
+      END IF;
+      RETURN to_timestamp( p_timestamp, p_format );
+  EXCEPTION
+  WHEN others THEN
+      RETURN null;
+  END;
+  $$;
+
+
+--
+-- Name: track_is_public(record); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.track_is_public(track record) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+begin
+  return track.is_unlisted = false
+     and track.is_available = true
+     and track.is_delete = false
+     and track.stem_of is null
+     and track.access_authorities is null;
+end
+$$;
+
+
+--
+-- Name: validate_territory_codes(text[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.validate_territory_codes(codes text[]) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $_$
+begin
+    -- null is valid
+    if codes is null then
+        return true;
+    end if;
+
+    -- array must have at least one element
+    if array_length(codes, 1) is null then
+        return false;
+    end if;
+
+    -- check each element to make sure it's a 2 letter ISO code
+    for i in 1..array_length(codes, 1) loop
+        if codes[i] !~ '^[A-Z]{2}$' then
+            return false;
+        end if;
+    end loop;
+
+    return true;
+end;
+$_$;
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: tracks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.tracks (
+    blockhash character varying,
+    track_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    owner_id integer NOT NULL,
+    title text,
+    cover_art character varying,
+    tags character varying,
+    genre character varying,
+    mood character varying,
+    credits_splits character varying,
+    create_date character varying,
+    file_type character varying,
+    metadata_multihash character varying,
+    blocknumber integer,
+    created_at timestamp without time zone NOT NULL,
+    description character varying,
+    isrc character varying,
+    iswc character varying,
+    license character varying,
+    updated_at timestamp without time zone NOT NULL,
+    cover_art_sizes character varying,
+    is_unlisted boolean DEFAULT false NOT NULL,
+    field_visibility jsonb,
+    route_id character varying,
+    stem_of jsonb,
+    remix_of jsonb,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer,
+    is_available boolean DEFAULT true NOT NULL,
+    is_stream_gated boolean DEFAULT false NOT NULL,
+    stream_conditions jsonb,
+    track_cid character varying,
+    is_playlist_upload boolean DEFAULT false NOT NULL,
+    duration integer DEFAULT 0,
+    ai_attribution_user_id integer,
+    preview_cid character varying,
+    audio_upload_id character varying,
+    preview_start_seconds double precision,
+    release_date timestamp without time zone,
+    track_segments jsonb DEFAULT '[]'::jsonb NOT NULL,
+    is_scheduled_release boolean DEFAULT false NOT NULL,
+    is_downloadable boolean DEFAULT false NOT NULL,
+    is_download_gated boolean DEFAULT false NOT NULL,
+    download_conditions jsonb,
+    is_original_available boolean DEFAULT false NOT NULL,
+    orig_file_cid character varying,
+    orig_filename character varying,
+    playlists_containing_track integer[] DEFAULT '{}'::integer[] NOT NULL,
+    placement_hosts text,
+    ddex_app character varying,
+    ddex_release_ids jsonb,
+    artists jsonb,
+    resource_contributors jsonb,
+    indirect_resource_contributors jsonb,
+    rights_controller jsonb,
+    copyright_line jsonb,
+    producer_copyright_line jsonb,
+    parental_warning_type character varying,
+    playlists_previously_containing_track jsonb DEFAULT jsonb_build_object() NOT NULL,
+    allowed_api_keys text[],
+    bpm double precision,
+    musical_key character varying,
+    audio_analysis_error_count integer DEFAULT 0 NOT NULL,
+    is_custom_bpm boolean DEFAULT false,
+    is_custom_musical_key boolean DEFAULT false,
+    comments_disabled boolean DEFAULT false,
+    pinned_comment_id integer,
+    cover_original_song_title character varying,
+    cover_original_artist character varying,
+    is_owned_by_user boolean DEFAULT false NOT NULL,
+    no_ai_use boolean DEFAULT false,
+    parental_warning public.parental_warning_type,
+    territory_codes text[],
+    access_authorities text[],
+    CONSTRAINT check_territory_codes CHECK (public.validate_territory_codes(territory_codes))
+);
+
+
+--
+-- Name: COLUMN tracks.cover_original_song_title; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.tracks.cover_original_song_title IS 'Title of the original song if this track is a cover';
+
+
+--
+-- Name: COLUMN tracks.cover_original_artist; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.tracks.cover_original_artist IS 'Artist of the original song if this track is a cover';
+
+
+--
+-- Name: COLUMN tracks.is_owned_by_user; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.tracks.is_owned_by_user IS 'Indicates whether the track is owned by the user for publishing payouts';
+
+
+--
+-- Name: track_should_notify(public.tracks, record, character varying); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.track_should_notify(old_track public.tracks, new_track record, tg_op character varying) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+begin
+  if tg_op = 'UPDATE' and old_track.track_id is not null then
+    return not track_is_public(old_track) and track_is_public(new_track);
+  else
+    return tg_op = 'INSERT'
+      and track_is_public(new_track)
+    ;
+  end if;
+end
+$$;
+
+
+--
+-- Name: update_sol_user_balance_mint(integer, character varying); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.update_sol_user_balance_mint(p_user_id integer, p_mint character varying) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO sol_user_balances
+        (user_id, mint, balance, updated_at, created_at)
+    SELECT
+        p_user_id,
+        p_mint,
+        SUM(balance),
+        NOW(),
+        NOW()
+    FROM (
+        SELECT 
+            p_user_id AS user_id, 
+            COALESCE(balance, 0) AS balance
+        FROM associated_wallets 
+        JOIN sol_token_account_balances AS associated_wallet_balances
+            ON associated_wallet_balances.owner = associated_wallets.wallet
+            AND associated_wallet_balances.mint = p_mint
+        WHERE associated_wallets.user_id = p_user_id
+            AND associated_wallets.chain = 'sol'
+            AND associated_wallets.is_delete = FALSE
+
+        UNION ALL
+
+        SELECT 
+            p_user_id AS user_id, 
+            COALESCE(balance, 0) AS balance
+        FROM users
+        JOIN sol_claimable_accounts
+            ON sol_claimable_accounts.ethereum_address = users.wallet
+            AND sol_claimable_accounts.mint = p_mint
+        JOIN sol_token_account_balances
+            ON sol_token_account_balances.account = sol_claimable_accounts.account
+        WHERE users.user_id = p_user_id
+    ) AS balances
+    GROUP BY user_id
+    ON CONFLICT (user_id, mint)
+    DO UPDATE SET
+        balance = EXCLUDED.balance,
+        updated_at = NOW();
+END;
+$$;
+
+
+--
+-- Name: user_mint_balance_at(integer, text, timestamp with time zone); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.user_mint_balance_at(p_user_id integer, p_mint text, p_cutoff timestamp with time zone) RETURNS bigint
+    LANGUAGE sql STABLE PARALLEL SAFE
+    AS $$
+WITH owners AS (
+  SELECT aw.wallet AS owner_address
+  FROM associated_wallets aw
+  WHERE aw.user_id = p_user_id
+    AND aw.chain = 'sol'
+    AND aw.is_delete = FALSE
+),
+accounts AS (
+  SELECT sca.account
+  FROM users u
+  JOIN sol_claimable_accounts sca
+    ON sca.ethereum_address = u.wallet
+  WHERE u.user_id = p_user_id
+),
+latest AS (
+  SELECT DISTINCT ON (s.mint, s.account) s.balance
+  FROM (
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.account IN (SELECT account FROM accounts)
+
+    UNION ALL
+
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.owner IN (SELECT owner_address FROM owners)
+  ) AS s
+  ORDER BY s.mint, s.account, s.block_timestamp DESC, s.slot DESC
+)
+SELECT COALESCE(SUM(balance), 0)::bigint
+FROM latest;
+$$;
+
+
+--
+-- Name: audius_ts_dict; Type: TEXT SEARCH DICTIONARY; Schema: public; Owner: -
+--
+
+CREATE TEXT SEARCH DICTIONARY public.audius_ts_dict (
+    TEMPLATE = pg_catalog.simple );
+
+
+--
+-- Name: audius_ts_config; Type: TEXT SEARCH CONFIGURATION; Schema: public; Owner: -
+--
+
+CREATE TEXT SEARCH CONFIGURATION public.audius_ts_config (
+    PARSER = pg_catalog."default" );
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR asciiword WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR word WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR numword WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR email WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR url WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR host WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR sfloat WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR version WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword_numpart WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword_part WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword_asciipart WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR numhword WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR asciihword WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR url_path WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR file WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR "float" WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR "int" WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR uint WITH simple;
+
+
+--
+-- Name: SequelizeMeta; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."SequelizeMeta" (
+    name character varying(255) NOT NULL
+);
+
+
+--
+-- Name: aggregate_daily_app_name_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_daily_app_name_metrics (
+    id integer NOT NULL,
+    application_name character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: aggregate_daily_app_name_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.aggregate_daily_app_name_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: aggregate_daily_app_name_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.aggregate_daily_app_name_metrics_id_seq OWNED BY public.aggregate_daily_app_name_metrics.id;
+
+
+--
+-- Name: aggregate_daily_total_users_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_daily_total_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    personal_count integer
+);
+
+
+--
+-- Name: aggregate_daily_total_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.aggregate_daily_total_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: aggregate_daily_total_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.aggregate_daily_total_users_metrics_id_seq OWNED BY public.aggregate_daily_total_users_metrics.id;
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_daily_unique_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    summed_count integer,
+    personal_count integer
+);
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.aggregate_daily_unique_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.aggregate_daily_unique_users_metrics_id_seq OWNED BY public.aggregate_daily_unique_users_metrics.id;
+
+
+--
+-- Name: plays; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.plays (
+    id integer NOT NULL,
+    user_id integer,
+    source character varying,
+    play_item_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    slot integer,
+    signature character varying,
+    city character varying,
+    region character varying,
+    country character varying
+);
+
+
+--
+-- Name: aggregate_interval_plays; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.aggregate_interval_plays AS
+ SELECT tracks.track_id,
+    tracks.genre,
+    tracks.created_at,
+    COALESCE(week_listen_counts.count, (0)::bigint) AS week_listen_counts,
+    COALESCE(month_listen_counts.count, (0)::bigint) AS month_listen_counts
+   FROM ((public.tracks
+     LEFT JOIN ( SELECT plays.play_item_id,
+            count(plays.id) AS count
+           FROM public.plays
+          WHERE (plays.created_at > (now() - '7 days'::interval))
+          GROUP BY plays.play_item_id) week_listen_counts ON ((week_listen_counts.play_item_id = tracks.track_id)))
+     LEFT JOIN ( SELECT plays.play_item_id,
+            count(plays.id) AS count
+           FROM public.plays
+          WHERE (plays.created_at > (now() - '1 mon'::interval))
+          GROUP BY plays.play_item_id) month_listen_counts ON ((month_listen_counts.play_item_id = tracks.track_id)))
+  WHERE ((tracks.is_current IS TRUE) AND (tracks.is_delete IS FALSE) AND (tracks.is_unlisted IS FALSE) AND (tracks.stem_of IS NULL))
+  WITH NO DATA;
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_monthly_app_name_metrics (
+    id integer NOT NULL,
+    application_name character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.aggregate_monthly_app_name_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.aggregate_monthly_app_name_metrics_id_seq OWNED BY public.aggregate_monthly_app_name_metrics.id;
+
+
+--
+-- Name: aggregate_monthly_plays; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_monthly_plays (
+    play_item_id integer NOT NULL,
+    "timestamp" date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    count integer NOT NULL,
+    country text DEFAULT ''::text NOT NULL
+);
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_monthly_total_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    personal_count integer
+);
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.aggregate_monthly_total_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.aggregate_monthly_total_users_metrics_id_seq OWNED BY public.aggregate_monthly_total_users_metrics.id;
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_monthly_unique_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    summed_count integer,
+    personal_count integer
+);
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.aggregate_monthly_unique_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.aggregate_monthly_unique_users_metrics_id_seq OWNED BY public.aggregate_monthly_unique_users_metrics.id;
+
+
+--
+-- Name: aggregate_playlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_playlist (
+    playlist_id integer NOT NULL,
+    is_album boolean,
+    repost_count integer DEFAULT 0,
+    save_count integer DEFAULT 0,
+    share_count integer DEFAULT 0
+);
+
+
+--
+-- Name: aggregate_plays; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_plays (
+    play_item_id integer NOT NULL,
+    count bigint
+);
+
+
+--
+-- Name: aggregate_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_track (
+    track_id integer NOT NULL,
+    repost_count integer DEFAULT 0 NOT NULL,
+    save_count integer DEFAULT 0 NOT NULL,
+    comment_count integer DEFAULT 0,
+    share_count integer DEFAULT 0
+);
+
+
+--
+-- Name: aggregate_user; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_user (
+    user_id integer NOT NULL,
+    track_count bigint DEFAULT 0,
+    playlist_count bigint DEFAULT 0,
+    album_count bigint DEFAULT 0,
+    follower_count bigint DEFAULT 0,
+    following_count bigint DEFAULT 0,
+    repost_count bigint DEFAULT 0,
+    track_save_count bigint DEFAULT 0,
+    supporter_count integer DEFAULT 0 NOT NULL,
+    supporting_count integer DEFAULT 0 NOT NULL,
+    dominant_genre character varying,
+    dominant_genre_count integer DEFAULT 0,
+    score integer DEFAULT 0,
+    total_track_count integer DEFAULT 0,
+    track_share_count integer DEFAULT 0
+);
+
+
+--
+-- Name: aggregate_user_tips; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.aggregate_user_tips (
+    sender_user_id integer NOT NULL,
+    receiver_user_id integer NOT NULL,
+    amount bigint NOT NULL
+);
+
+
+--
+-- Name: album_price_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.album_price_history (
+    playlist_id integer NOT NULL,
+    splits jsonb NOT NULL,
+    total_price_cents bigint NOT NULL,
+    blocknumber integer NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: api_access_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_access_keys (
+    api_key character varying(255) NOT NULL,
+    api_access_key character varying(255) NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    is_active boolean DEFAULT true NOT NULL
+);
+
+
+--
+-- Name: api_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_keys (
+    api_key character varying(255) NOT NULL,
+    api_secret character varying(255),
+    rps integer DEFAULT 10 NOT NULL,
+    rpm integer DEFAULT 500000 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: api_metrics_apps; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_metrics_apps (
+    date date NOT NULL,
+    api_key character varying(255) NOT NULL,
+    app_name character varying(255) NOT NULL,
+    request_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: api_metrics_apps_unique; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_metrics_apps_unique (
+    date date NOT NULL,
+    app_name character varying(255) NOT NULL,
+    hll_sketch bytea,
+    total_count bigint DEFAULT 0 NOT NULL,
+    unique_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: TABLE api_metrics_apps_unique; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.api_metrics_apps_unique IS 'Stores HLL sketches for tracking unique users per application. app_name stores the identifier (api_key if present, otherwise app_name from request).';
+
+
+--
+-- Name: api_metrics_counts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_metrics_counts (
+    date date NOT NULL,
+    hll_sketch bytea,
+    total_count bigint DEFAULT 0 NOT NULL,
+    unique_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: api_metrics_routes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_metrics_routes (
+    date date NOT NULL,
+    route_pattern character varying(512) NOT NULL,
+    method character varying(10) NOT NULL,
+    request_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: app_name_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.app_name_metrics (
+    application_name character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    id bigint NOT NULL,
+    ip character varying
+);
+
+
+--
+-- Name: app_name_metrics_all_time; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.app_name_metrics_all_time AS
+ SELECT application_name AS name,
+    sum(count) AS count
+   FROM public.app_name_metrics
+  GROUP BY application_name
+  WITH NO DATA;
+
+
+--
+-- Name: app_name_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.app_name_metrics ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.app_name_metrics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: app_name_metrics_trailing_month; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_month AS
+ SELECT application_name AS name,
+    sum(count) AS count
+   FROM public.app_name_metrics
+  WHERE ("timestamp" > (now() - '1 mon'::interval))
+  GROUP BY application_name
+  WITH NO DATA;
+
+
+--
+-- Name: app_name_metrics_trailing_week; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_week AS
+ SELECT application_name AS name,
+    sum(count) AS count
+   FROM public.app_name_metrics
+  WHERE ("timestamp" > (now() - '7 days'::interval))
+  GROUP BY application_name
+  WITH NO DATA;
+
+
+--
+-- Name: artist_coin_pools; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.artist_coin_pools (
+    address text NOT NULL,
+    base_mint text NOT NULL,
+    quote_mint text,
+    token_decimals integer,
+    base_reserve numeric,
+    quote_reserve numeric,
+    migration_base_threshold numeric,
+    migration_quote_threshold numeric,
+    protocol_quote_fee numeric,
+    partner_quote_fee numeric,
+    creator_base_fee numeric,
+    creator_quote_fee numeric,
+    price double precision,
+    price_usd double precision,
+    curve_progress double precision,
+    is_migrated boolean,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    total_trading_quote_fee numeric,
+    creator_wallet_address text
+);
+
+
+--
+-- Name: artist_coin_stats; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.artist_coin_stats (
+    mint text NOT NULL,
+    market_cap double precision,
+    fdv double precision,
+    liquidity double precision,
+    last_trade_unix_time bigint,
+    last_trade_human_time text,
+    price double precision,
+    history_24h_price double precision,
+    price_change_24h_percent double precision,
+    unique_wallet_24h integer,
+    unique_wallet_history_24h integer,
+    unique_wallet_24h_change_percent double precision,
+    total_supply double precision,
+    circulating_supply double precision,
+    holder integer,
+    trade_24h integer,
+    trade_history_24h integer,
+    trade_24h_change_percent double precision,
+    sell_24h integer,
+    sell_history_24h integer,
+    sell_24h_change_percent double precision,
+    buy_24h integer,
+    buy_history_24h integer,
+    buy_24h_change_percent double precision,
+    v_24h double precision,
+    v_24h_usd double precision,
+    v_history_24h double precision,
+    v_history_24h_usd double precision,
+    v_24h_change_percent double precision,
+    v_buy_24h double precision,
+    v_buy_24h_usd double precision,
+    v_buy_history_24h double precision,
+    v_buy_history_24h_usd double precision,
+    v_buy_24h_change_percent double precision,
+    v_sell_24h double precision,
+    v_sell_24h_usd double precision,
+    v_sell_history_24h double precision,
+    v_sell_history_24h_usd double precision,
+    v_sell_24h_change_percent double precision,
+    number_markets integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    total_volume double precision,
+    total_volume_usd double precision,
+    volume_buy double precision,
+    volume_buy_usd double precision,
+    volume_sell double precision,
+    volume_sell_usd double precision,
+    buy integer,
+    sell integer,
+    total_trade integer
+);
+
+
+--
+-- Name: artist_coins; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.artist_coins (
+    mint character varying NOT NULL,
+    ticker character varying NOT NULL,
+    user_id integer NOT NULL,
+    decimals integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    logo_uri text,
+    banner_image_url text,
+    description text,
+    name text DEFAULT ''::text NOT NULL,
+    has_discord boolean DEFAULT false NOT NULL,
+    updated_at timestamp without time zone DEFAULT now(),
+    twitter text,
+    instagram text,
+    tiktok text,
+    link_1 text,
+    link_2 text,
+    link_3 text,
+    link_4 text,
+    damm_v2_pool text
+);
+
+
+--
+-- Name: TABLE artist_coins; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.artist_coins IS 'Stores the token mints for artist coins that the indexer is tracking and their tickers.';
+
+
+--
+-- Name: COLUMN artist_coins.damm_v2_pool; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.artist_coins.damm_v2_pool IS 'The canonical DAMM V2 pool address for this artist coin, if any. Used in solana indexer.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pools; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pools (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    token_a_mint text NOT NULL,
+    token_b_mint text NOT NULL,
+    token_a_vault text NOT NULL,
+    token_b_vault text NOT NULL,
+    whitelisted_vault text NOT NULL,
+    partner text NOT NULL,
+    liquidity numeric NOT NULL,
+    protocol_a_fee bigint NOT NULL,
+    protocol_b_fee bigint NOT NULL,
+    partner_a_fee bigint NOT NULL,
+    partner_b_fee bigint NOT NULL,
+    sqrt_min_price numeric NOT NULL,
+    sqrt_max_price numeric NOT NULL,
+    sqrt_price numeric NOT NULL,
+    activation_point bigint NOT NULL,
+    activation_type smallint NOT NULL,
+    pool_status smallint NOT NULL,
+    token_a_flag smallint NOT NULL,
+    token_b_flag smallint NOT NULL,
+    collect_fee_mode smallint NOT NULL,
+    pool_type smallint NOT NULL,
+    version smallint NOT NULL,
+    fee_a_per_liquidity numeric NOT NULL,
+    fee_b_per_liquidity numeric NOT NULL,
+    permanent_lock_liquidity numeric NOT NULL,
+    creator text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pools; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pools IS 'Tracks DAMM V2 pool state. Join with sol_meteora_damm_v2_pool_metrics, sol_meteora_damm_v2_pool_fees, sol_meteora_damm_v2_pool_base_fees, and sol_meteora_damm_v2_pool_dynamic_fees for full pool state.';
+
+
+--
+-- Name: sol_meteora_dbc_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_configs (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    quote_mint text NOT NULL,
+    fee_claimer text NOT NULL,
+    leftover_receiver text NOT NULL,
+    collect_fee_mode smallint NOT NULL,
+    migration_option smallint NOT NULL,
+    activation_type smallint,
+    token_decimal smallint,
+    version smallint,
+    token_type smallint,
+    quote_token_flag smallint,
+    partner_locked_lp_percentage smallint,
+    partner_lp_percentage smallint,
+    creator_locked_lp_percentage smallint,
+    creator_lp_percentage smallint,
+    migration_fee_option smallint,
+    fixed_token_supply_flag smallint,
+    creator_trading_fee_percentage smallint,
+    token_update_authority smallint,
+    migration_fee_percentage smallint,
+    creator_migration_fee_percentage smallint,
+    swap_base_amount bigint,
+    migration_quote_threshold bigint,
+    migration_base_threshold bigint,
+    migration_sqrt_price numeric,
+    pre_migration_token_supply bigint,
+    post_migration_token_supply bigint,
+    migrated_collect_fee_mode smallint,
+    migrated_dynamic_fee smallint,
+    migrated_pool_fee_bps smallint,
+    sqrt_start_price numeric,
+    curve jsonb,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: sol_meteora_dbc_pools; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_pools (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    config text NOT NULL,
+    creator text NOT NULL,
+    base_mint text NOT NULL,
+    base_vault text NOT NULL,
+    quote_vault text NOT NULL,
+    base_reserve bigint NOT NULL,
+    quote_reserve bigint NOT NULL,
+    protocol_base_fee bigint NOT NULL,
+    protocol_quote_fee bigint NOT NULL,
+    partner_base_fee bigint NOT NULL,
+    partner_quote_fee bigint NOT NULL,
+    sqrt_price numeric NOT NULL,
+    activation_point bigint NOT NULL,
+    pool_type smallint NOT NULL,
+    is_migrated smallint NOT NULL,
+    is_partner_withdraw_surplus smallint NOT NULL,
+    is_protocol_withdraw_surplus smallint NOT NULL,
+    migration_progress smallint NOT NULL,
+    is_withdraw_leftover smallint NOT NULL,
+    is_creator_withdraw_surplus smallint NOT NULL,
+    migration_fee_withdraw_status smallint NOT NULL,
+    finish_curve_timestamp bigint NOT NULL,
+    creator_base_fee bigint NOT NULL,
+    creator_quote_fee bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: artist_coin_prices; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.artist_coin_prices AS
+ WITH dbc AS (
+         SELECT artist_coins_1.mint,
+            ((public.price_from_sqrt_price(dbc_pool.sqrt_price, artist_coins_1.decimals))::double precision * dbc_quote_token.price) AS price
+           FROM (((public.artist_coins artist_coins_1
+             JOIN public.sol_meteora_dbc_pools dbc_pool ON (((dbc_pool.base_mint = (artist_coins_1.mint)::text) AND (dbc_pool.is_migrated = 0))))
+             JOIN public.sol_meteora_dbc_configs dbc_config ON ((dbc_config.account = dbc_pool.config)))
+             JOIN public.artist_coin_stats dbc_quote_token ON ((dbc_quote_token.mint = dbc_config.quote_mint)))
+          WHERE (dbc_pool.is_migrated = 0)
+        ), damm_v2 AS (
+         SELECT artist_coins_1.mint,
+            ((public.price_from_sqrt_price(damm_v2_pool.sqrt_price, artist_coins_1.decimals))::double precision * damm_v2_quote_token.price) AS price
+           FROM ((public.artist_coins artist_coins_1
+             JOIN public.sol_meteora_damm_v2_pools damm_v2_pool ON ((damm_v2_pool.token_a_mint = (artist_coins_1.mint)::text)))
+             JOIN public.artist_coin_stats damm_v2_quote_token ON ((damm_v2_quote_token.mint = damm_v2_pool.token_b_mint)))
+        )
+ SELECT artist_coins.mint,
+    damm_v2.price AS damm_v2_price,
+    dbc.price AS dbc_price,
+    pools.price_usd AS pools_price_usd,
+    stats.price AS stats_price,
+    COALESCE(damm_v2.price, dbc.price, pools.price_usd, stats.price) AS price
+   FROM ((((public.artist_coins
+     LEFT JOIN dbc ON (((artist_coins.mint)::text = (dbc.mint)::text)))
+     LEFT JOIN damm_v2 ON (((artist_coins.mint)::text = (damm_v2.mint)::text)))
+     LEFT JOIN public.artist_coin_pools pools ON ((pools.base_mint = (artist_coins.mint)::text)))
+     LEFT JOIN public.artist_coin_stats stats ON ((stats.mint = (artist_coins.mint)::text)));
+
+
+--
+-- Name: VIEW artist_coin_prices; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON VIEW public.artist_coin_prices IS 'View that provides artist coin prices using DAMM V2 pool if available, DBC pools if not and still applicable, artist_coin_pools.price_usd as fallback, and artist_coin_stats.price as final fallback (primarily for AUDIO and other tokens without pools). Makes use of the price of the quote token (AUDIO) from Birdeye if using a pool.';
+
+
+--
+-- Name: associated_wallets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.associated_wallets (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    wallet character varying NOT NULL,
+    blockhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    chain public.wallet_chain NOT NULL
+);
+
+
+--
+-- Name: associated_wallets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.associated_wallets_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: associated_wallets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.associated_wallets_id_seq OWNED BY public.associated_wallets.id;
+
+
+--
+-- Name: audio_transactions_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.audio_transactions_history (
+    user_bank character varying NOT NULL,
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    transaction_type character varying NOT NULL,
+    method character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    transaction_created_at timestamp without time zone NOT NULL,
+    change numeric NOT NULL,
+    balance numeric NOT NULL,
+    tx_metadata character varying
+);
+
+
+--
+-- Name: audius_data_txs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.audius_data_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL
+);
+
+
+--
+-- Name: blocks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.blocks (
+    blockhash character varying NOT NULL,
+    parenthash character varying,
+    is_current boolean,
+    number integer
+);
+
+
+--
+-- Name: challenge_disbursements; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.challenge_disbursements (
+    challenge_id character varying NOT NULL,
+    user_id integer NOT NULL,
+    specifier character varying NOT NULL,
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    amount character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: challenge_listen_streak; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.challenge_listen_streak (
+    user_id integer NOT NULL,
+    last_listen_date timestamp without time zone,
+    listen_streak integer NOT NULL
+);
+
+
+--
+-- Name: challenge_listen_streak_user_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.challenge_listen_streak_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: challenge_listen_streak_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.challenge_listen_streak_user_id_seq OWNED BY public.challenge_listen_streak.user_id;
+
+
+--
+-- Name: challenge_profile_completion; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.challenge_profile_completion (
+    user_id integer NOT NULL,
+    profile_description boolean NOT NULL,
+    profile_name boolean NOT NULL,
+    profile_picture boolean NOT NULL,
+    profile_cover_photo boolean NOT NULL,
+    follows boolean NOT NULL,
+    favorites boolean NOT NULL,
+    reposts boolean NOT NULL
+);
+
+
+--
+-- Name: challenge_profile_completion_user_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.challenge_profile_completion_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: challenge_profile_completion_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.challenge_profile_completion_user_id_seq OWNED BY public.challenge_profile_completion.user_id;
+
+
+--
+-- Name: challenges; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.challenges (
+    id character varying NOT NULL,
+    type public.challengetype NOT NULL,
+    amount character varying NOT NULL,
+    active boolean NOT NULL,
+    step_count integer,
+    starting_block integer,
+    weekly_pool integer,
+    cooldown_days integer
+);
+
+
+--
+-- Name: chat; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat (
+    chat_id text NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    last_message_at timestamp without time zone NOT NULL,
+    last_message text,
+    last_message_is_plaintext boolean DEFAULT false
+);
+
+
+--
+-- Name: chat_ban; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_ban (
+    user_id integer NOT NULL,
+    is_banned boolean NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: chat_blast; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_blast (
+    blast_id text NOT NULL,
+    from_user_id integer NOT NULL,
+    audience text NOT NULL,
+    audience_content_id integer,
+    plaintext text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    audience_content_type text
+);
+
+
+--
+-- Name: chat_blocked_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_blocked_users (
+    blocker_user_id integer NOT NULL,
+    blockee_user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: chat_member; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_member (
+    chat_id text NOT NULL,
+    user_id integer NOT NULL,
+    cleared_history_at timestamp without time zone,
+    invited_by_user_id integer NOT NULL,
+    invite_code text NOT NULL,
+    last_active_at timestamp without time zone,
+    unread_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    is_hidden boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: chat_message; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_message (
+    message_id text NOT NULL,
+    chat_id text NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    ciphertext text,
+    blast_id text
+);
+
+
+--
+-- Name: chat_message_reactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_message_reactions (
+    user_id integer NOT NULL,
+    message_id text NOT NULL,
+    reaction text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: chat_permissions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chat_permissions (
+    user_id integer NOT NULL,
+    permits text DEFAULT 'all'::text NOT NULL,
+    updated_at timestamp without time zone DEFAULT to_timestamp((0)::double precision) NOT NULL,
+    allowed boolean DEFAULT true NOT NULL
+);
+
+
+--
+-- Name: cid_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.cid_data (
+    cid character varying NOT NULL,
+    type character varying,
+    data jsonb
+);
+
+
+--
+-- Name: claimed_prizes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.claimed_prizes (
+    id integer NOT NULL,
+    wallet character varying NOT NULL,
+    signature character varying NOT NULL,
+    mint character varying NOT NULL,
+    amount bigint NOT NULL,
+    prize_id character varying NOT NULL,
+    prize_name character varying NOT NULL,
+    prize_type character varying,
+    action_data jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE claimed_prizes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.claimed_prizes IS 'Stores claimed prizes where users pay tokens to claim and win prizes.';
+
+
+--
+-- Name: claimed_prizes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.claimed_prizes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: claimed_prizes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.claimed_prizes_id_seq OWNED BY public.claimed_prizes.id;
+
+
+--
+-- Name: collectibles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.collectibles (
+    user_id integer NOT NULL,
+    data jsonb NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: TABLE collectibles; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.collectibles IS 'Stores collectibles data for users';
+
+
+--
+-- Name: COLUMN collectibles.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.collectibles.user_id IS 'User ID of the person who owns the collectibles';
+
+
+--
+-- Name: COLUMN collectibles.data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.collectibles.data IS 'Data about the collectibles';
+
+
+--
+-- Name: COLUMN collectibles.blockhash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.collectibles.blockhash IS 'Blockhash of the most recent block that changed the collectibles data';
+
+
+--
+-- Name: COLUMN collectibles.blocknumber; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.collectibles.blocknumber IS 'Block number of the most recent block that changed the collectibles data';
+
+
+--
+-- Name: comment_mentions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comment_mentions (
+    comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: comment_notification_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comment_notification_settings (
+    user_id integer NOT NULL,
+    entity_id integer NOT NULL,
+    entity_type text NOT NULL,
+    is_muted boolean DEFAULT false,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: comment_reactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comment_reactions (
+    comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: comment_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comment_reports (
+    comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: comment_threads; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comment_threads (
+    comment_id integer NOT NULL,
+    parent_comment_id integer NOT NULL
+);
+
+
+--
+-- Name: comments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comments (
+    comment_id integer NOT NULL,
+    text text NOT NULL,
+    user_id integer NOT NULL,
+    entity_id integer NOT NULL,
+    entity_type text NOT NULL,
+    track_timestamp_s bigint,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    is_visible boolean DEFAULT true,
+    is_edited boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: core_indexed_blocks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.core_indexed_blocks (
+    blockhash character varying NOT NULL,
+    parenthash character varying,
+    chain_id text NOT NULL,
+    height integer NOT NULL,
+    plays_slot integer DEFAULT 0,
+    em_block integer
+);
+
+
+--
+-- Name: countries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.countries (
+    iso character(2) NOT NULL,
+    name character varying(80) NOT NULL,
+    nicename character varying(80) NOT NULL,
+    iso3 character(3) DEFAULT NULL::bpchar,
+    numcode smallint,
+    phonecode integer NOT NULL
+);
+
+
+--
+-- Name: dashboard_wallet_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.dashboard_wallet_users (
+    wallet character varying NOT NULL,
+    user_id integer NOT NULL,
+    is_delete boolean DEFAULT false NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    txhash character varying NOT NULL
+);
+
+
+--
+-- Name: delist_status_cursor; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.delist_status_cursor (
+    host text NOT NULL,
+    entity public.delist_entity NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: developer_apps; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.developer_apps (
+    address character varying NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer,
+    name character varying NOT NULL,
+    is_personal_access boolean DEFAULT false NOT NULL,
+    is_delete boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying NOT NULL,
+    is_current boolean NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    description character varying(255),
+    image_url character varying
+);
+
+
+--
+-- Name: email_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_access (
+    id integer NOT NULL,
+    email_owner_user_id integer NOT NULL,
+    receiving_user_id integer NOT NULL,
+    grantor_user_id integer NOT NULL,
+    encrypted_key text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    is_initial boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: TABLE email_access; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.email_access IS 'Tracks who has access to encrypted emails';
+
+
+--
+-- Name: COLUMN email_access.email_owner_user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.email_access.email_owner_user_id IS 'The user ID of the email owner';
+
+
+--
+-- Name: COLUMN email_access.receiving_user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.email_access.receiving_user_id IS 'The user ID of the person granted access';
+
+
+--
+-- Name: COLUMN email_access.grantor_user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.email_access.grantor_user_id IS 'The user ID of the person who granted access';
+
+
+--
+-- Name: COLUMN email_access.encrypted_key; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.email_access.encrypted_key IS 'The symmetric key (SK) encrypted for the receiving user';
+
+
+--
+-- Name: email_access_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_access_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_access_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_access_id_seq OWNED BY public.email_access.id;
+
+
+--
+-- Name: encrypted_emails; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.encrypted_emails (
+    id integer NOT NULL,
+    email_owner_user_id integer NOT NULL,
+    encrypted_email text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: TABLE encrypted_emails; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.encrypted_emails IS 'Stores encrypted email addresses';
+
+
+--
+-- Name: COLUMN encrypted_emails.email_owner_user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.encrypted_emails.email_owner_user_id IS 'The user ID of the email owner';
+
+
+--
+-- Name: COLUMN encrypted_emails.encrypted_email; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.encrypted_emails.encrypted_email IS 'The encrypted email address (base64 encoded)';
+
+
+--
+-- Name: encrypted_emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.encrypted_emails_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: encrypted_emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.encrypted_emails_id_seq OWNED BY public.encrypted_emails.id;
+
+
+--
+-- Name: eth_blocks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.eth_blocks (
+    last_scanned_block integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: eth_blocks_last_scanned_block_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.eth_blocks_last_scanned_block_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: eth_blocks_last_scanned_block_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.eth_blocks_last_scanned_block_seq OWNED BY public.eth_blocks.last_scanned_block;
+
+
+--
+-- Name: events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events (
+    event_id integer NOT NULL,
+    event_type public.event_type NOT NULL,
+    user_id integer NOT NULL,
+    entity_type public.event_entity_type,
+    entity_id integer,
+    end_date timestamp without time zone,
+    is_deleted boolean DEFAULT false,
+    event_data jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: follows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.follows (
+    blockhash character varying,
+    blocknumber integer,
+    follower_user_id integer NOT NULL,
+    followee_user_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer
+);
+
+
+--
+-- Name: grants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.grants (
+    blockhash character varying,
+    blocknumber integer,
+    grantee_address character varying NOT NULL,
+    user_id integer NOT NULL,
+    is_revoked boolean DEFAULT false NOT NULL,
+    is_current boolean NOT NULL,
+    is_approved boolean,
+    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying NOT NULL
+);
+
+
+--
+-- Name: hourly_play_counts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.hourly_play_counts (
+    hourly_timestamp timestamp without time zone NOT NULL,
+    play_count integer NOT NULL
+);
+
+
+--
+-- Name: indexing_checkpoints; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.indexing_checkpoints (
+    tablename character varying NOT NULL,
+    last_checkpoint integer NOT NULL,
+    signature character varying
+);
+
+
+--
+-- Name: milestones; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.milestones (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    threshold integer NOT NULL,
+    blocknumber integer,
+    slot integer,
+    "timestamp" timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: muted_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.muted_users (
+    muted_user_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: notification; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notification (
+    id integer NOT NULL,
+    specifier character varying NOT NULL,
+    group_id character varying NOT NULL,
+    type character varying NOT NULL,
+    slot integer,
+    blocknumber integer,
+    "timestamp" timestamp without time zone NOT NULL,
+    data jsonb,
+    user_ids integer[],
+    type_v2 character varying
+);
+
+
+--
+-- Name: notification_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.notification_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: notification_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.notification_id_seq OWNED BY public.notification.id;
+
+
+--
+-- Name: notification_seen; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notification_seen (
+    user_id integer NOT NULL,
+    seen_at timestamp without time zone NOT NULL,
+    blocknumber integer,
+    blockhash character varying,
+    txhash character varying
+);
+
+
+--
+-- Name: oauth_authorization_codes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_authorization_codes (
+    code character varying(255) NOT NULL,
+    client_id character varying(255) NOT NULL,
+    user_id integer NOT NULL,
+    redirect_uri text NOT NULL,
+    code_challenge character varying(255) NOT NULL,
+    code_challenge_method character varying(10) DEFAULT 'S256'::character varying NOT NULL,
+    scope character varying(50) NOT NULL,
+    expires_at timestamp with time zone DEFAULT (now() + '00:10:00'::interval) NOT NULL,
+    used boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: oauth_redirect_uris; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_redirect_uris (
+    id integer NOT NULL,
+    client_id character varying(255) NOT NULL,
+    redirect_uri text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: oauth_redirect_uris_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.oauth_redirect_uris_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: oauth_redirect_uris_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.oauth_redirect_uris_id_seq OWNED BY public.oauth_redirect_uris.id;
+
+
+--
+-- Name: oauth_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_tokens (
+    token character varying(255) NOT NULL,
+    token_type character varying(10) NOT NULL,
+    client_id character varying(255) NOT NULL,
+    user_id integer NOT NULL,
+    scope character varying(50) NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    is_revoked boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    refresh_token_id character varying(255),
+    family_id character varying(255) NOT NULL
+);
+
+
+--
+-- Name: payment_router_txs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.payment_router_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: playlist_routes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.playlist_routes (
+    slug character varying NOT NULL,
+    title_slug character varying NOT NULL,
+    collision_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    playlist_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    blockhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    txhash character varying NOT NULL
+);
+
+
+--
+-- Name: playlist_seen; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.playlist_seen (
+    user_id integer NOT NULL,
+    playlist_id integer NOT NULL,
+    seen_at timestamp without time zone NOT NULL,
+    is_current boolean NOT NULL,
+    blocknumber integer,
+    blockhash character varying,
+    txhash character varying
+);
+
+
+--
+-- Name: playlist_tracks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.playlist_tracks (
+    playlist_id integer NOT NULL,
+    track_id integer NOT NULL,
+    is_removed boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: playlist_trending_scores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.playlist_trending_scores (
+    playlist_id integer NOT NULL,
+    type character varying NOT NULL,
+    version character varying NOT NULL,
+    time_range character varying NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: playlists; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.playlists (
+    blockhash character varying,
+    blocknumber integer,
+    playlist_id integer NOT NULL,
+    playlist_owner_id integer NOT NULL,
+    is_album boolean NOT NULL,
+    is_private boolean NOT NULL,
+    playlist_name character varying,
+    playlist_contents jsonb NOT NULL,
+    playlist_image_multihash character varying,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    description character varying,
+    created_at timestamp without time zone NOT NULL,
+    upc character varying,
+    updated_at timestamp without time zone NOT NULL,
+    playlist_image_sizes_multihash character varying,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    last_added_to timestamp without time zone,
+    slot integer,
+    metadata_multihash character varying,
+    is_image_autogenerated boolean DEFAULT false NOT NULL,
+    is_stream_gated boolean DEFAULT false NOT NULL,
+    stream_conditions jsonb,
+    ddex_app character varying,
+    ddex_release_ids jsonb,
+    artists jsonb,
+    copyright_line jsonb,
+    producer_copyright_line jsonb,
+    parental_warning_type character varying,
+    is_scheduled_release boolean DEFAULT false NOT NULL,
+    release_date timestamp without time zone
+);
+
+
+--
+-- Name: plays_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.plays_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: plays_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.plays_id_seq OWNED BY public.plays.id;
+
+
+--
+-- Name: prizes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.prizes (
+    id integer NOT NULL,
+    prize_id character varying NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    weight integer DEFAULT 1 NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    metadata jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE prizes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.prizes IS 'Defines prizes available for claiming. Prizes are selected randomly based on weight.';
+
+
+--
+-- Name: prizes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.prizes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: prizes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.prizes_id_seq OWNED BY public.prizes.id;
+
+
+--
+-- Name: pubkeys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pubkeys (
+    wallet text NOT NULL,
+    pubkey text
+);
+
+
+--
+-- Name: reactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reactions (
+    id integer NOT NULL,
+    reaction_value integer NOT NULL,
+    sender_wallet character varying NOT NULL,
+    reaction_type character varying NOT NULL,
+    reacted_to character varying NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: reactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.reactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: reactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.reactions_id_seq OWNED BY public.reactions.id;
+
+
+--
+-- Name: related_artists; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.related_artists (
+    user_id integer NOT NULL,
+    related_artist_user_id integer NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: remixes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.remixes (
+    parent_track_id integer NOT NULL,
+    child_track_id integer NOT NULL
+);
+
+
+--
+-- Name: reported_comments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reported_comments (
+    reported_comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+--
+-- Name: reposts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reposts (
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer NOT NULL,
+    repost_item_id integer NOT NULL,
+    repost_type public.reposttype NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer,
+    is_repost_of_repost boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: revert_blocks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.revert_blocks (
+    blocknumber integer NOT NULL,
+    prev_records jsonb NOT NULL
+);
+
+
+--
+-- Name: reward_codes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reward_codes (
+    code text NOT NULL,
+    mint text NOT NULL,
+    reward_address text NOT NULL,
+    amount bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    remaining_uses integer DEFAULT 1 NOT NULL,
+    signature text
+);
+
+
+--
+-- Name: TABLE reward_codes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.reward_codes IS 'Stores reward codes for distributing coins';
+
+
+--
+-- Name: COLUMN reward_codes.code; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.reward_codes.code IS 'Unique code for redemption';
+
+
+--
+-- Name: COLUMN reward_codes.mint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.reward_codes.mint IS 'Coin mint address';
+
+
+--
+-- Name: COLUMN reward_codes.reward_address; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.reward_codes.reward_address IS 'Address of the reward instance onchain';
+
+
+--
+-- Name: COLUMN reward_codes.amount; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.reward_codes.amount IS 'Amount of coins to reward';
+
+
+--
+-- Name: COLUMN reward_codes.remaining_uses; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.reward_codes.remaining_uses IS 'Number of times the code can still be redeemed';
+
+
+--
+-- Name: COLUMN reward_codes.signature; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.reward_codes.signature IS 'Signature used to generate the reward code';
+
+
+--
+-- Name: reward_manager_txs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reward_manager_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: route_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.route_metrics (
+    route_path character varying NOT NULL,
+    version character varying NOT NULL,
+    query_string character varying DEFAULT ''::character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    id bigint NOT NULL,
+    ip character varying
+);
+
+
+--
+-- Name: route_metrics_all_time; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_all_time AS
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count
+   FROM public.route_metrics
+  WITH NO DATA;
+
+
+--
+-- Name: route_metrics_day_bucket; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_day_bucket AS
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count,
+    date_trunc('day'::text, "timestamp") AS "time"
+   FROM public.route_metrics
+  GROUP BY (date_trunc('day'::text, "timestamp"))
+  WITH NO DATA;
+
+
+--
+-- Name: route_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.route_metrics ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.route_metrics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: route_metrics_month_bucket; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_month_bucket AS
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count,
+    date_trunc('month'::text, "timestamp") AS "time"
+   FROM public.route_metrics
+  GROUP BY (date_trunc('month'::text, "timestamp"))
+  WITH NO DATA;
+
+
+--
+-- Name: route_metrics_trailing_month; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_trailing_month AS
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count
+   FROM public.route_metrics
+  WHERE ("timestamp" > (now() - '1 mon'::interval))
+  WITH NO DATA;
+
+
+--
+-- Name: route_metrics_trailing_week; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_trailing_week AS
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count
+   FROM public.route_metrics
+  WHERE ("timestamp" > (now() - '7 days'::interval))
+  WITH NO DATA;
+
+
+--
+-- Name: rpc_cursor; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rpc_cursor (
+    relayed_by text NOT NULL,
+    relayed_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: rpc_error; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rpc_error (
+    sig text NOT NULL,
+    rpc_log_json jsonb NOT NULL,
+    error_text text NOT NULL,
+    error_count integer DEFAULT 0 NOT NULL,
+    last_attempt timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: rpc_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rpc_log (
+    relayed_at timestamp without time zone NOT NULL,
+    from_wallet text NOT NULL,
+    rpc json NOT NULL,
+    sig text NOT NULL,
+    relayed_by text NOT NULL,
+    applied_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: rpclog; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rpclog (
+    cuid text NOT NULL,
+    wallet text,
+    method text,
+    params jsonb,
+    jetstream_seq integer
+);
+
+
+--
+-- Name: saves; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.saves (
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer NOT NULL,
+    save_item_id integer NOT NULL,
+    save_type public.savetype NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer,
+    is_save_of_repost boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying(255) NOT NULL
+);
+
+
+--
+-- Name: schema_version; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_version (
+    file_name text NOT NULL,
+    md5 text,
+    applied_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: shares; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shares (
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer NOT NULL,
+    share_item_id integer NOT NULL,
+    share_type public.sharetype NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer
+);
+
+
+--
+-- Name: skipped_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.skipped_transactions (
+    id integer NOT NULL,
+    blocknumber integer NOT NULL,
+    blockhash character varying NOT NULL,
+    txhash character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    level public.skippedtransactionlevel DEFAULT 'node'::public.skippedtransactionlevel
+);
+
+
+--
+-- Name: skipped_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.skipped_transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: skipped_transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.skipped_transactions_id_seq OWNED BY public.skipped_transactions.id;
+
+
+--
+-- Name: sol_claimable_account_transfers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_claimable_account_transfers (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    from_account character varying NOT NULL,
+    to_account character varying NOT NULL,
+    sender_eth_address character varying NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_claimable_account_transfers; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_claimable_account_transfers IS 'Stores claimable tokens program Transfer instructions for tracked mints.';
+
+
+--
+-- Name: sol_claimable_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_claimable_accounts (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    mint character varying NOT NULL,
+    ethereum_address character varying NOT NULL,
+    account character varying NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_claimable_accounts; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_claimable_accounts IS 'Stores claimable tokens program Create instructions for tracked mints.';
+
+
+--
+-- Name: sol_keypairs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_keypairs (
+    public_key character varying NOT NULL,
+    private_key bytea NOT NULL
+);
+
+
+--
+-- Name: sol_locker_vesting_escrows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_locker_vesting_escrows (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    recipient text NOT NULL,
+    token_mint text NOT NULL,
+    creator text NOT NULL,
+    base text NOT NULL,
+    escrow_bump smallint NOT NULL,
+    update_recipient_mode smallint NOT NULL,
+    cancel_mode smallint NOT NULL,
+    token_program_flag smallint NOT NULL,
+    cliff_time bigint NOT NULL,
+    frequency bigint NOT NULL,
+    cliff_unlock_amount bigint NOT NULL,
+    amount_per_period bigint NOT NULL,
+    number_of_period bigint NOT NULL,
+    total_claimed_amount bigint NOT NULL,
+    vesting_start_time bigint NOT NULL,
+    cancelled_at bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: sol_meteora_damm_v2_initialize_custom_pool_instructions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_initialize_custom_pool_instructions (
+    signature text NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    creator text,
+    position_nft_mint text,
+    position_nft_account text,
+    payer text,
+    pool_authority text,
+    pool text,
+    "position" text,
+    token_a_mint text,
+    token_b_mint text,
+    token_a_vault text,
+    token_b_vault text,
+    payer_token_a text,
+    payer_token_b text,
+    token_a_program text,
+    token_b_program text,
+    token_2022_program text,
+    system_program text,
+    event_authority text,
+    program text,
+    remaining_accounts jsonb DEFAULT '[]'::jsonb,
+    base_fee_cliff_fee_numerator bigint,
+    base_fee_first_factor integer,
+    base_fee_second_factor_max_limiter_duration integer,
+    base_fee_second_factor_max_fee_bps integer,
+    base_fee_third_factor bigint,
+    base_fee_mode smallint,
+    dynamic_fee_bin_step smallint,
+    dynamic_fee_bin_step_u128 numeric,
+    dynamic_fee_filter_period smallint,
+    dynamic_fee_decay_period smallint,
+    dynamic_fee_reduction_factor smallint,
+    dynamic_fee_max_volatility_accumulator integer,
+    dynamic_fee_variable_fee_control integer,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_initialize_custom_pool_instructions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_initialize_custom_pool_instructions IS 'Tracks InitializeCustomPool instructions for DAMM V2 pools.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_base_fees; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_base_fees (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    cliff_fee_numerator bigint NOT NULL,
+    fee_scheduler_mode smallint NOT NULL,
+    number_of_period smallint NOT NULL,
+    period_frequency bigint NOT NULL,
+    reduction_factor bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_base_fees; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_base_fees IS 'Tracks base fee configuration for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_dynamic_fees; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_dynamic_fees (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    initialized smallint NOT NULL,
+    max_volatility_accumulator integer NOT NULL,
+    variable_fee_control integer NOT NULL,
+    bin_step smallint NOT NULL,
+    filter_period smallint NOT NULL,
+    decay_period smallint NOT NULL,
+    reduction_factor smallint NOT NULL,
+    last_update_timestamp bigint NOT NULL,
+    bin_step_u128 numeric NOT NULL,
+    sqrt_price_reference numeric NOT NULL,
+    volatility_accumulator numeric NOT NULL,
+    volatility_reference numeric NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_dynamic_fees; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_dynamic_fees IS 'Tracks dynamic fee configuration for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_fees; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_fees (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    protocol_fee_percent smallint NOT NULL,
+    partner_fee_percent smallint NOT NULL,
+    referral_fee_percent smallint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_fees; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_fees IS 'Tracks fee configuration for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_metrics (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    total_lp_a_fee numeric NOT NULL,
+    total_lp_b_fee numeric NOT NULL,
+    total_protocol_a_fee numeric NOT NULL,
+    total_protocol_b_fee numeric NOT NULL,
+    total_partner_a_fee numeric NOT NULL,
+    total_partner_b_fee numeric NOT NULL,
+    total_position bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_metrics; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_metrics IS 'Tracks aggregated metrics for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_position_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_position_metrics (
+    "position" text NOT NULL,
+    slot bigint NOT NULL,
+    total_claimed_a_fee bigint NOT NULL,
+    total_claimed_b_fee bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_position_metrics; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_position_metrics IS 'Tracks aggregated metrics for DAMM V2 positions. A slice of the DAMM V2 position state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_positions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_positions (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    pool text NOT NULL,
+    nft_mint text NOT NULL,
+    fee_a_per_token_checkpoint bigint NOT NULL,
+    fee_b_per_token_checkpoint bigint NOT NULL,
+    fee_a_pending bigint NOT NULL,
+    fee_b_pending bigint NOT NULL,
+    unlocked_liquidity numeric NOT NULL,
+    vested_liquidity numeric NOT NULL,
+    permanent_locked_liquidity numeric NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_damm_v2_positions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_positions IS 'Tracks DAMM V2 positions representing a claim to the liquidity and associated fees in a DAMM V2 pool. Join with sol_meteora_damm_v2_position_metrics for full position state.';
+
+
+--
+-- Name: sol_meteora_dbc_config_fees; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_config_fees (
+    config text NOT NULL,
+    slot bigint NOT NULL,
+    base_fee_cliff_fee_numerator bigint,
+    base_fee_period_frequency bigint,
+    base_fee_reduction_factor bigint,
+    base_fee_number_of_period smallint,
+    base_fee_fee_scheduler_mode smallint,
+    dynamic_fee_initialized smallint,
+    dynamic_fee_max_volatility_accumulator integer,
+    dynamic_fee_variable_fee_control integer,
+    dynamic_fee_bin_step smallint,
+    dynamic_fee_filter_period smallint,
+    dynamic_fee_decay_period smallint,
+    dynamic_fee_reduction_factor smallint,
+    dynamic_fee_bin_step_u128 numeric,
+    protocol_fee_percent smallint,
+    referral_fee_percent smallint
+);
+
+
+--
+-- Name: sol_meteora_dbc_config_vestings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_config_vestings (
+    config text NOT NULL,
+    slot bigint NOT NULL,
+    amount_per_period bigint,
+    cliff_duration_from_migration_time bigint,
+    frequency bigint,
+    number_of_period bigint,
+    cliff_unlock_amount bigint
+);
+
+
+--
+-- Name: sol_meteora_dbc_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_migrations (
+    signature text NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    dbc_pool text NOT NULL,
+    migration_metadata text NOT NULL,
+    config text NOT NULL,
+    dbc_pool_authority text NOT NULL,
+    damm_v2_pool text NOT NULL,
+    first_position_nft_mint text NOT NULL,
+    first_position_nft_account text NOT NULL,
+    first_position text NOT NULL,
+    second_position_nft_mint text NOT NULL,
+    second_position_nft_account text NOT NULL,
+    second_position text NOT NULL,
+    damm_pool_authority text NOT NULL,
+    base_mint text NOT NULL,
+    quote_mint text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_meteora_dbc_migrations; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_meteora_dbc_migrations IS 'Tracks migrations from DBC pools to DAMM V2 pools.';
+
+
+--
+-- Name: sol_meteora_dbc_pool_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_pool_metrics (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    total_protocol_base_fee bigint NOT NULL,
+    total_protocol_quote_fee bigint NOT NULL,
+    total_trading_base_fee bigint NOT NULL,
+    total_trading_quote_fee bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: sol_meteora_dbc_pool_volatility_trackers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_meteora_dbc_pool_volatility_trackers (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    last_update_timestamp bigint NOT NULL,
+    volatility_accumulator numeric NOT NULL,
+    volatility_reference numeric NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: sol_payments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_payments (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    route_index integer NOT NULL,
+    to_account character varying NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_payments; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_payments IS 'Stores payment router program Route instruction recipients and amounts for tracked mints.';
+
+
+--
+-- Name: sol_purchases; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_purchases (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    from_account character varying NOT NULL,
+    content_type character varying NOT NULL,
+    content_id integer NOT NULL,
+    buyer_user_id integer NOT NULL,
+    access_type character varying NOT NULL,
+    valid_after_blocknumber bigint NOT NULL,
+    is_valid boolean,
+    city character varying,
+    region character varying,
+    country character varying,
+    block_timestamp timestamp with time zone
+);
+
+
+--
+-- Name: TABLE sol_purchases; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_purchases IS 'Stores payment router program Route instructions that are paired with purchase information for tracked mints.';
+
+
+--
+-- Name: COLUMN sol_purchases.valid_after_blocknumber; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_purchases.valid_after_blocknumber IS 'Purchase transactions include the blocknumber that the content was most recently updated in order to ensure that the relevant pricing information has been indexed before evaluating whether the purchase is valid.';
+
+
+--
+-- Name: COLUMN sol_purchases.is_valid; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_purchases.is_valid IS 'A purchase is valid if it meets the pricing information set by the artist. If the pricing information is not available yet (as indicated by the valid_after_blocknumber), then is_valid will be NULL which indicates a "pending" state.';
+
+
+--
+-- Name: sol_retry_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_retry_queue (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    indexer text NOT NULL,
+    update_message jsonb NOT NULL,
+    error text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_retry_queue; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_retry_queue IS 'Queue for retrying failed indexer updates.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.indexer; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.indexer IS 'The name of the indexer that failed (e.g., token_indexer, damm_v2_indexer).';
+
+
+--
+-- Name: COLUMN sol_retry_queue.update_message; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.update_message IS 'The JSONB update data that failed to process.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.error; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.error IS 'The error message from the failure.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.created_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.created_at IS 'The timestamp when the retry entry was created.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.updated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.updated_at IS 'The timestamp when the retry entry was last updated.';
+
+
+--
+-- Name: sol_reward_disbursements; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_reward_disbursements (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    user_bank character varying NOT NULL,
+    challenge_id character varying NOT NULL,
+    specifier character varying NOT NULL,
+    recipient_eth_address text
+);
+
+
+--
+-- Name: TABLE sol_reward_disbursements; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_reward_disbursements IS 'Stores reward manager program Evaluate instructions for tracked mints.';
+
+
+--
+-- Name: COLUMN sol_reward_disbursements.recipient_eth_address; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_disbursements.recipient_eth_address IS 'The Ethereum address of the recipient of the reward.';
+
+
+--
+-- Name: sol_reward_manager_inits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_reward_manager_inits (
+    signature text NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    min_votes integer NOT NULL,
+    reward_manager_state text NOT NULL,
+    token_source text NOT NULL,
+    mint text NOT NULL,
+    manager text NOT NULL,
+    authority text NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_reward_manager_inits; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_reward_manager_inits IS 'Stores Init instructions for the Reward Manager program';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.min_votes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.min_votes IS 'Minimum number of votes required for reward distribution';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.reward_manager_state; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.reward_manager_state IS 'Public key of the Reward Manager state account';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.token_source; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.token_source IS 'Public key of the token source account (Note: Any token account on the authority account is valid)';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.mint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.mint IS 'Public key of the mint for the token source account';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.manager; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.manager IS 'Public key of the manager account that initially has authority to create and remove senders without quorum';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.authority; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.authority IS 'Public key of the authority account, which holds the token accounts that reward manager can disburse from';
+
+
+--
+-- Name: sol_slot_checkpoints; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_slot_checkpoints (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    from_slot bigint NOT NULL,
+    to_slot bigint NOT NULL,
+    subscription_hash text NOT NULL,
+    subscription jsonb NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    name text
+);
+
+
+--
+-- Name: TABLE sol_slot_checkpoints; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_slot_checkpoints IS 'Stores checkpoints for Solana slots to track indexing progress.';
+
+
+--
+-- Name: COLUMN sol_slot_checkpoints.name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_slot_checkpoints.name IS 'The name of the indexer this checkpoint is for (e.g., token_indexer, damm_v2_indexer).';
+
+
+--
+-- Name: sol_token_account_balance_changes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_token_account_balance_changes (
+    signature character varying NOT NULL,
+    mint character varying NOT NULL,
+    owner character varying NOT NULL,
+    account character varying NOT NULL,
+    change bigint NOT NULL,
+    balance bigint NOT NULL,
+    slot bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    fee_payer character varying
+);
+
+
+--
+-- Name: TABLE sol_token_account_balance_changes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_token_account_balance_changes IS 'Stores token balance changes for all accounts of tracked mints.';
+
+
+--
+-- Name: COLUMN sol_token_account_balance_changes.fee_payer; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sol_token_account_balance_changes.fee_payer IS 'The public key of the account that paid the fee for the transaction.';
+
+
+--
+-- Name: sol_token_account_balances; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_token_account_balances (
+    account character varying NOT NULL,
+    mint character varying NOT NULL,
+    owner character varying NOT NULL,
+    balance bigint NOT NULL,
+    slot bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_token_account_balances; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_token_account_balances IS 'Stores current token balances for all accounts of tracked mints.';
+
+
+--
+-- Name: sol_token_transfers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_token_transfers (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    from_account character varying NOT NULL,
+    to_account character varying NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_token_transfers; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_token_transfers IS 'Stores SPL token transfers for tracked mints.';
+
+
+--
+-- Name: sol_user_balances; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_user_balances (
+    user_id integer NOT NULL,
+    mint text NOT NULL,
+    balance bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_user_balances; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_user_balances IS 'Stores the balances of Solana tokens for users.';
+
+
+--
+-- Name: spl_token_tx; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.spl_token_tx (
+    last_scanned_slot integer NOT NULL,
+    signature character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: stems; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.stems (
+    parent_track_id integer NOT NULL,
+    child_track_id integer NOT NULL
+);
+
+
+--
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subscriptions (
+    blockhash character varying,
+    blocknumber integer,
+    subscriber_id integer NOT NULL,
+    user_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: supporter_rank_ups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.supporter_rank_ups (
+    slot integer NOT NULL,
+    sender_user_id integer NOT NULL,
+    receiver_user_id integer NOT NULL,
+    rank integer NOT NULL
+);
+
+
+--
+-- Name: tag_track_user; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.tag_track_user AS
+ SELECT unnest(tags) AS tag,
+    track_id,
+    owner_id
+   FROM ( SELECT string_to_array(lower((tracks.tags)::text), ','::text) AS tags,
+            tracks.track_id,
+            tracks.owner_id
+           FROM public.tracks
+          WHERE (((tracks.tags)::text <> ''::text) AND (tracks.tags IS NOT NULL) AND (tracks.is_current IS TRUE) AND (tracks.is_unlisted IS FALSE) AND (tracks.stem_of IS NULL))
+          ORDER BY tracks.updated_at DESC) t
+  GROUP BY (unnest(tags)), track_id, owner_id
+  WITH NO DATA;
+
+
+--
+-- Name: track_delist_statuses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.track_delist_statuses (
+    created_at timestamp with time zone NOT NULL,
+    track_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    track_cid character varying NOT NULL,
+    delisted boolean NOT NULL,
+    reason public.delist_track_reason NOT NULL
+);
+
+
+--
+-- Name: track_downloads; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.track_downloads (
+    txhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    parent_track_id integer NOT NULL,
+    track_id integer NOT NULL,
+    user_id integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    city character varying,
+    region character varying,
+    country character varying
+);
+
+
+--
+-- Name: track_price_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.track_price_history (
+    track_id integer NOT NULL,
+    splits jsonb NOT NULL,
+    total_price_cents bigint NOT NULL,
+    blocknumber integer NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    access public.usdc_purchase_access_type DEFAULT 'stream'::public.usdc_purchase_access_type NOT NULL
+);
+
+
+--
+-- Name: track_routes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.track_routes (
+    slug character varying NOT NULL,
+    title_slug character varying NOT NULL,
+    collision_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    track_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    blockhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    txhash character varying NOT NULL
+);
+
+
+--
+-- Name: track_trending_scores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.track_trending_scores (
+    track_id integer NOT NULL,
+    type character varying NOT NULL,
+    genre character varying,
+    version character varying NOT NULL,
+    time_range character varying NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    blockhash character varying,
+    user_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    handle character varying,
+    wallet character varying,
+    name text,
+    profile_picture character varying,
+    cover_photo character varying,
+    bio character varying,
+    location character varying,
+    metadata_multihash character varying,
+    creator_node_endpoint character varying,
+    blocknumber integer,
+    is_verified boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    handle_lc character varying,
+    cover_photo_sizes character varying,
+    profile_picture_sizes character varying,
+    primary_id integer,
+    secondary_ids integer[],
+    replica_set_update_signer character varying,
+    has_collectibles boolean DEFAULT false NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    playlist_library jsonb,
+    is_deactivated boolean DEFAULT false NOT NULL,
+    slot integer,
+    user_storage_account character varying,
+    user_authority_account character varying,
+    artist_pick_track_id integer,
+    is_available boolean DEFAULT true NOT NULL,
+    is_storage_v2 boolean DEFAULT false NOT NULL,
+    allow_ai_attribution boolean DEFAULT false NOT NULL,
+    spl_usdc_payout_wallet character varying,
+    twitter_handle character varying,
+    instagram_handle character varying,
+    tiktok_handle character varying,
+    verified_with_twitter boolean DEFAULT false,
+    verified_with_instagram boolean DEFAULT false,
+    verified_with_tiktok boolean DEFAULT false,
+    website character varying,
+    donation character varying,
+    profile_type public.profile_type_enum,
+    coin_flair_mint text
+);
+
+
+--
+-- Name: COLUMN users.coin_flair_mint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.coin_flair_mint IS 'The mint of the coin which the user has selected as their preferred flair. NULL for auto, empty string for none.';
+
+
+--
+-- Name: trending_params; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.trending_params AS
+ SELECT t.track_id,
+    t.release_date,
+    t.genre,
+    t.owner_id,
+    ap.play_count,
+    au.follower_count AS owner_follower_count,
+    COALESCE(aggregate_track.repost_count, 0) AS repost_count,
+    COALESCE(aggregate_track.save_count, 0) AS save_count,
+    COALESCE(repost_week.repost_count, (0)::bigint) AS repost_week_count,
+    COALESCE(repost_month.repost_count, (0)::bigint) AS repost_month_count,
+    COALESCE(repost_year.repost_count, (0)::bigint) AS repost_year_count,
+    COALESCE(save_week.repost_count, (0)::bigint) AS save_week_count,
+    COALESCE(save_month.repost_count, (0)::bigint) AS save_month_count,
+    COALESCE(save_year.repost_count, (0)::bigint) AS save_year_count,
+    COALESCE(karma.karma, (0)::numeric) AS karma
+   FROM ((((((((((public.tracks t
+     LEFT JOIN ( SELECT ap_1.count AS play_count,
+            ap_1.play_item_id
+           FROM public.aggregate_plays ap_1) ap ON ((ap.play_item_id = t.track_id)))
+     LEFT JOIN ( SELECT au_1.user_id,
+            au_1.follower_count
+           FROM public.aggregate_user au_1) au ON ((au.user_id = t.owner_id)))
+     LEFT JOIN ( SELECT aggregate_track_1.track_id,
+            aggregate_track_1.repost_count,
+            aggregate_track_1.save_count
+           FROM public.aggregate_track aggregate_track_1) aggregate_track ON ((aggregate_track.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.repost_item_id AS track_id,
+            count(r.repost_item_id) AS repost_count
+           FROM public.reposts r
+          WHERE ((r.is_current IS TRUE) AND (r.repost_type = 'track'::public.reposttype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 year'::interval)))
+          GROUP BY r.repost_item_id) repost_year ON ((repost_year.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.repost_item_id AS track_id,
+            count(r.repost_item_id) AS repost_count
+           FROM public.reposts r
+          WHERE ((r.is_current IS TRUE) AND (r.repost_type = 'track'::public.reposttype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 mon'::interval)))
+          GROUP BY r.repost_item_id) repost_month ON ((repost_month.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.repost_item_id AS track_id,
+            count(r.repost_item_id) AS repost_count
+           FROM public.reposts r
+          WHERE ((r.is_current IS TRUE) AND (r.repost_type = 'track'::public.reposttype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '7 days'::interval)))
+          GROUP BY r.repost_item_id) repost_week ON ((repost_week.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.save_item_id AS track_id,
+            count(r.save_item_id) AS repost_count
+           FROM public.saves r
+          WHERE ((r.is_current IS TRUE) AND (r.save_type = 'track'::public.savetype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 year'::interval)))
+          GROUP BY r.save_item_id) save_year ON ((save_year.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.save_item_id AS track_id,
+            count(r.save_item_id) AS repost_count
+           FROM public.saves r
+          WHERE ((r.is_current IS TRUE) AND (r.save_type = 'track'::public.savetype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 mon'::interval)))
+          GROUP BY r.save_item_id) save_month ON ((save_month.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.save_item_id AS track_id,
+            count(r.save_item_id) AS repost_count
+           FROM public.saves r
+          WHERE ((r.is_current IS TRUE) AND (r.save_type = 'track'::public.savetype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '7 days'::interval)))
+          GROUP BY r.save_item_id) save_week ON ((save_week.track_id = t.track_id)))
+     LEFT JOIN ( SELECT save_and_reposts.item_id AS track_id,
+            sum(au_1.follower_count) AS karma
+           FROM (( SELECT r_and_s.user_id,
+                    r_and_s.item_id
+                   FROM (( SELECT reposts.user_id,
+                            reposts.repost_item_id AS item_id
+                           FROM public.reposts
+                          WHERE ((reposts.is_delete IS FALSE) AND (reposts.is_current IS TRUE) AND (reposts.repost_type = 'track'::public.reposttype))
+                        UNION ALL
+                         SELECT saves.user_id,
+                            saves.save_item_id AS item_id
+                           FROM public.saves
+                          WHERE ((saves.is_delete IS FALSE) AND (saves.is_current IS TRUE) AND (saves.save_type = 'track'::public.savetype))) r_and_s
+                     JOIN public.users ON ((r_and_s.user_id = users.user_id)))
+                  WHERE (((users.cover_photo IS NOT NULL) OR (users.cover_photo_sizes IS NOT NULL)) AND ((users.profile_picture IS NOT NULL) OR (users.profile_picture_sizes IS NOT NULL)) AND (users.bio IS NOT NULL))) save_and_reposts
+             JOIN public.aggregate_user au_1 ON ((save_and_reposts.user_id = au_1.user_id)))
+          GROUP BY save_and_reposts.item_id) karma ON ((karma.track_id = t.track_id)))
+  WHERE ((t.is_current IS TRUE) AND (t.is_delete IS FALSE) AND (t.is_unlisted IS FALSE) AND (t.stem_of IS NULL))
+  WITH NO DATA;
+
+
+--
+-- Name: trending_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.trending_results (
+    user_id integer NOT NULL,
+    id character varying,
+    rank integer NOT NULL,
+    type character varying NOT NULL,
+    version character varying NOT NULL,
+    week date NOT NULL
+);
+
+
+--
+-- Name: usdc_purchases; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.usdc_purchases (
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    buyer_user_id integer NOT NULL,
+    seller_user_id integer NOT NULL,
+    amount bigint NOT NULL,
+    content_type public.usdc_purchase_content_type NOT NULL,
+    content_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    extra_amount bigint DEFAULT 0 NOT NULL,
+    access public.usdc_purchase_access_type DEFAULT 'stream'::public.usdc_purchase_access_type NOT NULL,
+    city character varying,
+    region character varying,
+    country character varying,
+    vendor character varying,
+    splits jsonb NOT NULL
+);
+
+
+--
+-- Name: usdc_transactions_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.usdc_transactions_history (
+    user_bank character varying NOT NULL,
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    transaction_type character varying NOT NULL,
+    method character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    transaction_created_at timestamp without time zone NOT NULL,
+    change numeric NOT NULL,
+    balance numeric NOT NULL,
+    tx_metadata character varying
+);
+
+
+--
+-- Name: usdc_user_bank_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.usdc_user_bank_accounts (
+    signature character varying NOT NULL,
+    ethereum_address character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    bank_account character varying NOT NULL
+);
+
+
+--
+-- Name: user_balance_changes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_balance_changes (
+    user_id integer NOT NULL,
+    blocknumber integer NOT NULL,
+    current_balance character varying NOT NULL,
+    previous_balance character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: user_balance_changes_user_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_balance_changes_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_balance_changes_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_balance_changes_user_id_seq OWNED BY public.user_balance_changes.user_id;
+
+
+--
+-- Name: user_balance_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_balance_history (
+    user_id integer NOT NULL,
+    mint text NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    balance bigint NOT NULL,
+    balance_usd double precision NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE user_balance_history; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_balance_history IS 'Stores historical snapshots of user token balances per mint, binned hourly by timestamp';
+
+
+--
+-- Name: COLUMN user_balance_history.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_balance_history.user_id IS 'The user ID this balance snapshot belongs to';
+
+
+--
+-- Name: COLUMN user_balance_history.mint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_balance_history.mint IS 'The token mint address';
+
+
+--
+-- Name: COLUMN user_balance_history."timestamp"; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_balance_history."timestamp" IS 'The binned timestamp (hourly) for this balance snapshot';
+
+
+--
+-- Name: COLUMN user_balance_history.balance; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_balance_history.balance IS 'The raw token balance (in token units, accounting for decimals)';
+
+
+--
+-- Name: COLUMN user_balance_history.balance_usd; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_balance_history.balance_usd IS 'The USD value of this token balance at this timestamp';
+
+
+--
+-- Name: COLUMN user_balance_history.created_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_balance_history.created_at IS 'When this record was created';
+
+
+--
+-- Name: user_balances; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_balances (
+    user_id integer NOT NULL,
+    balance character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    associated_wallets_balance character varying DEFAULT '0'::character varying NOT NULL,
+    waudio character varying DEFAULT '0'::character varying,
+    associated_sol_wallets_balance character varying DEFAULT '0'::character varying NOT NULL
+);
+
+
+--
+-- Name: user_balances_user_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_balances_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_balances_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_balances_user_id_seq OWNED BY public.user_balances.user_id;
+
+
+--
+-- Name: user_bank_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_bank_accounts (
+    signature character varying NOT NULL,
+    ethereum_address character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    bank_account character varying NOT NULL
+);
+
+
+--
+-- Name: user_bank_txs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_bank_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: user_challenges; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_challenges (
+    challenge_id character varying NOT NULL,
+    user_id integer NOT NULL,
+    specifier character varying NOT NULL,
+    is_complete boolean NOT NULL,
+    current_step_count integer,
+    completed_blocknumber integer,
+    amount integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp without time zone
+);
+
+
+--
+-- Name: user_delist_statuses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_delist_statuses (
+    created_at timestamp with time zone NOT NULL,
+    user_id integer NOT NULL,
+    delisted boolean NOT NULL,
+    reason public.delist_user_reason NOT NULL
+);
+
+
+--
+-- Name: user_distinct_play_hours; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_distinct_play_hours (
+    user_id integer NOT NULL,
+    hours_with_play integer DEFAULT 0 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: TABLE user_distinct_play_hours; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_distinct_play_hours IS 'Tracks the number of distinct hours in which a user has listened to a track';
+
+
+--
+-- Name: user_distinct_play_tracks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_distinct_play_tracks (
+    user_id integer NOT NULL,
+    track_count integer DEFAULT 0 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: TABLE user_distinct_play_tracks; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_distinct_play_tracks IS 'Tracks the number of distinct tracks a user has listened to';
+
+
+--
+-- Name: user_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_events (
+    id integer NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    is_current boolean NOT NULL,
+    user_id integer NOT NULL,
+    referrer integer,
+    is_mobile_user boolean DEFAULT false NOT NULL,
+    slot integer
+);
+
+
+--
+-- Name: user_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_events_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_events_id_seq OWNED BY public.user_events.id;
+
+
+--
+-- Name: user_listening_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_listening_history (
+    user_id integer NOT NULL,
+    listening_history jsonb NOT NULL
+);
+
+
+--
+-- Name: user_listening_history_user_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_listening_history_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_listening_history_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_listening_history_user_id_seq OWNED BY public.user_listening_history.user_id;
+
+
+--
+-- Name: user_payout_wallet_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_payout_wallet_history (
+    user_id integer NOT NULL,
+    spl_usdc_payout_wallet character varying,
+    blocknumber integer NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: user_pubkeys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_pubkeys (
+    user_id integer NOT NULL,
+    pubkey_base64 text NOT NULL
+);
+
+
+--
+-- Name: user_score_features; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_score_features (
+    user_id integer NOT NULL,
+    challenge_count integer DEFAULT 0,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: TABLE user_score_features; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_score_features IS 'Tracks some features used in user score calculation';
+
+
+--
+-- Name: COLUMN user_score_features.challenge_count; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_score_features.challenge_count IS 'Tracks the number of fast challenges auser has completed';
+
+
+--
+-- Name: user_tips; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_tips (
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    sender_user_id integer NOT NULL,
+    receiver_user_id integer NOT NULL,
+    amount bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: volume_leader_exclusions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.volume_leader_exclusions (
+    address text NOT NULL,
+    description text
+);
+
+
+--
+-- Name: aggregate_daily_app_name_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_daily_app_name_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_daily_app_name_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_daily_total_users_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_daily_total_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_daily_total_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_daily_unique_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_daily_unique_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_app_name_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_monthly_app_name_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_total_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_monthly_total_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_unique_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_monthly_unique_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: associated_wallets id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.associated_wallets ALTER COLUMN id SET DEFAULT nextval('public.associated_wallets_id_seq'::regclass);
+
+
+--
+-- Name: challenge_listen_streak user_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.challenge_listen_streak ALTER COLUMN user_id SET DEFAULT nextval('public.challenge_listen_streak_user_id_seq'::regclass);
+
+
+--
+-- Name: challenge_profile_completion user_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.challenge_profile_completion ALTER COLUMN user_id SET DEFAULT nextval('public.challenge_profile_completion_user_id_seq'::regclass);
+
+
+--
+-- Name: claimed_prizes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.claimed_prizes ALTER COLUMN id SET DEFAULT nextval('public.claimed_prizes_id_seq'::regclass);
+
+
+--
+-- Name: email_access id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_access ALTER COLUMN id SET DEFAULT nextval('public.email_access_id_seq'::regclass);
+
+
+--
+-- Name: encrypted_emails id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.encrypted_emails ALTER COLUMN id SET DEFAULT nextval('public.encrypted_emails_id_seq'::regclass);
+
+
+--
+-- Name: eth_blocks last_scanned_block; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.eth_blocks ALTER COLUMN last_scanned_block SET DEFAULT nextval('public.eth_blocks_last_scanned_block_seq'::regclass);
+
+
+--
+-- Name: notification id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification ALTER COLUMN id SET DEFAULT nextval('public.notification_id_seq'::regclass);
+
+
+--
+-- Name: oauth_redirect_uris id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_redirect_uris ALTER COLUMN id SET DEFAULT nextval('public.oauth_redirect_uris_id_seq'::regclass);
+
+
+--
+-- Name: plays id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plays ALTER COLUMN id SET DEFAULT nextval('public.plays_id_seq'::regclass);
+
+
+--
+-- Name: prizes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prizes ALTER COLUMN id SET DEFAULT nextval('public.prizes_id_seq'::regclass);
+
+
+--
+-- Name: reactions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reactions ALTER COLUMN id SET DEFAULT nextval('public.reactions_id_seq'::regclass);
+
+
+--
+-- Name: skipped_transactions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.skipped_transactions ALTER COLUMN id SET DEFAULT nextval('public.skipped_transactions_id_seq'::regclass);
+
+
+--
+-- Name: user_balance_changes user_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_balance_changes ALTER COLUMN user_id SET DEFAULT nextval('public.user_balance_changes_user_id_seq'::regclass);
+
+
+--
+-- Name: user_balances user_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_balances ALTER COLUMN user_id SET DEFAULT nextval('public.user_balances_user_id_seq'::regclass);
+
+
+--
+-- Name: user_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_events ALTER COLUMN id SET DEFAULT nextval('public.user_events_id_seq'::regclass);
+
+
+--
+-- Name: user_listening_history user_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_listening_history ALTER COLUMN user_id SET DEFAULT nextval('public.user_listening_history_user_id_seq'::regclass);
+
+
+--
+-- Name: SequelizeMeta SequelizeMeta_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."SequelizeMeta"
+    ADD CONSTRAINT "SequelizeMeta_pkey" PRIMARY KEY (name);
+
+
+--
+-- Name: aggregate_daily_app_name_metrics aggregate_daily_app_name_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_daily_app_name_metrics
+    ADD CONSTRAINT aggregate_daily_app_name_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_daily_total_users_metrics aggregate_daily_total_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_daily_total_users_metrics
+    ADD CONSTRAINT aggregate_daily_total_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics aggregate_daily_unique_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_daily_unique_users_metrics
+    ADD CONSTRAINT aggregate_daily_unique_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics aggregate_monthly_app_name_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_app_name_metrics
+    ADD CONSTRAINT aggregate_monthly_app_name_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_monthly_plays aggregate_monthly_plays_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_plays
+    ADD CONSTRAINT aggregate_monthly_plays_pkey PRIMARY KEY (play_item_id, "timestamp", country);
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics aggregate_monthly_total_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_total_users_metrics
+    ADD CONSTRAINT aggregate_monthly_total_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics aggregate_monthly_unique_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_unique_users_metrics
+    ADD CONSTRAINT aggregate_monthly_unique_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_playlist aggregate_playlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_playlist
+    ADD CONSTRAINT aggregate_playlist_pkey PRIMARY KEY (playlist_id);
+
+
+--
+-- Name: aggregate_track aggregate_track_table_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_track
+    ADD CONSTRAINT aggregate_track_table_pkey PRIMARY KEY (track_id);
+
+
+--
+-- Name: aggregate_user aggregate_user_table_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_user
+    ADD CONSTRAINT aggregate_user_table_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: aggregate_user_tips aggregate_user_tips_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_user_tips
+    ADD CONSTRAINT aggregate_user_tips_pkey PRIMARY KEY (sender_user_id, receiver_user_id);
+
+
+--
+-- Name: album_price_history album_price_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.album_price_history
+    ADD CONSTRAINT album_price_history_pkey PRIMARY KEY (playlist_id, block_timestamp);
+
+
+--
+-- Name: api_access_keys api_access_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_access_keys
+    ADD CONSTRAINT api_access_keys_pkey PRIMARY KEY (api_key, api_access_key);
+
+
+--
+-- Name: api_keys api_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_keys
+    ADD CONSTRAINT api_keys_pkey PRIMARY KEY (api_key);
+
+
+--
+-- Name: api_metrics_apps api_metrics_apps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_metrics_apps
+    ADD CONSTRAINT api_metrics_apps_pkey PRIMARY KEY (date, api_key, app_name);
+
+
+--
+-- Name: api_metrics_apps_unique api_metrics_apps_unique_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_metrics_apps_unique
+    ADD CONSTRAINT api_metrics_apps_unique_pkey PRIMARY KEY (date, app_name);
+
+
+--
+-- Name: api_metrics_counts api_metrics_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_metrics_counts
+    ADD CONSTRAINT api_metrics_counts_pkey PRIMARY KEY (date);
+
+
+--
+-- Name: api_metrics_routes api_metrics_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_metrics_routes
+    ADD CONSTRAINT api_metrics_routes_pkey PRIMARY KEY (date, route_pattern, method);
+
+
+--
+-- Name: app_name_metrics app_name_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.app_name_metrics
+    ADD CONSTRAINT app_name_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: artist_coin_pools artist_coin_pools_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.artist_coin_pools
+    ADD CONSTRAINT artist_coin_pools_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: artist_coin_stats artist_coin_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.artist_coin_stats
+    ADD CONSTRAINT artist_coin_stats_pkey PRIMARY KEY (mint);
+
+
+--
+-- Name: artist_coins artist_coins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.artist_coins
+    ADD CONSTRAINT artist_coins_pkey PRIMARY KEY (mint);
+
+
+--
+-- Name: artist_coins artist_coins_ticker_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.artist_coins
+    ADD CONSTRAINT artist_coins_ticker_unique UNIQUE (ticker);
+
+
+--
+-- Name: associated_wallets associated_wallets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.associated_wallets
+    ADD CONSTRAINT associated_wallets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: audio_transactions_history audio_transactions_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audio_transactions_history
+    ADD CONSTRAINT audio_transactions_history_pkey PRIMARY KEY (user_bank, signature);
+
+
+--
+-- Name: audius_data_txs audius_data_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audius_data_txs
+    ADD CONSTRAINT audius_data_txs_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: blocks blocks_number_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blocks
+    ADD CONSTRAINT blocks_number_key UNIQUE (number);
+
+
+--
+-- Name: blocks blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blocks
+    ADD CONSTRAINT blocks_pkey PRIMARY KEY (blockhash);
+
+
+--
+-- Name: challenge_disbursements challenge_disbursements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.challenge_disbursements
+    ADD CONSTRAINT challenge_disbursements_pkey PRIMARY KEY (challenge_id, specifier);
+
+
+--
+-- Name: challenge_listen_streak challenge_listen_streak_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.challenge_listen_streak
+    ADD CONSTRAINT challenge_listen_streak_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: challenge_profile_completion challenge_profile_completion_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.challenge_profile_completion
+    ADD CONSTRAINT challenge_profile_completion_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: challenges challenges_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.challenges
+    ADD CONSTRAINT challenges_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: chat_ban chat_ban_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_ban
+    ADD CONSTRAINT chat_ban_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: chat_blast chat_blast_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_blast
+    ADD CONSTRAINT chat_blast_pkey PRIMARY KEY (blast_id);
+
+
+--
+-- Name: chat_blocked_users chat_blocked_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_blocked_users
+    ADD CONSTRAINT chat_blocked_users_pkey PRIMARY KEY (blocker_user_id, blockee_user_id);
+
+
+--
+-- Name: chat_member chat_member_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_member
+    ADD CONSTRAINT chat_member_pkey PRIMARY KEY (chat_id, user_id);
+
+
+--
+-- Name: chat_message chat_message_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_message
+    ADD CONSTRAINT chat_message_pkey PRIMARY KEY (message_id);
+
+
+--
+-- Name: chat_message_reactions chat_message_reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_message_reactions
+    ADD CONSTRAINT chat_message_reactions_pkey PRIMARY KEY (user_id, message_id);
+
+
+--
+-- Name: chat_permissions chat_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_permissions
+    ADD CONSTRAINT chat_permissions_pkey PRIMARY KEY (user_id, permits);
+
+
+--
+-- Name: chat chat_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat
+    ADD CONSTRAINT chat_pkey PRIMARY KEY (chat_id);
+
+
+--
+-- Name: cid_data cid_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cid_data
+    ADD CONSTRAINT cid_data_pkey PRIMARY KEY (cid);
+
+
+--
+-- Name: claimed_prizes claimed_prizes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.claimed_prizes
+    ADD CONSTRAINT claimed_prizes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: claimed_prizes claimed_prizes_signature_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.claimed_prizes
+    ADD CONSTRAINT claimed_prizes_signature_key UNIQUE (signature);
+
+
+--
+-- Name: comment_mentions comment_mentions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_mentions
+    ADD CONSTRAINT comment_mentions_pkey PRIMARY KEY (comment_id, user_id);
+
+
+--
+-- Name: comment_notification_settings comment_notification_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_notification_settings
+    ADD CONSTRAINT comment_notification_settings_pkey PRIMARY KEY (user_id, entity_id, entity_type);
+
+
+--
+-- Name: comment_reactions comment_reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_reactions
+    ADD CONSTRAINT comment_reactions_pkey PRIMARY KEY (comment_id, user_id);
+
+
+--
+-- Name: comment_reports comment_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_reports
+    ADD CONSTRAINT comment_reports_pkey PRIMARY KEY (comment_id, user_id);
+
+
+--
+-- Name: comment_threads comment_threads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_threads
+    ADD CONSTRAINT comment_threads_pkey PRIMARY KEY (parent_comment_id, comment_id);
+
+
+--
+-- Name: comments comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comments
+    ADD CONSTRAINT comments_pkey PRIMARY KEY (comment_id);
+
+
+--
+-- Name: countries countries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.countries
+    ADD CONSTRAINT countries_pkey PRIMARY KEY (iso);
+
+
+--
+-- Name: dashboard_wallet_users dashboard_wallet_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dashboard_wallet_users
+    ADD CONSTRAINT dashboard_wallet_users_pkey PRIMARY KEY (wallet);
+
+
+--
+-- Name: delist_status_cursor delist_status_cursor_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.delist_status_cursor
+    ADD CONSTRAINT delist_status_cursor_pkey PRIMARY KEY (host, entity);
+
+
+--
+-- Name: developer_apps developer_apps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.developer_apps
+    ADD CONSTRAINT developer_apps_pkey PRIMARY KEY (txhash, address);
+
+
+--
+-- Name: email_access email_access_email_owner_user_id_receiving_user_id_grantor__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_access
+    ADD CONSTRAINT email_access_email_owner_user_id_receiving_user_id_grantor__key UNIQUE (email_owner_user_id, receiving_user_id, grantor_user_id);
+
+
+--
+-- Name: email_access email_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_access
+    ADD CONSTRAINT email_access_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: encrypted_emails encrypted_emails_email_owner_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.encrypted_emails
+    ADD CONSTRAINT encrypted_emails_email_owner_user_id_key UNIQUE (email_owner_user_id);
+
+
+--
+-- Name: encrypted_emails encrypted_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.encrypted_emails
+    ADD CONSTRAINT encrypted_emails_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: eth_blocks eth_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.eth_blocks
+    ADD CONSTRAINT eth_blocks_pkey PRIMARY KEY (last_scanned_block);
+
+
+--
+-- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_pkey PRIMARY KEY (event_id);
+
+
+--
+-- Name: follows follows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT follows_pkey PRIMARY KEY (followee_user_id, txhash, follower_user_id);
+
+
+--
+-- Name: grants grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.grants
+    ADD CONSTRAINT grants_pkey PRIMARY KEY (user_id, txhash, grantee_address);
+
+
+--
+-- Name: hourly_play_counts hourly_play_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hourly_play_counts
+    ADD CONSTRAINT hourly_play_counts_pkey PRIMARY KEY (hourly_timestamp);
+
+
+--
+-- Name: indexing_checkpoints indexing_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.indexing_checkpoints
+    ADD CONSTRAINT indexing_checkpoints_pkey PRIMARY KEY (tablename);
+
+
+--
+-- Name: milestones milestones_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.milestones
+    ADD CONSTRAINT milestones_pkey PRIMARY KEY (id, name, threshold);
+
+
+--
+-- Name: muted_users muted_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.muted_users
+    ADD CONSTRAINT muted_users_pkey PRIMARY KEY (muted_user_id, user_id);
+
+
+--
+-- Name: notification notification_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification
+    ADD CONSTRAINT notification_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notification_seen notification_seen_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_seen
+    ADD CONSTRAINT notification_seen_pkey PRIMARY KEY (user_id, seen_at);
+
+
+--
+-- Name: oauth_authorization_codes oauth_authorization_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_authorization_codes
+    ADD CONSTRAINT oauth_authorization_codes_pkey PRIMARY KEY (code);
+
+
+--
+-- Name: oauth_redirect_uris oauth_redirect_uris_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_redirect_uris
+    ADD CONSTRAINT oauth_redirect_uris_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_tokens oauth_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_pkey PRIMARY KEY (token);
+
+
+--
+-- Name: core_indexed_blocks pk_chain_id_height; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.core_indexed_blocks
+    ADD CONSTRAINT pk_chain_id_height PRIMARY KEY (chain_id, height);
+
+
+--
+-- Name: collectibles pk_user_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collectibles
+    ADD CONSTRAINT pk_user_id PRIMARY KEY (user_id);
+
+
+--
+-- Name: aggregate_plays play_item_id_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.aggregate_plays
+    ADD CONSTRAINT play_item_id_pkey PRIMARY KEY (play_item_id);
+
+
+--
+-- Name: playlist_routes playlist_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlist_routes
+    ADD CONSTRAINT playlist_routes_pkey PRIMARY KEY (owner_id, slug);
+
+
+--
+-- Name: playlist_seen playlist_seen_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlist_seen
+    ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (playlist_id, seen_at, user_id);
+
+
+--
+-- Name: playlist_tracks playlist_tracks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlist_tracks
+    ADD CONSTRAINT playlist_tracks_pkey PRIMARY KEY (playlist_id, track_id);
+
+
+--
+-- Name: playlist_trending_scores playlist_trending_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlist_trending_scores
+    ADD CONSTRAINT playlist_trending_scores_pkey PRIMARY KEY (playlist_id, type, version, time_range);
+
+
+--
+-- Name: playlists playlists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlists
+    ADD CONSTRAINT playlists_pkey PRIMARY KEY (txhash, playlist_id);
+
+
+--
+-- Name: plays plays_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plays
+    ADD CONSTRAINT plays_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prizes prizes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prizes
+    ADD CONSTRAINT prizes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prizes prizes_prize_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prizes
+    ADD CONSTRAINT prizes_prize_id_key UNIQUE (prize_id);
+
+
+--
+-- Name: pubkeys pubkeys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pubkeys
+    ADD CONSTRAINT pubkeys_pkey PRIMARY KEY (wallet);
+
+
+--
+-- Name: reactions reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reactions
+    ADD CONSTRAINT reactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: related_artists related_artists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.related_artists
+    ADD CONSTRAINT related_artists_pkey PRIMARY KEY (user_id, related_artist_user_id);
+
+
+--
+-- Name: remixes remixes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.remixes
+    ADD CONSTRAINT remixes_pkey PRIMARY KEY (parent_track_id, child_track_id);
+
+
+--
+-- Name: reported_comments reported_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reported_comments
+    ADD CONSTRAINT reported_comments_pkey PRIMARY KEY (reported_comment_id, user_id);
+
+
+--
+-- Name: reposts reposts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reposts
+    ADD CONSTRAINT reposts_pkey PRIMARY KEY (txhash, user_id, repost_item_id, repost_type);
+
+
+--
+-- Name: revert_blocks revert_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.revert_blocks
+    ADD CONSTRAINT revert_blocks_pkey PRIMARY KEY (blocknumber);
+
+
+--
+-- Name: reward_codes reward_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reward_codes
+    ADD CONSTRAINT reward_codes_pkey PRIMARY KEY (code);
+
+
+--
+-- Name: reward_manager_txs reward_manager_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reward_manager_txs
+    ADD CONSTRAINT reward_manager_txs_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: route_metrics route_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.route_metrics
+    ADD CONSTRAINT route_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rpc_cursor rpc_cursor_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rpc_cursor
+    ADD CONSTRAINT rpc_cursor_pkey PRIMARY KEY (relayed_by);
+
+
+--
+-- Name: rpc_error rpc_error_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rpc_error
+    ADD CONSTRAINT rpc_error_pkey PRIMARY KEY (sig);
+
+
+--
+-- Name: rpc_log rpc_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rpc_log
+    ADD CONSTRAINT rpc_log_pkey PRIMARY KEY (sig);
+
+
+--
+-- Name: rpclog rpclog_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rpclog
+    ADD CONSTRAINT rpclog_pkey PRIMARY KEY (cuid);
+
+
+--
+-- Name: saves saves_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.saves
+    ADD CONSTRAINT saves_pkey PRIMARY KEY (save_item_id, user_id, txhash, save_type);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: schema_version schema_version_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_version
+    ADD CONSTRAINT schema_version_pkey PRIMARY KEY (file_name);
+
+
+--
+-- Name: shares shares_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.shares
+    ADD CONSTRAINT shares_pkey PRIMARY KEY (user_id, share_item_id, share_type, txhash);
+
+
+--
+-- Name: skipped_transactions skipped_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.skipped_transactions
+    ADD CONSTRAINT skipped_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sol_claimable_account_transfers sol_claimable_account_transfers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_claimable_account_transfers
+    ADD CONSTRAINT sol_claimable_account_transfers_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_claimable_accounts sol_claimable_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_claimable_accounts
+    ADD CONSTRAINT sol_claimable_accounts_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_keypairs sol_keypairs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_keypairs
+    ADD CONSTRAINT sol_keypairs_pkey PRIMARY KEY (public_key);
+
+
+--
+-- Name: sol_locker_vesting_escrows sol_locker_vesting_escrows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_locker_vesting_escrows
+    ADD CONSTRAINT sol_locker_vesting_escrows_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_damm_v2_initialize_custom_pool_instructions sol_meteora_damm_v2_initialize_custom_pool_instructions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_initialize_custom_pool_instructions
+    ADD CONSTRAINT sol_meteora_damm_v2_initialize_custom_pool_instructions_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_base_fees sol_meteora_damm_v2_pool_base_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_base_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_base_fees_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_dynamic_fees sol_meteora_damm_v2_pool_dynamic_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_dynamic_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_dynamic_fees_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_fees sol_meteora_damm_v2_pool_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_fees_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_metrics sol_meteora_damm_v2_pool_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_metrics
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_metrics_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pools sol_meteora_damm_v2_pools_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pools
+    ADD CONSTRAINT sol_meteora_damm_v2_pools_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_damm_v2_position_metrics sol_meteora_damm_v2_position_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_position_metrics
+    ADD CONSTRAINT sol_meteora_damm_v2_position_metrics_pkey PRIMARY KEY ("position");
+
+
+--
+-- Name: sol_meteora_damm_v2_positions sol_meteora_damm_v2_positions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_positions
+    ADD CONSTRAINT sol_meteora_damm_v2_positions_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_dbc_config_fees sol_meteora_dbc_config_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_fees
+    ADD CONSTRAINT sol_meteora_dbc_config_fees_pkey PRIMARY KEY (config);
+
+
+--
+-- Name: sol_meteora_dbc_config_vestings sol_meteora_dbc_config_vestings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_vestings
+    ADD CONSTRAINT sol_meteora_dbc_config_vestings_pkey PRIMARY KEY (config);
+
+
+--
+-- Name: sol_meteora_dbc_configs sol_meteora_dbc_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_configs
+    ADD CONSTRAINT sol_meteora_dbc_configs_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_dbc_migrations sol_meteora_dbc_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_migrations
+    ADD CONSTRAINT sol_meteora_dbc_migrations_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_meteora_dbc_pool_metrics sol_meteora_dbc_pool_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_pool_metrics
+    ADD CONSTRAINT sol_meteora_dbc_pool_metrics_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_dbc_pool_volatility_trackers sol_meteora_dbc_pool_volatility_trackers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_pool_volatility_trackers
+    ADD CONSTRAINT sol_meteora_dbc_pool_volatility_trackers_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_dbc_pools sol_meteora_dbc_pools_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_pools
+    ADD CONSTRAINT sol_meteora_dbc_pools_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_payments sol_payments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_payments
+    ADD CONSTRAINT sol_payments_pkey PRIMARY KEY (signature, instruction_index, route_index);
+
+
+--
+-- Name: sol_purchases sol_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_purchases
+    ADD CONSTRAINT sol_purchases_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_retry_queue sol_retry_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_retry_queue
+    ADD CONSTRAINT sol_retry_queue_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sol_reward_disbursements sol_reward_disbursements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_reward_disbursements
+    ADD CONSTRAINT sol_reward_disbursements_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_reward_manager_inits sol_reward_manager_inits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_reward_manager_inits
+    ADD CONSTRAINT sol_reward_manager_inits_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_slot_checkpoints sol_slot_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_slot_checkpoints
+    ADD CONSTRAINT sol_slot_checkpoints_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sol_token_account_balance_changes sol_token_account_balance_changes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_token_account_balance_changes
+    ADD CONSTRAINT sol_token_account_balance_changes_pkey PRIMARY KEY (signature, mint, account);
+
+
+--
+-- Name: sol_token_account_balances sol_token_account_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_token_account_balances
+    ADD CONSTRAINT sol_token_account_balances_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_token_transfers sol_token_transfers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_token_transfers
+    ADD CONSTRAINT sol_token_transfers_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_user_balances sol_user_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_user_balances
+    ADD CONSTRAINT sol_user_balances_pkey PRIMARY KEY (user_id, mint);
+
+
+--
+-- Name: spl_token_tx spl_token_tx_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.spl_token_tx
+    ADD CONSTRAINT spl_token_tx_pkey PRIMARY KEY (last_scanned_slot);
+
+
+--
+-- Name: stems stems_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stems
+    ADD CONSTRAINT stems_pkey PRIMARY KEY (parent_track_id, child_track_id);
+
+
+--
+-- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (txhash, user_id, subscriber_id);
+
+
+--
+-- Name: supporter_rank_ups supporter_rank_ups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.supporter_rank_ups
+    ADD CONSTRAINT supporter_rank_ups_pkey PRIMARY KEY (slot, sender_user_id, receiver_user_id);
+
+
+--
+-- Name: track_delist_statuses track_delist_statuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_delist_statuses
+    ADD CONSTRAINT track_delist_statuses_pkey PRIMARY KEY (created_at, track_id, delisted);
+
+
+--
+-- Name: track_downloads track_downloads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_downloads
+    ADD CONSTRAINT track_downloads_pkey PRIMARY KEY (parent_track_id, track_id, txhash);
+
+
+--
+-- Name: track_price_history track_price_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_price_history
+    ADD CONSTRAINT track_price_history_pkey PRIMARY KEY (track_id, block_timestamp);
+
+
+--
+-- Name: track_routes track_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_routes
+    ADD CONSTRAINT track_routes_pkey PRIMARY KEY (owner_id, slug);
+
+
+--
+-- Name: track_trending_scores track_trending_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_trending_scores
+    ADD CONSTRAINT track_trending_scores_pkey PRIMARY KEY (track_id, type, version, time_range);
+
+
+--
+-- Name: tracks tracks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.tracks
+    ADD CONSTRAINT tracks_pkey PRIMARY KEY (txhash, track_id);
+
+
+--
+-- Name: trending_results trending_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.trending_results
+    ADD CONSTRAINT trending_results_pkey PRIMARY KEY (rank, type, version, week);
+
+
+--
+-- Name: developer_apps unique_developer_apps_address; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.developer_apps
+    ADD CONSTRAINT unique_developer_apps_address UNIQUE (address);
+
+
+--
+-- Name: associated_wallets unique_user_wallet_chain; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.associated_wallets
+    ADD CONSTRAINT unique_user_wallet_chain UNIQUE (user_id, wallet, chain);
+
+
+--
+-- Name: notification uq_notification; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification
+    ADD CONSTRAINT uq_notification UNIQUE (group_id, specifier);
+
+
+--
+-- Name: usdc_purchases usdc_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usdc_purchases
+    ADD CONSTRAINT usdc_purchases_pkey PRIMARY KEY (slot, signature);
+
+
+--
+-- Name: usdc_transactions_history usdc_transactions_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usdc_transactions_history
+    ADD CONSTRAINT usdc_transactions_history_pkey PRIMARY KEY (user_bank, signature);
+
+
+--
+-- Name: usdc_user_bank_accounts usdc_user_bank_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usdc_user_bank_accounts
+    ADD CONSTRAINT usdc_user_bank_accounts_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: user_balance_changes user_balance_changes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_balance_changes
+    ADD CONSTRAINT user_balance_changes_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_balance_history user_balance_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_balance_history
+    ADD CONSTRAINT user_balance_history_pkey PRIMARY KEY (user_id, "timestamp", mint);
+
+
+--
+-- Name: user_balances user_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_balances
+    ADD CONSTRAINT user_balances_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_bank_accounts user_bank_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_bank_accounts
+    ADD CONSTRAINT user_bank_accounts_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: user_bank_txs user_bank_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_bank_txs
+    ADD CONSTRAINT user_bank_txs_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: user_challenges user_challenges_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_challenges
+    ADD CONSTRAINT user_challenges_pkey PRIMARY KEY (challenge_id, specifier);
+
+
+--
+-- Name: user_delist_statuses user_delist_statuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_delist_statuses
+    ADD CONSTRAINT user_delist_statuses_pkey PRIMARY KEY (created_at, user_id, delisted);
+
+
+--
+-- Name: user_distinct_play_hours user_distinct_play_hours_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_distinct_play_hours
+    ADD CONSTRAINT user_distinct_play_hours_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_distinct_play_tracks user_distinct_play_tracks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_distinct_play_tracks
+    ADD CONSTRAINT user_distinct_play_tracks_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_events user_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_events
+    ADD CONSTRAINT user_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_listening_history user_listening_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_listening_history
+    ADD CONSTRAINT user_listening_history_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_payout_wallet_history user_payout_wallet_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_payout_wallet_history
+    ADD CONSTRAINT user_payout_wallet_history_pkey PRIMARY KEY (user_id, block_timestamp);
+
+
+--
+-- Name: user_pubkeys user_pubkeys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_pubkeys
+    ADD CONSTRAINT user_pubkeys_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_score_features user_score_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_score_features
+    ADD CONSTRAINT user_score_features_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_tips user_tips_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_tips
+    ADD CONSTRAINT user_tips_pkey PRIMARY KEY (slot, signature);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (txhash, user_id);
+
+
+--
+-- Name: volume_leader_exclusions volume_leader_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.volume_leader_exclusions
+    ADD CONSTRAINT volume_leader_exclusions_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: agg_user_has_tracks_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agg_user_has_tracks_idx ON public.aggregate_user USING btree (user_id) WHERE (total_track_count > 0);
+
+
+--
+-- Name: artist_coins_ticker_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX artist_coins_ticker_idx ON public.artist_coins USING btree (ticker, user_id);
+
+
+--
+-- Name: INDEX artist_coins_ticker_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.artist_coins_ticker_idx IS 'Used for getting mint address by ticker.';
+
+
+--
+-- Name: artist_coins_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX artist_coins_user_id_idx ON public.artist_coins USING btree (user_id);
+
+
+--
+-- Name: INDEX artist_coins_user_id_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.artist_coins_user_id_idx IS 'Used for getting coins minted by a particular artist.';
+
+
+--
+-- Name: blocks_is_current_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX blocks_is_current_idx ON public.blocks USING btree (is_current) WHERE (is_current IS TRUE);
+
+
+--
+-- Name: challenge_disbursements_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX challenge_disbursements_user_id ON public.challenge_disbursements USING btree (user_id);
+
+
+--
+-- Name: chat_chat_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX chat_chat_id_idx ON public.chat USING btree (chat_id);
+
+
+--
+-- Name: chat_member_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX chat_member_user_idx ON public.chat_member USING btree (user_id);
+
+
+--
+-- Name: claimed_prizes_mint_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX claimed_prizes_mint_idx ON public.claimed_prizes USING btree (mint);
+
+
+--
+-- Name: INDEX claimed_prizes_mint_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.claimed_prizes_mint_idx IS 'Used for getting claimed prizes by coin mint.';
+
+
+--
+-- Name: claimed_prizes_signature_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX claimed_prizes_signature_idx ON public.claimed_prizes USING btree (signature);
+
+
+--
+-- Name: INDEX claimed_prizes_signature_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.claimed_prizes_signature_idx IS 'Used for checking if a signature has already been used.';
+
+
+--
+-- Name: claimed_prizes_wallet_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX claimed_prizes_wallet_idx ON public.claimed_prizes USING btree (wallet);
+
+
+--
+-- Name: INDEX claimed_prizes_wallet_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.claimed_prizes_wallet_idx IS 'Used for getting claimed prizes by wallet.';
+
+
+--
+-- Name: fix_tracks_top_genre_users_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX fix_tracks_top_genre_users_idx ON public.tracks USING btree (track_id, owner_id, genre, is_unlisted, is_delete) WHERE (stem_of IS NULL);
+
+
+--
+-- Name: follows_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX follows_blocknumber_idx ON public.follows USING btree (blocknumber);
+
+
+--
+-- Name: follows_inbound_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX follows_inbound_idx ON public.follows USING btree (followee_user_id, follower_user_id, is_delete);
+
+
+--
+-- Name: idx_aggregate_user_follower_count; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_aggregate_user_follower_count ON public.aggregate_user USING btree (user_id, follower_count);
+
+
+--
+-- Name: idx_api_access_keys_api_access_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_access_keys_api_access_key ON public.api_access_keys USING btree (api_access_key);
+
+
+--
+-- Name: idx_api_access_keys_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_access_keys_is_active ON public.api_access_keys USING btree (api_key, is_active) WHERE (is_active = true);
+
+
+--
+-- Name: idx_api_metrics_apps_api_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_apps_api_key ON public.api_metrics_apps USING btree (api_key) WHERE (api_key IS NOT NULL);
+
+
+--
+-- Name: idx_api_metrics_apps_app_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_apps_app_name ON public.api_metrics_apps USING btree (app_name) WHERE (app_name IS NOT NULL);
+
+
+--
+-- Name: idx_api_metrics_apps_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_apps_date ON public.api_metrics_apps USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_apps_unique_app_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_apps_unique_app_name ON public.api_metrics_apps_unique USING btree (app_name);
+
+
+--
+-- Name: idx_api_metrics_apps_unique_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_apps_unique_date ON public.api_metrics_apps_unique USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_counts_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_counts_date ON public.api_metrics_counts USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_routes_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_routes_date ON public.api_metrics_routes USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_routes_method; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_routes_method ON public.api_metrics_routes USING btree (method);
+
+
+--
+-- Name: idx_api_metrics_routes_route_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_api_metrics_routes_route_pattern ON public.api_metrics_routes USING btree (route_pattern);
+
+
+--
+-- Name: idx_chain_blockhash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chain_blockhash ON public.core_indexed_blocks USING btree (blockhash);
+
+
+--
+-- Name: idx_chain_id_height; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chain_id_height ON public.core_indexed_blocks USING btree (chain_id, height);
+
+
+--
+-- Name: idx_challenge_disbursements_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_challenge_disbursements_created_at ON public.challenge_disbursements USING btree (created_at);
+
+
+--
+-- Name: idx_challenge_disbursements_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_challenge_disbursements_slot ON public.challenge_disbursements USING btree (slot);
+
+
+--
+-- Name: idx_chat_message_chat_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chat_message_chat_id ON public.chat_message USING btree (chat_id);
+
+
+--
+-- Name: idx_chat_message_reactions_message_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chat_message_reactions_message_id ON public.chat_message_reactions USING btree (message_id);
+
+
+--
+-- Name: idx_chat_message_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chat_message_user_id ON public.chat_message USING btree (user_id, created_at);
+
+
+--
+-- Name: idx_ddex_release_ids; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_ddex_release_ids ON public.tracks USING gin (ddex_release_ids);
+
+
+--
+-- Name: idx_email_access_grantor; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_access_grantor ON public.email_access USING btree (grantor_user_id);
+
+
+--
+-- Name: idx_email_access_receiver; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_email_access_receiver ON public.email_access USING btree (receiving_user_id);
+
+
+--
+-- Name: idx_encrypted_emails_email_address_owner_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_encrypted_emails_email_address_owner_user_id ON public.encrypted_emails USING btree (email_owner_user_id);
+
+
+--
+-- Name: idx_events_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_created_at ON public.events USING btree (created_at);
+
+
+--
+-- Name: idx_events_end_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_end_date ON public.events USING btree (end_date);
+
+
+--
+-- Name: idx_events_entity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_entity_id ON public.events USING btree (entity_id);
+
+
+--
+-- Name: idx_events_entity_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_entity_type ON public.events USING btree (entity_type);
+
+
+--
+-- Name: idx_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_event_type ON public.events USING btree (event_type);
+
+
+--
+-- Name: idx_fanout; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_fanout ON public.follows USING btree (follower_user_id, followee_user_id);
+
+
+--
+-- Name: idx_fanout_not_deleted; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_fanout_not_deleted ON public.follows USING btree (follower_user_id, followee_user_id) WHERE (is_delete = false);
+
+
+--
+-- Name: idx_genre_related_artists; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_genre_related_artists ON public.aggregate_user USING btree (dominant_genre, follower_count, user_id);
+
+
+--
+-- Name: idx_lower_wallet; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_lower_wallet ON public.users USING btree (lower((wallet)::text));
+
+
+--
+-- Name: idx_oauth_authorization_codes_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_authorization_codes_client_id ON public.oauth_authorization_codes USING btree (client_id);
+
+
+--
+-- Name: idx_oauth_authorization_codes_expires_used; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_authorization_codes_expires_used ON public.oauth_authorization_codes USING btree (expires_at, used);
+
+
+--
+-- Name: idx_oauth_redirect_uris_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_redirect_uris_client_id ON public.oauth_redirect_uris USING btree (client_id);
+
+
+--
+-- Name: idx_oauth_tokens_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_tokens_client_id ON public.oauth_tokens USING btree (client_id);
+
+
+--
+-- Name: idx_oauth_tokens_family_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_tokens_family_id ON public.oauth_tokens USING btree (family_id);
+
+
+--
+-- Name: idx_oauth_tokens_lookup; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_tokens_lookup ON public.oauth_tokens USING btree (token, token_type, is_revoked, expires_at);
+
+
+--
+-- Name: idx_oauth_tokens_refresh_token_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_tokens_refresh_token_id ON public.oauth_tokens USING btree (refresh_token_id);
+
+
+--
+-- Name: idx_oauth_tokens_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_oauth_tokens_user_id ON public.oauth_tokens USING btree (user_id);
+
+
+--
+-- Name: idx_payment_router_txs_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_payment_router_txs_slot ON public.payment_router_txs USING btree (slot);
+
+
+--
+-- Name: idx_playlist_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_playlist_status ON public.playlists USING btree (playlist_id, is_album, is_private, is_delete, is_current);
+
+
+--
+-- Name: idx_playlist_tracks_track_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_playlist_tracks_track_id ON public.playlist_tracks USING btree (track_id, created_at);
+
+
+--
+-- Name: idx_reward_manager_txs_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_reward_manager_txs_slot ON public.reward_manager_txs USING btree (slot);
+
+
+--
+-- Name: idx_rpc_relayed_by; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rpc_relayed_by ON public.rpc_log USING btree (relayed_by, relayed_at);
+
+
+--
+-- Name: idx_sol_reward_manager_inits_mint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_sol_reward_manager_inits_mint ON public.sol_reward_manager_inits USING btree (mint);
+
+
+--
+-- Name: INDEX idx_sol_reward_manager_inits_mint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.idx_sol_reward_manager_inits_mint IS 'Index to quickly find reward manager init instructions by mint of its token rewards';
+
+
+--
+-- Name: idx_track_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_track_status ON public.tracks USING btree (track_id, is_unlisted, is_available, is_delete, is_current);
+
+
+--
+-- Name: idx_tts_genre_time_score; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_tts_genre_time_score ON public.track_trending_scores USING btree (genre, time_range, score DESC, track_id);
+
+
+--
+-- Name: idx_usdc_purchases_buyer; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_usdc_purchases_buyer ON public.usdc_purchases USING btree (buyer_user_id);
+
+
+--
+-- Name: idx_usdc_purchases_seller; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_usdc_purchases_seller ON public.usdc_purchases USING btree (seller_user_id);
+
+
+--
+-- Name: idx_usdc_purchases_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_usdc_purchases_type ON public.usdc_purchases USING btree (content_type);
+
+
+--
+-- Name: idx_usdc_transactions_history_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_usdc_transactions_history_slot ON public.usdc_transactions_history USING btree (slot);
+
+
+--
+-- Name: idx_usdc_transactions_history_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_usdc_transactions_history_type ON public.usdc_transactions_history USING btree (transaction_type);
+
+
+--
+-- Name: idx_usdc_user_bank_accounts_eth_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_usdc_user_bank_accounts_eth_address ON public.usdc_user_bank_accounts USING btree (ethereum_address);
+
+
+--
+-- Name: idx_user_bank_eth_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_bank_eth_address ON public.user_bank_accounts USING btree (ethereum_address);
+
+
+--
+-- Name: idx_user_bank_txs_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_bank_txs_slot ON public.user_bank_txs USING btree (slot);
+
+
+--
+-- Name: idx_user_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_status ON public.users USING btree (user_id, is_deactivated, is_available, is_current);
+
+
+--
+-- Name: interval_play_month_count_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX interval_play_month_count_idx ON public.aggregate_interval_plays USING btree (month_listen_counts);
+
+
+--
+-- Name: interval_play_track_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX interval_play_track_id_idx ON public.aggregate_interval_plays USING btree (track_id);
+
+
+--
+-- Name: interval_play_week_count_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX interval_play_week_count_idx ON public.aggregate_interval_plays USING btree (week_listen_counts);
+
+
+--
+-- Name: is_current_blocks_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX is_current_blocks_idx ON public.blocks USING btree (is_current);
+
+
+--
+-- Name: ix_aggregate_user_tips_receiver_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_aggregate_user_tips_receiver_user_id ON public.aggregate_user_tips USING btree (receiver_user_id);
+
+
+--
+-- Name: ix_announcement; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_announcement ON public.notification USING btree (type, "timestamp") WHERE ((type)::text = 'announcement'::text);
+
+
+--
+-- Name: ix_associated_wallets_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_associated_wallets_user_id ON public.associated_wallets USING btree (user_id);
+
+
+--
+-- Name: ix_associated_wallets_wallet; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_associated_wallets_wallet ON public.associated_wallets USING btree (wallet);
+
+
+--
+-- Name: ix_au_user_follows; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_au_user_follows ON public.aggregate_user USING btree (user_id) INCLUDE (follower_count, following_count);
+
+
+--
+-- Name: INDEX ix_au_user_follows; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.ix_au_user_follows IS 'Fast lookup for fields use in karma calculation';
+
+
+--
+-- Name: ix_audio_transactions_history_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audio_transactions_history_slot ON public.audio_transactions_history USING btree (slot);
+
+
+--
+-- Name: ix_audio_transactions_history_transaction_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audio_transactions_history_transaction_type ON public.audio_transactions_history USING btree (transaction_type);
+
+
+--
+-- Name: ix_follows_followee_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_follows_followee_user_id ON public.follows USING btree (followee_user_id);
+
+
+--
+-- Name: ix_follows_follower_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_follows_follower_user_id ON public.follows USING btree (follower_user_id);
+
+
+--
+-- Name: ix_notification; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_notification ON public.notification USING gin (user_ids);
+
+
+--
+-- Name: ix_playlist_trending_scores_playlist_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_playlist_trending_scores_playlist_id ON public.playlist_trending_scores USING btree (playlist_id);
+
+
+--
+-- Name: ix_plays_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_plays_created_at ON public.plays USING btree (created_at);
+
+
+--
+-- Name: ix_plays_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_plays_slot ON public.plays USING btree (slot);
+
+
+--
+-- Name: ix_plays_sol_signature; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_plays_sol_signature ON public.plays USING btree (signature);
+
+
+--
+-- Name: ix_plays_user_hour; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_plays_user_hour ON public.plays USING btree (user_id, date_trunc('hour'::text, created_at)) WHERE (user_id IS NOT NULL);
+
+
+--
+-- Name: INDEX ix_plays_user_hour; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.ix_plays_user_hour IS 'Helps compute distinct hourly plays by user id';
+
+
+--
+-- Name: ix_plays_user_track_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_plays_user_track_date ON public.plays USING btree (user_id, play_item_id, created_at) WHERE (user_id IS NOT NULL);
+
+
+--
+-- Name: ix_reactions_reacted_to_reaction_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_reactions_reacted_to_reaction_type ON public.reactions USING btree (reacted_to, reaction_type);
+
+
+--
+-- Name: ix_subscriptions_blocknumber; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_subscriptions_blocknumber ON public.subscriptions USING btree (blocknumber);
+
+
+--
+-- Name: ix_subscriptions_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_subscriptions_user_id ON public.subscriptions USING btree (user_id);
+
+
+--
+-- Name: ix_supporter_rank_ups_receiver_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_supporter_rank_ups_receiver_user_id ON public.supporter_rank_ups USING btree (receiver_user_id);
+
+
+--
+-- Name: ix_supporter_rank_ups_sender_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_supporter_rank_ups_sender_user_id ON public.supporter_rank_ups USING btree (sender_user_id);
+
+
+--
+-- Name: ix_supporter_rank_ups_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_supporter_rank_ups_slot ON public.supporter_rank_ups USING btree (slot);
+
+
+--
+-- Name: ix_track_trending_scores_genre; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_track_trending_scores_genre ON public.track_trending_scores USING btree (genre);
+
+
+--
+-- Name: ix_track_trending_scores_track_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_track_trending_scores_track_id ON public.track_trending_scores USING btree (track_id);
+
+
+--
+-- Name: ix_trending_scores; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_trending_scores ON public.track_trending_scores USING btree (type, version, time_range, score DESC, track_id);
+
+
+--
+-- Name: ix_user_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_user_created_at ON public.users USING btree (created_at, user_id, is_current);
+
+
+--
+-- Name: ix_user_tips_receiver_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_user_tips_receiver_user_id ON public.user_tips USING btree (receiver_user_id);
+
+
+--
+-- Name: ix_user_tips_sender_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_user_tips_sender_user_id ON public.user_tips USING btree (sender_user_id);
+
+
+--
+-- Name: ix_user_tips_slot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_user_tips_slot ON public.user_tips USING btree (slot);
+
+
+--
+-- Name: milestones_name_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX milestones_name_idx ON public.milestones USING btree (name, id);
+
+
+--
+-- Name: notification_seen_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX notification_seen_blocknumber_idx ON public.notification_seen USING btree (blocknumber);
+
+
+--
+-- Name: playlist_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX playlist_created_at_idx ON public.playlists USING btree (created_at);
+
+
+--
+-- Name: playlist_owner_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX playlist_owner_idx ON public.playlists USING btree (playlist_owner_id, created_at);
+
+
+--
+-- Name: playlist_routes_playlist_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX playlist_routes_playlist_id_idx ON public.playlist_routes USING btree (playlist_id);
+
+
+--
+-- Name: playlists_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX playlists_blocknumber_idx ON public.playlists USING btree (blocknumber);
+
+
+--
+-- Name: prizes_active_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX prizes_active_idx ON public.prizes USING btree (is_active);
+
+
+--
+-- Name: INDEX prizes_active_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.prizes_active_idx IS 'Used for filtering active prizes.';
+
+
+--
+-- Name: related_artists_related_artist_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX related_artists_related_artist_id_idx ON public.related_artists USING btree (related_artist_user_id, user_id);
+
+
+--
+-- Name: remixes_child_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX remixes_child_idx ON public.remixes USING btree (child_track_id, parent_track_id);
+
+
+--
+-- Name: reposts_item_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX reposts_item_idx ON public.reposts USING btree (repost_item_id, repost_type, user_id, is_delete);
+
+
+--
+-- Name: reposts_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX reposts_new_blocknumber_idx ON public.reposts USING btree (blocknumber);
+
+
+--
+-- Name: reposts_new_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX reposts_new_created_at_idx ON public.reposts USING btree (created_at);
+
+
+--
+-- Name: reposts_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX reposts_user_idx ON public.reposts USING btree (user_id, repost_type, repost_item_id, created_at, is_delete);
+
+
+--
+-- Name: reward_codes_mint_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX reward_codes_mint_idx ON public.reward_codes USING btree (mint);
+
+
+--
+-- Name: reward_codes_reward_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX reward_codes_reward_address_idx ON public.reward_codes USING btree (reward_address);
+
+
+--
+-- Name: rpc_log_applied_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX rpc_log_applied_at_idx ON public.rpc_log USING brin (applied_at);
+
+
+--
+-- Name: rpclog_method_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX rpclog_method_idx ON public.rpclog USING btree (method);
+
+
+--
+-- Name: rpclog_wallet_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX rpclog_wallet_idx ON public.rpclog USING btree (wallet);
+
+
+--
+-- Name: saves_item_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX saves_item_idx ON public.saves USING btree (save_item_id, save_type, user_id, is_delete);
+
+
+--
+-- Name: saves_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX saves_new_blocknumber_idx ON public.saves USING btree (blocknumber);
+
+
+--
+-- Name: saves_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX saves_user_idx ON public.saves USING btree (user_id, save_type, save_item_id, is_delete);
+
+
+--
+-- Name: shares_item_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX shares_item_idx ON public.shares USING btree (share_item_id, share_type, user_id);
+
+
+--
+-- Name: shares_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX shares_new_blocknumber_idx ON public.shares USING btree (blocknumber);
+
+
+--
+-- Name: shares_new_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX shares_new_created_at_idx ON public.shares USING btree (created_at);
+
+
+--
+-- Name: shares_slot_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX shares_slot_idx ON public.shares USING btree (slot);
+
+
+--
+-- Name: shares_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX shares_user_idx ON public.shares USING btree (user_id, share_type, share_item_id, created_at);
+
+
+--
+-- Name: sol_claimable_account_transfers_from_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_claimable_account_transfers_from_idx ON public.sol_claimable_account_transfers USING btree (from_account);
+
+
+--
+-- Name: INDEX sol_claimable_account_transfers_from_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_claimable_account_transfers_from_idx IS 'Used for getting transfers by recipient.';
+
+
+--
+-- Name: sol_claimable_account_transfers_sender_eth_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_claimable_account_transfers_sender_eth_address_idx ON public.sol_claimable_account_transfers USING btree (sender_eth_address);
+
+
+--
+-- Name: INDEX sol_claimable_account_transfers_sender_eth_address_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_claimable_account_transfers_sender_eth_address_idx IS 'Used for getting transfers by sender user wallet.';
+
+
+--
+-- Name: sol_claimable_account_transfers_to_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_claimable_account_transfers_to_idx ON public.sol_claimable_account_transfers USING btree (to_account);
+
+
+--
+-- Name: INDEX sol_claimable_account_transfers_to_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_claimable_account_transfers_to_idx IS 'Used for getting transfers by sender.';
+
+
+--
+-- Name: sol_claimable_accounts_account_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_claimable_accounts_account_idx ON public.sol_claimable_accounts USING btree (account);
+
+
+--
+-- Name: INDEX sol_claimable_accounts_account_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_claimable_accounts_account_idx IS 'Used for getting user wallet by account.';
+
+
+--
+-- Name: sol_claimable_accounts_ethereum_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_claimable_accounts_ethereum_address_idx ON public.sol_claimable_accounts USING btree (ethereum_address, mint);
+
+
+--
+-- Name: INDEX sol_claimable_accounts_ethereum_address_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_claimable_accounts_ethereum_address_idx IS 'Used for getting account by user wallet and mint.';
+
+
+--
+-- Name: sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a ON public.sol_meteora_damm_v2_initialize_custom_pool_instructions USING btree (token_a_mint);
+
+
+--
+-- Name: INDEX sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a IS 'Used for finding artist positions by token_a_mint.';
+
+
+--
+-- Name: sol_meteora_dbc_migrations_base_mint_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_meteora_dbc_migrations_base_mint_idx ON public.sol_meteora_dbc_migrations USING btree (base_mint);
+
+
+--
+-- Name: INDEX sol_meteora_dbc_migrations_base_mint_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_meteora_dbc_migrations_base_mint_idx IS 'Used for finding artist positions by base_mint.';
+
+
+--
+-- Name: sol_payments_to_account; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_payments_to_account ON public.sol_payments USING btree (to_account);
+
+
+--
+-- Name: INDEX sol_payments_to_account; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_payments_to_account IS 'Used for getting payments to a particular user.';
+
+
+--
+-- Name: sol_purchases_buyer_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_purchases_buyer_user_id_idx ON public.sol_purchases USING btree (buyer_user_id, is_valid);
+
+
+--
+-- Name: INDEX sol_purchases_buyer_user_id_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_purchases_buyer_user_id_idx IS 'Used for getting purchases by a user.';
+
+
+--
+-- Name: sol_purchases_content_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_purchases_content_idx ON public.sol_purchases USING btree (content_id, content_type, access_type, is_valid);
+
+
+--
+-- Name: INDEX sol_purchases_content_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_purchases_content_idx IS 'Used for getting sales of particular content.';
+
+
+--
+-- Name: sol_purchases_from_account_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_purchases_from_account_idx ON public.sol_purchases USING btree (from_account, is_valid);
+
+
+--
+-- Name: INDEX sol_purchases_from_account_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_purchases_from_account_idx IS 'Used for getting purchases by a user via their account.';
+
+
+--
+-- Name: sol_purchases_valid_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_purchases_valid_idx ON public.sol_purchases USING btree (is_valid, valid_after_blocknumber);
+
+
+--
+-- Name: INDEX sol_purchases_valid_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_purchases_valid_idx IS 'Used for updating purchases to be valid after the specified blocknumber is reached.';
+
+
+--
+-- Name: sol_reward_disbursements_challenge_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_reward_disbursements_challenge_idx ON public.sol_reward_disbursements USING btree (challenge_id, specifier);
+
+
+--
+-- Name: INDEX sol_reward_disbursements_challenge_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_reward_disbursements_challenge_idx IS 'Used for getting reward disbursements for a specific challenge type or claim.';
+
+
+--
+-- Name: sol_reward_disbursements_user_bank_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_reward_disbursements_user_bank_idx ON public.sol_reward_disbursements USING btree (user_bank);
+
+
+--
+-- Name: INDEX sol_reward_disbursements_user_bank_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_reward_disbursements_user_bank_idx IS 'Used for getting reward disbursements for a user.';
+
+
+--
+-- Name: sol_slot_checkpoints_from_slot_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_slot_checkpoints_from_slot_idx ON public.sol_slot_checkpoints USING btree (subscription_hash, from_slot);
+
+
+--
+-- Name: sol_slot_checkpoints_to_slot_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_slot_checkpoints_to_slot_idx ON public.sol_slot_checkpoints USING btree (subscription_hash, to_slot);
+
+
+--
+-- Name: sol_token_account_balance_changes_account_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_account_balance_changes_account_idx ON public.sol_token_account_balance_changes USING btree (account, slot);
+
+
+--
+-- Name: INDEX sol_token_account_balance_changes_account_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_token_account_balance_changes_account_idx IS 'Used for getting recent transactions by account.';
+
+
+--
+-- Name: sol_token_account_balance_changes_mint_block_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_account_balance_changes_mint_block_timestamp ON public.sol_token_account_balance_changes USING btree (mint, block_timestamp DESC);
+
+
+--
+-- Name: sol_token_account_balance_changes_mint_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_account_balance_changes_mint_idx ON public.sol_token_account_balance_changes USING btree (mint, slot);
+
+
+--
+-- Name: INDEX sol_token_account_balance_changes_mint_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_token_account_balance_changes_mint_idx IS 'Used for getting recent transactions by mint.';
+
+
+--
+-- Name: sol_token_account_balance_changes_owner_slot_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_account_balance_changes_owner_slot_idx ON public.sol_token_account_balance_changes USING btree (owner, slot DESC);
+
+
+--
+-- Name: INDEX sol_token_account_balance_changes_owner_slot_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_token_account_balance_changes_owner_slot_idx IS 'Used for associating connected wallets with the transaction.';
+
+
+--
+-- Name: sol_token_account_balances_mint_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_account_balances_mint_idx ON public.sol_token_account_balances USING btree (mint);
+
+
+--
+-- Name: INDEX sol_token_account_balances_mint_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_token_account_balances_mint_idx IS 'Used for getting current balances by mint.';
+
+
+--
+-- Name: sol_token_transfers_from_account_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_transfers_from_account_idx ON public.sol_token_transfers USING btree (from_account);
+
+
+--
+-- Name: sol_token_transfers_to_account_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_token_transfers_to_account_idx ON public.sol_token_transfers USING btree (to_account);
+
+
+--
+-- Name: sol_user_balances_mint_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_user_balances_mint_user_id_idx ON public.sol_user_balances USING btree (mint, user_id);
+
+
+--
+-- Name: INDEX sol_user_balances_mint_user_id_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.sol_user_balances_mint_user_id_idx IS 'Index for quick access to user balances by mint and user ID.';
+
+
+--
+-- Name: tag_track_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX tag_track_user_idx ON public.tag_track_user USING btree (tag, track_id, owner_id);
+
+
+--
+-- Name: tag_track_user_tag_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX tag_track_user_tag_idx ON public.tag_track_user USING btree (tag);
+
+
+--
+-- Name: track_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_created_at_idx ON public.tracks USING btree (created_at);
+
+
+--
+-- Name: track_delist_statuses_owner_id_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_delist_statuses_owner_id_created_at ON public.track_delist_statuses USING btree (owner_id, created_at);
+
+
+--
+-- Name: track_delist_statuses_track_cid_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_delist_statuses_track_cid_created_at ON public.track_delist_statuses USING btree (track_cid, created_at);
+
+
+--
+-- Name: track_is_premium_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_is_premium_idx ON public.tracks USING btree (is_stream_gated, is_delete);
+
+
+--
+-- Name: track_owner_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_owner_id_idx ON public.tracks USING btree (owner_id);
+
+
+--
+-- Name: track_owner_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_owner_idx ON public.tracks USING btree (owner_id, created_at);
+
+
+--
+-- Name: track_routes_track_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_routes_track_id_idx ON public.track_routes USING btree (track_id);
+
+
+--
+-- Name: tracks_ai_attribution_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX tracks_ai_attribution_user_id ON public.tracks USING btree (ai_attribution_user_id) WHERE (ai_attribution_user_id IS NOT NULL);
+
+
+--
+-- Name: tracks_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX tracks_blocknumber_idx ON public.tracks USING btree (blocknumber);
+
+
+--
+-- Name: tracks_track_cid_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX tracks_track_cid_idx ON public.tracks USING btree (track_cid, is_delete);
+
+
+--
+-- Name: trending_params_track_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX trending_params_track_id_idx ON public.trending_params USING btree (track_id);
+
+
+--
+-- Name: user_balance_history_timestamp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_balance_history_timestamp_idx ON public.user_balance_history USING btree ("timestamp" DESC);
+
+
+--
+-- Name: INDEX user_balance_history_timestamp_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.user_balance_history_timestamp_idx IS 'Optimizes queries finding recent balances across all users';
+
+
+--
+-- Name: user_balance_history_user_mint_timestamp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_balance_history_user_mint_timestamp_idx ON public.user_balance_history USING btree (user_id, mint, "timestamp");
+
+
+--
+-- Name: INDEX user_balance_history_user_mint_timestamp_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.user_balance_history_user_mint_timestamp_idx IS 'Optimizes queries filtering by specific mint(s) and time range (e.g., "show USDC balance history")';
+
+
+--
+-- Name: user_balance_history_user_timestamp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_balance_history_user_timestamp_idx ON public.user_balance_history USING btree (user_id, "timestamp");
+
+
+--
+-- Name: INDEX user_balance_history_user_timestamp_idx; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON INDEX public.user_balance_history_user_timestamp_idx IS 'Optimizes time-range queries for a user, ordered by timestamp ASC';
+
+
+--
+-- Name: user_challenges_challenge_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_challenges_challenge_idx ON public.user_challenges USING btree (challenge_id);
+
+
+--
+-- Name: user_challenges_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_challenges_user_id ON public.user_challenges USING btree (user_id);
+
+
+--
+-- Name: user_events_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_events_user_id_idx ON public.user_events USING btree (user_id);
+
+
+--
+-- Name: users_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX users_new_blocknumber_idx ON public.users USING btree (blocknumber);
+
+
+--
+-- Name: users_new_handle_lc_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX users_new_handle_lc_idx ON public.users USING btree (handle_lc);
+
+
+--
+-- Name: users_new_wallet_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX users_new_wallet_idx ON public.users USING btree (wallet);
+
+
+--
+-- Name: artist_coins on_artist_coins_change; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_artist_coins_change AFTER INSERT OR DELETE OR UPDATE ON public.artist_coins FOR EACH ROW EXECUTE FUNCTION public.handle_artist_coins_change();
+
+
+--
+-- Name: TRIGGER on_artist_coins_change ON artist_coins; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TRIGGER on_artist_coins_change ON public.artist_coins IS 'Notifies when artist coins are added, removed, or updated.';
+
+
+--
+-- Name: associated_wallets on_associated_wallets; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_associated_wallets AFTER INSERT OR DELETE OR UPDATE ON public.associated_wallets FOR EACH ROW EXECUTE FUNCTION public.handle_associated_wallets();
+
+
+--
+-- Name: TRIGGER on_associated_wallets ON associated_wallets; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TRIGGER on_associated_wallets ON public.associated_wallets IS 'Updates sol_user_balances when associated_wallets are added and removed';
+
+
+--
+-- Name: challenge_disbursements on_challenge_disbursement; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_challenge_disbursement AFTER INSERT ON public.challenge_disbursements FOR EACH ROW EXECUTE FUNCTION public.handle_challenge_disbursement();
+
+
+--
+-- Name: chat_blast on_chat_blast; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_chat_blast AFTER INSERT ON public.chat_blast FOR EACH ROW EXECUTE FUNCTION public.handle_chat_blast();
+
+
+--
+-- Name: chat_message on_chat_message; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_chat_message AFTER INSERT ON public.chat_message FOR EACH ROW EXECUTE FUNCTION public.handle_chat_message();
+
+
+--
+-- Name: chat_message_reactions on_chat_message_reaction_changed; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_chat_message_reaction_changed AFTER INSERT OR DELETE OR UPDATE ON public.chat_message_reactions FOR EACH ROW EXECUTE FUNCTION public.handle_chat_message_reaction_changed();
+
+
+--
+-- Name: comments on_comment; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_comment AFTER INSERT ON public.comments FOR EACH ROW EXECUTE FUNCTION public.handle_comment();
+
+
+--
+-- Name: sol_meteora_dbc_pools on_dbc_pool_change; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_dbc_pool_change AFTER INSERT ON public.sol_meteora_dbc_pools FOR EACH ROW EXECUTE FUNCTION public.handle_dbc_pool();
+
+
+--
+-- Name: TRIGGER on_dbc_pool_change ON sol_meteora_dbc_pools; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TRIGGER on_dbc_pool_change ON public.sol_meteora_dbc_pools IS 'Notifies when DBC pools are added, removed, or updated.';
+
+
+--
+-- Name: events on_event; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_event AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.handle_event();
+
+
+--
+-- Name: follows on_follow; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_follow AFTER INSERT ON public.follows FOR EACH ROW EXECUTE FUNCTION public.handle_follow();
+
+
+--
+-- Name: plays on_play; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_play AFTER INSERT ON public.plays FOR EACH ROW EXECUTE FUNCTION public.handle_play();
+
+
+--
+-- Name: playlists on_playlist; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_playlist AFTER INSERT ON public.playlists FOR EACH ROW EXECUTE FUNCTION public.handle_playlist();
+
+
+--
+-- Name: playlist_tracks on_playlist_track; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_playlist_track AFTER INSERT ON public.playlist_tracks FOR EACH ROW EXECUTE FUNCTION public.handle_playlist_track();
+
+
+--
+-- Name: reactions on_reaction; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_reaction AFTER INSERT ON public.reactions FOR EACH ROW EXECUTE FUNCTION public.handle_reaction();
+
+
+--
+-- Name: reposts on_repost; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_repost AFTER INSERT ON public.reposts FOR EACH ROW EXECUTE FUNCTION public.handle_repost();
+
+
+--
+-- Name: rpc_log on_rpc_log; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_rpc_log AFTER INSERT ON public.rpc_log FOR EACH ROW EXECUTE FUNCTION public.handle_comms_rpc_log();
+
+
+--
+-- Name: saves on_save; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_save AFTER INSERT ON public.saves FOR EACH ROW EXECUTE FUNCTION public.handle_save();
+
+
+--
+-- Name: shares on_share; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_share AFTER INSERT ON public.shares FOR EACH ROW EXECUTE FUNCTION public.handle_share();
+
+
+--
+-- Name: sol_claimable_accounts on_sol_claimable_accounts; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_sol_claimable_accounts AFTER INSERT ON public.sol_claimable_accounts FOR EACH ROW EXECUTE FUNCTION public.handle_sol_claimable_accounts();
+
+
+--
+-- Name: TRIGGER on_sol_claimable_accounts ON sol_claimable_accounts; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TRIGGER on_sol_claimable_accounts ON public.sol_claimable_accounts IS 'Updates sol_user_balances whenever a sol_claimable_account is inserted.';
+
+
+--
+-- Name: sol_token_account_balance_changes on_sol_token_account_balance_changes; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_sol_token_account_balance_changes AFTER INSERT ON public.sol_token_account_balance_changes FOR EACH ROW EXECUTE FUNCTION public.handle_sol_token_balance_change();
+
+
+--
+-- Name: TRIGGER on_sol_token_account_balance_changes ON sol_token_account_balance_changes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TRIGGER on_sol_token_account_balance_changes ON public.sol_token_account_balance_changes IS 'Updates sol_token_account_balances whenever a sol_token_balance_change is inserted with a higher slot.';
+
+
+--
+-- Name: supporter_rank_ups on_supporter_rank_up; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_supporter_rank_up AFTER INSERT ON public.supporter_rank_ups FOR EACH ROW EXECUTE FUNCTION public.handle_supporter_rank_up();
+
+
+--
+-- Name: tracks on_track; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_track AFTER INSERT OR UPDATE ON public.tracks FOR EACH ROW EXECUTE FUNCTION public.handle_track();
+
+
+--
+-- Name: usdc_purchases on_usdc_purchase; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_usdc_purchase AFTER INSERT ON public.usdc_purchases FOR EACH ROW EXECUTE FUNCTION public.handle_usdc_purchase();
+
+
+--
+-- Name: usdc_transactions_history on_usdc_withdrawal; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_usdc_withdrawal AFTER INSERT ON public.usdc_transactions_history FOR EACH ROW EXECUTE FUNCTION public.handle_usdc_withdrawal();
+
+
+--
+-- Name: users on_user; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_user AFTER INSERT ON public.users FOR EACH ROW EXECUTE FUNCTION public.handle_user();
+
+
+--
+-- Name: user_balance_changes on_user_balance_changes; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_user_balance_changes AFTER INSERT OR UPDATE ON public.user_balance_changes FOR EACH ROW EXECUTE FUNCTION public.handle_user_balance_change();
+
+
+--
+-- Name: user_challenges on_user_challenge; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_user_challenge AFTER INSERT OR UPDATE ON public.user_challenges FOR EACH ROW EXECUTE FUNCTION public.handle_on_user_challenge();
+
+
+--
+-- Name: user_tips on_user_tip; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_user_tip AFTER INSERT ON public.user_tips FOR EACH ROW EXECUTE FUNCTION public.handle_user_tip();
+
+
+--
+-- Name: aggregate_plays trg_aggregate_plays; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_aggregate_plays AFTER INSERT OR UPDATE ON public.aggregate_plays FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: aggregate_user trg_aggregate_user; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_aggregate_user AFTER INSERT OR UPDATE ON public.aggregate_user FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: artist_coins trg_artist_coins; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_artist_coins AFTER INSERT OR UPDATE ON public.artist_coins FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: follows trg_follows; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_follows AFTER INSERT OR UPDATE ON public.follows FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: playlists trg_playlists; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_playlists AFTER INSERT OR UPDATE ON public.playlists FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: reposts trg_reposts; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_reposts AFTER INSERT OR UPDATE ON public.reposts FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: saves trg_saves; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_saves AFTER INSERT OR UPDATE ON public.saves FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: shares trg_shares; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_shares AFTER INSERT OR UPDATE ON public.shares FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: tracks trg_tracks; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_tracks AFTER INSERT OR UPDATE ON public.tracks FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: usdc_purchases trg_usdc_purchases; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_usdc_purchases AFTER INSERT OR UPDATE ON public.usdc_purchases FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: users trg_users; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_users AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: grants trigger_grant_change; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_grant_change AFTER INSERT OR UPDATE ON public.grants FOR EACH ROW EXECUTE FUNCTION public.process_grant_change();
+
+
+--
+-- Name: album_price_history album_price_history_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.album_price_history
+    ADD CONSTRAINT album_price_history_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: associated_wallets associated_wallets_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.associated_wallets
+    ADD CONSTRAINT associated_wallets_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: chat_member chat_member_chat_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_member
+    ADD CONSTRAINT chat_member_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES public.chat(chat_id) ON DELETE CASCADE;
+
+
+--
+-- Name: chat_message chat_message_blast_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_message
+    ADD CONSTRAINT chat_message_blast_id_fkey FOREIGN KEY (blast_id) REFERENCES public.chat_blast(blast_id);
+
+
+--
+-- Name: chat_message chat_message_chat_member_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_message
+    ADD CONSTRAINT chat_message_chat_member_fkey FOREIGN KEY (chat_id, user_id) REFERENCES public.chat_member(chat_id, user_id) ON DELETE CASCADE;
+
+
+--
+-- Name: chat_message_reactions chat_message_reactions_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chat_message_reactions
+    ADD CONSTRAINT chat_message_reactions_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.chat_message(message_id) ON DELETE CASCADE;
+
+
+--
+-- Name: collectibles collectibles_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collectibles
+    ADD CONSTRAINT collectibles_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comment_mentions comment_mentions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_mentions
+    ADD CONSTRAINT comment_mentions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comment_reactions comment_reactions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_reactions
+    ADD CONSTRAINT comment_reactions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comment_reports comment_reports_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_reports
+    ADD CONSTRAINT comment_reports_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comments comments_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comments
+    ADD CONSTRAINT comments_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: dashboard_wallet_users dashboard_wallet_users_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dashboard_wallet_users
+    ADD CONSTRAINT dashboard_wallet_users_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: developer_apps developer_apps_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.developer_apps
+    ADD CONSTRAINT developer_apps_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: events events_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number);
+
+
+--
+-- Name: follows follows_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT follows_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: grants grants_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.grants
+    ADD CONSTRAINT grants_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: muted_users muted_users_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.muted_users
+    ADD CONSTRAINT muted_users_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: notification_seen notification_seen_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_seen
+    ADD CONSTRAINT notification_seen_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: playlist_seen playlist_seen_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlist_seen
+    ADD CONSTRAINT playlist_seen_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: playlists playlists_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlists
+    ADD CONSTRAINT playlists_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: reactions reactions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reactions
+    ADD CONSTRAINT reactions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: reported_comments reported_comments_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reported_comments
+    ADD CONSTRAINT reported_comments_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: reposts reposts_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reposts
+    ADD CONSTRAINT reposts_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: revert_blocks revert_blocks_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.revert_blocks
+    ADD CONSTRAINT revert_blocks_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: saves saves_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.saves
+    ADD CONSTRAINT saves_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_dbc_config_fees sol_meteora_dbc_config_fees_config_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_fees
+    ADD CONSTRAINT sol_meteora_dbc_config_fees_config_fkey FOREIGN KEY (config) REFERENCES public.sol_meteora_dbc_configs(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_dbc_config_vestings sol_meteora_dbc_config_vestings_config_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_vestings
+    ADD CONSTRAINT sol_meteora_dbc_config_vestings_config_fkey FOREIGN KEY (config) REFERENCES public.sol_meteora_dbc_configs(account) ON DELETE CASCADE;
+
+
+--
+-- Name: subscriptions subscriptions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: track_downloads track_downloads_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_downloads
+    ADD CONSTRAINT track_downloads_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: track_price_history track_price_history_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.track_price_history
+    ADD CONSTRAINT track_price_history_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: tracks tracks_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.tracks
+    ADD CONSTRAINT tracks_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: user_challenges user_challenges_challenge_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_challenges
+    ADD CONSTRAINT user_challenges_challenge_id_fkey FOREIGN KEY (challenge_id) REFERENCES public.challenges(id);
+
+
+--
+-- Name: user_events user_events_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_events
+    ADD CONSTRAINT user_events_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: user_payout_wallet_history user_payout_wallet_history_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_payout_wallet_history
+    ADD CONSTRAINT user_payout_wallet_history_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: users users_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+

--- a/cmd/genesis-replay/testdata/dp_seed.sql
+++ b/cmd/genesis-replay/testdata/dp_seed.sql
@@ -1,0 +1,7 @@
+-- Seed data required for the discovery provider indexer to start.
+-- The indexer expects a current block record to exist before it can process core events.
+INSERT INTO public.blocks (blockhash, parenthash, number, is_current)
+VALUES ('0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        0,
+        true);

--- a/cmd/genesis-replay/testdata/seed.sql
+++ b/cmd/genesis-replay/testdata/seed.sql
@@ -1,0 +1,328 @@
+-- Test seed data for genesis-replay verification.
+-- Covers: users, tracks (with remix), album, playlist, follows, reposts,
+--         saves, plays, comments (with reply), comment reactions, tip reactions.
+--
+-- ID ranges mirror production offsets:
+--   users:     >= 3,000,000
+--   tracks:    >= 2,000,000
+--   playlists: >= 400,000
+--   comments:  >= 4,000,000
+--
+-- All rows share a single block so there is only one FK dependency to satisfy.
+
+-- ============================================================
+-- BLOCK (anchor for all FK references)
+-- ============================================================
+
+INSERT INTO blocks (blockhash, number, parenthash, is_current) VALUES
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1, '0x0000000000000000000000000000000000000000000000000000000000000000', true);
+
+-- ============================================================
+-- USERS
+-- user1 = artist (has tracks, album)
+-- user2 = artist (has tracks)
+-- user3 = artist (has tracks, is remixed by user2)
+-- user4 = fan (follows, saves, reposts, comments)
+-- user5 = fan (follows, reacts)
+-- ============================================================
+
+INSERT INTO users (
+  blockhash, blocknumber, user_id, is_current, txhash,
+  handle, handle_lc, wallet, name, bio, location,
+  is_verified, is_deactivated, is_available, is_storage_v2,
+  allow_ai_attribution, created_at, updated_at
+) VALUES
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    3000001, true, '0xaaa0000000000000000000000000000000000000000000000000000000000001',
+    'artist_one', 'artist_one', '0xAAAA000000000000000000000000000000000001',
+    'Artist One', 'Electronic producer based in LA', 'Los Angeles, CA',
+    false, false, true, true, false,
+    '2021-01-01 00:00:00', '2021-01-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    3000002, true, '0xaaa0000000000000000000000000000000000000000000000000000000000002',
+    'artist_two', 'artist_two', '0xAAAA000000000000000000000000000000000002',
+    'Artist Two', 'Indie rock and folk', 'Nashville, TN',
+    false, false, true, true, false,
+    '2021-02-01 00:00:00', '2021-02-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    3000003, true, '0xaaa0000000000000000000000000000000000000000000000000000000000003',
+    'artist_three', 'artist_three', '0xAAAA000000000000000000000000000000000003',
+    'Artist Three', 'Jazz and soul', 'New York, NY',
+    true, false, true, true, false,
+    '2021-03-01 00:00:00', '2021-03-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    3000004, true, '0xaaa0000000000000000000000000000000000000000000000000000000000004',
+    'fan_four', 'fan_four', '0xAAAA000000000000000000000000000000000004',
+    'Fan Four', NULL, NULL,
+    false, false, true, false, false,
+    '2021-04-01 00:00:00', '2021-04-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    3000005, true, '0xaaa0000000000000000000000000000000000000000000000000000000000005',
+    'fan_five', 'fan_five', '0xAAAA000000000000000000000000000000000005',
+    'Fan Five', NULL, NULL,
+    false, false, true, false, false,
+    '2021-05-01 00:00:00', '2021-05-01 00:00:00'
+  );
+
+-- ============================================================
+-- TRACKS
+-- 2000001: user1 original track
+-- 2000002: user1 second track (unlisted)
+-- 2000003: user2 track (remix of 2000001)
+-- 2000004: user3 track
+-- ============================================================
+
+INSERT INTO tracks (
+  blockhash, blocknumber, track_id, is_current, is_delete, txhash,
+  owner_id, title, duration, genre, mood, tags,
+  track_cid, cover_art_sizes,
+  track_segments, is_downloadable, is_original_available,
+  is_unlisted, is_scheduled_release, is_stream_gated, is_download_gated,
+  is_available, is_playlist_upload, is_owned_by_user,
+  remix_of, stem_of,
+  comments_disabled, no_ai_use,
+  created_at, updated_at
+) VALUES
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    2000001, true, false,
+    '0xbbb0000000000000000000000000000000000000000000000000000000000001',
+    3000001, 'Sunrise Drive', 210, 'Electronic', 'Energizing', 'electronic,synth',
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01',
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa02',
+    '[]', true, false,
+    false, false, false, false,
+    true, false, true,
+    NULL, NULL,
+    false, false,
+    '2021-06-01 00:00:00', '2021-06-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    2000002, true, false,
+    '0xbbb0000000000000000000000000000000000000000000000000000000000002',
+    3000001, 'Hidden Gem (Unlisted)', 180, 'Electronic', 'Melancholic', NULL,
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa03',
+    NULL,
+    '[]', false, false,
+    true, false, false, false,
+    true, false, true,
+    NULL, NULL,
+    false, false,
+    '2021-06-15 00:00:00', '2021-06-15 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    2000003, true, false,
+    '0xbbb0000000000000000000000000000000000000000000000000000000000003',
+    3000002, 'Sunrise Drive (Remix)', 195, 'Electronic', 'Energizing', 'remix,electronic',
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa04',
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05',
+    '[]', false, false,
+    false, false, false, false,
+    true, false, false,
+    '{"tracks": [{"parent_track_id": 2000001}]}', NULL,
+    false, false,
+    '2021-07-01 00:00:00', '2021-07-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    2000004, true, false,
+    '0xbbb0000000000000000000000000000000000000000000000000000000000004',
+    3000003, 'Blue Note Sessions', 320, 'Jazz', 'Peaceful', 'jazz,live',
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa06',
+    'baeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa07',
+    '[]', true, true,
+    false, false, false, false,
+    true, false, true,
+    NULL, NULL,
+    false, false,
+    '2021-08-01 00:00:00', '2021-08-01 00:00:00'
+  );
+
+-- ============================================================
+-- PLAYLISTS
+-- 400001: user1 album (contains tracks 2000001, 2000002)
+-- 400002: user4 playlist (contains tracks 2000001, 2000004)
+-- ============================================================
+
+INSERT INTO playlists (
+  blockhash, blocknumber, playlist_id, is_current, is_delete, txhash,
+  playlist_owner_id, playlist_name, is_album, is_private,
+  is_scheduled_release, is_stream_gated, is_image_autogenerated,
+  playlist_contents, description,
+  created_at, updated_at
+) VALUES
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    400001, true, false,
+    '0xccc0000000000000000000000000000000000000000000000000000000000001',
+    3000001, 'Sunrise EP', true, false,
+    false, false, false,
+    '{"track_ids": [{"track": 2000001, "timestamp": 1622505600}, {"track": 2000002, "timestamp": 1623715200}]}',
+    'My debut EP',
+    '2021-09-01 00:00:00', '2021-09-01 00:00:00'
+  ),
+  (
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    400002, true, false,
+    '0xccc0000000000000000000000000000000000000000000000000000000000002',
+    3000004, 'My Favorites', false, false,
+    false, false, false,
+    '{"track_ids": [{"track": 2000001, "timestamp": 1622505600}, {"track": 2000004, "timestamp": 1628812800}]}',
+    'Tracks I keep coming back to',
+    '2021-10-01 00:00:00', '2021-10-01 00:00:00'
+  );
+
+-- ============================================================
+-- FOLLOWS
+-- user4 follows user1, user2, user3
+-- user5 follows user1
+-- ============================================================
+
+INSERT INTO follows (
+  blockhash, blocknumber, follower_user_id, followee_user_id,
+  is_current, is_delete, txhash, created_at
+) VALUES
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000004, 3000001, true, false,
+   '0xddd0000000000000000000000000000000000000000000000000000000000001',
+   '2021-10-02 00:00:00'),
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000004, 3000002, true, false,
+   '0xddd0000000000000000000000000000000000000000000000000000000000002',
+   '2021-10-02 01:00:00'),
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000004, 3000003, true, false,
+   '0xddd0000000000000000000000000000000000000000000000000000000000003',
+   '2021-10-02 02:00:00'),
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000005, 3000001, true, false,
+   '0xddd0000000000000000000000000000000000000000000000000000000000004',
+   '2021-10-03 00:00:00');
+
+-- ============================================================
+-- REPOSTS
+-- user4 reposts track 2000001
+-- user5 reposts playlist 400002
+-- ============================================================
+
+INSERT INTO reposts (
+  blockhash, blocknumber, user_id, repost_item_id, repost_type,
+  is_current, is_delete, is_repost_of_repost, txhash, created_at
+) VALUES
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000004, 2000001, 'track',
+   true, false, false,
+   '0xeee0000000000000000000000000000000000000000000000000000000000001',
+   '2021-10-04 00:00:00'),
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000005, 400002, 'playlist',
+   true, false, false,
+   '0xeee0000000000000000000000000000000000000000000000000000000000002',
+   '2021-10-05 00:00:00');
+
+-- ============================================================
+-- SAVES
+-- user4 saves track 2000004
+-- user5 saves album 400001
+-- ============================================================
+
+INSERT INTO saves (
+  blockhash, blocknumber, user_id, save_item_id, save_type,
+  is_current, is_delete, is_save_of_repost, txhash, created_at
+) VALUES
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000004, 2000004, 'track',
+   true, false, false,
+   '0xfff0000000000000000000000000000000000000000000000000000000000001',
+   '2021-10-06 00:00:00'),
+  ('0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+   3000005, 400001, 'album',
+   true, false, false,
+   '0xfff0000000000000000000000000000000000000000000000000000000000002',
+   '2021-10-07 00:00:00');
+
+-- ============================================================
+-- PLAYS
+-- Mix of identified (user_id set) and anonymous plays
+-- ============================================================
+
+INSERT INTO plays (user_id, play_item_id, source, created_at, updated_at, signature) VALUES
+  (3000004, 2000001, 'feed',      '2021-10-08 10:00:00', '2021-10-08 10:00:00', 'sig-play-0001'),
+  (3000005, 2000001, 'search',    '2021-10-08 11:00:00', '2021-10-08 11:00:00', 'sig-play-0002'),
+  (3000004, 2000004, 'profile',   '2021-10-08 12:00:00', '2021-10-08 12:00:00', 'sig-play-0003'),
+  (NULL,    2000003, 'embed',     '2021-10-09 09:00:00', '2021-10-09 09:00:00', 'sig-play-0004'),
+  (3000005, 2000004, 'trending',  '2021-10-09 14:00:00', '2021-10-09 14:00:00', 'sig-play-0005');
+
+-- ============================================================
+-- COMMENTS
+-- 4000001: user4 top-level comment on track 2000001
+-- 4000002: user5 reply to 4000001 (parent_comment_id is tracked in thread table,
+--          but comment row itself just references the same entity)
+-- ============================================================
+
+INSERT INTO comments (
+  comment_id, text, user_id, entity_id, entity_type,
+  track_timestamp_s, is_delete, is_visible, is_edited,
+  txhash, blockhash, blocknumber, created_at, updated_at
+) VALUES
+  (
+    4000001, 'This track is incredible, love the drop at 1:30!',
+    3000004, 2000001, 'Track',
+    NULL, false, true, false,
+    '0x1110000000000000000000000000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    '2021-10-10 08:00:00', '2021-10-10 08:00:00'
+  ),
+  (
+    4000002, 'Agreed, that synth progression is fire',
+    3000005, 2000001, 'Track',
+    NULL, false, true, false,
+    '0x1110000000000000000000000000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    '2021-10-10 09:00:00', '2021-10-10 09:00:00'
+  );
+
+-- ============================================================
+-- COMMENT REACTIONS
+-- user5 reacts to user4's comment
+-- ============================================================
+
+INSERT INTO comment_reactions (
+  comment_id, user_id, is_delete,
+  txhash, blockhash, blocknumber, created_at, updated_at
+) VALUES
+  (
+    4000001, 3000005, false,
+    '0x2220000000000000000000000000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1,
+    '2021-10-10 10:00:00', '2021-10-10 10:00:00'
+  );
+
+-- ============================================================
+-- TIP REACTIONS (reactions table)
+-- user4 reacts (reaction_value=1) to a tip tx signed by user5's wallet
+-- reaction_type = 'tip', reacted_to = tip transaction signature
+-- ============================================================
+
+INSERT INTO reactions (
+  reaction_value, sender_wallet, reaction_type, reacted_to, timestamp, blocknumber
+) VALUES
+  (
+    1,
+    '0xAAAA000000000000000000000000000000000004',
+    'tip',
+    'tip-tx-signature-0000000000000000000000000000000000000000000000001',
+    '2021-10-11 12:00:00',
+    1
+  );

--- a/cmd/genesis-replay/testdata/source_init.sh
+++ b/cmd/genesis-replay/testdata/source_init.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Creates the genesis_replay_source database and seeds it with test data.
+# Runs as part of postgres docker-entrypoint-initdb.d (after 01_schema.sql and 02_seed.sql).
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE DATABASE genesis_replay_source;
+EOSQL
+
+psql -v ON_ERROR_STOP=1 \
+    --username "$POSTGRES_USER" \
+    --dbname genesis_replay_source \
+    -f /docker-entrypoint-initdb.d/01_schema.sql
+
+psql -v ON_ERROR_STOP=1 \
+    --username "$POSTGRES_USER" \
+    --dbname genesis_replay_source \
+    -f /tmp/source_seed.sql

--- a/cmd/genesis-replay/tracks.go
+++ b/cmd/genesis-replay/tracks.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+// trackMetadataWrapper is the CID-wrapped format the DP expects for Track CREATE/UPDATE.
+type trackMetadataWrapper struct {
+	CID  string             `json:"cid"`
+	Data trackMetadataInner `json:"data"`
+}
+
+type trackMetadataInner struct {
+	Title              string      `json:"title,omitempty"`
+	OwnerID            int64       `json:"owner_id"`
+	Duration           int         `json:"duration,omitempty"`
+	Description        string      `json:"description,omitempty"`
+	Genre              string      `json:"genre,omitempty"`
+	Mood               string      `json:"mood,omitempty"`
+	Tags               string      `json:"tags,omitempty"`
+	TrackCID           string      `json:"track_cid,omitempty"`
+	PreviewCID         string      `json:"preview_cid,omitempty"`
+	CoverArt           string      `json:"cover_art,omitempty"`
+	CoverArtSizes      string      `json:"cover_art_sizes,omitempty"`
+	IsUnlisted         bool        `json:"is_unlisted,omitempty"`
+	IsDownloadable     bool        `json:"is_downloadable,omitempty"`
+	IsOriginalAvail    bool        `json:"is_original_available,omitempty"`
+	ReleaseDate        string      `json:"release_date,omitempty"`
+	License            string      `json:"license,omitempty"`
+	ISRC               string      `json:"isrc,omitempty"`
+	ISWC               string      `json:"iswc,omitempty"`
+	BPM                *float64    `json:"bpm,omitempty"`
+	MusicalKey         string      `json:"musical_key,omitempty"`
+	RemixOf            interface{} `json:"remix_of,omitempty"`
+	StemOf             interface{} `json:"stem_of,omitempty"`
+	IsStreamGated      bool        `json:"is_stream_gated,omitempty"`
+	StreamConditions   interface{} `json:"stream_conditions,omitempty"`
+	IsDownloadGated    bool        `json:"is_download_gated,omitempty"`
+	DownloadConditions interface{} `json:"download_conditions,omitempty"`
+}
+
+type sourceTrack struct {
+	TrackID              int64
+	OwnerID              int64
+	Title                *string
+	Description          *string
+	Duration             *int
+	Genre                *string
+	Mood                 *string
+	Tags                 *string
+	MetadataMultihash    *string
+	TrackSegments        []byte // JSONB
+	CoverArt             *string
+	CoverArtSizes        *string
+	PreviewCID           *string
+	IsUnlisted           bool
+	IsDownloadable       bool
+	IsOriginalAvailable  bool
+	ReleaseDate          *string
+	License              *string
+	ISRC                 *string
+	ISWC                 *string
+	BPM                  *float64
+	MusicalKey           *string
+	RemixOf              []byte // JSONB
+	StemOf               []byte // JSONB
+	IsStreamGated        bool
+	StreamConditions     []byte // JSONB
+	IsDownloadGated      bool
+	DownloadConditions   []byte // JSONB
+}
+
+func (r *Replayer) replayTracks(ctx context.Context) error {
+	const countQ = `SELECT count(*) FROM tracks WHERE is_current = true AND is_delete = false AND is_available = true`
+	const selectQ = `
+		SELECT
+			track_id, owner_id, title, description, duration, genre, mood, tags,
+			metadata_multihash, track_segments,
+			cover_art, cover_art_sizes, preview_cid,
+			is_unlisted, is_downloadable, is_original_available,
+			release_date::text, license, isrc, iswc, bpm, musical_key,
+			remix_of, stem_of,
+			is_stream_gated, stream_conditions,
+			is_download_gated, download_conditions
+		FROM tracks
+		WHERE is_current = true AND is_delete = false AND is_available = true
+		ORDER BY track_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count tracks: %w", err)
+	}
+	r.logger.Info("replaying tracks", zap.Int64("total", total))
+
+	sem := make(chan struct{}, r.cfg.Concurrency)
+	batchStart := time.Now()
+	var processed int64
+
+	for offset := int64(0); offset < total; offset += int64(r.cfg.BatchSize) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		rows, err := r.srcDB.Query(ctx, selectQ, r.cfg.BatchSize, offset)
+		if err != nil {
+			return fmt.Errorf("query tracks at offset %d: %w", offset, err)
+		}
+
+		tracks, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (sourceTrack, error) {
+			var t sourceTrack
+			err := row.Scan(
+				&t.TrackID, &t.OwnerID, &t.Title, &t.Description, &t.Duration,
+				&t.Genre, &t.Mood, &t.Tags,
+				&t.MetadataMultihash, &t.TrackSegments,
+				&t.CoverArt, &t.CoverArtSizes, &t.PreviewCID,
+				&t.IsUnlisted, &t.IsDownloadable, &t.IsOriginalAvailable,
+				&t.ReleaseDate, &t.License, &t.ISRC, &t.ISWC,
+				&t.BPM, &t.MusicalKey,
+				&t.RemixOf, &t.StemOf,
+				&t.IsStreamGated, &t.StreamConditions,
+				&t.IsDownloadGated, &t.DownloadConditions,
+			)
+			return t, err
+		})
+		if err != nil {
+			return fmt.Errorf("scan tracks: %w", err)
+		}
+
+		for _, t := range tracks {
+			if ctx.Err() != nil {
+				break
+			}
+			t := t
+
+			sem <- struct{}{}
+			go func() {
+				defer func() { <-sem }()
+				if err := r.submitTrack(ctx, t); err != nil {
+					if ctx.Err() == nil {
+						r.logger.Warn("track tx error", zap.Int64("track_id", t.TrackID), zap.Error(err))
+						r.stats["tracks"].Errors++
+					}
+				} else {
+					r.stats["tracks"].Submitted++
+				}
+			}()
+
+			processed++
+		}
+
+		if processed%10000 == 0 {
+			r.logProgress("tracks", processed, total, batchStart)
+		}
+	}
+
+	for i := 0; i < r.cfg.Concurrency; i++ {
+		sem <- struct{}{}
+	}
+
+	r.logProgress("tracks", processed, total, batchStart)
+	return nil
+}
+
+func (r *Replayer) submitTrack(ctx context.Context, t sourceTrack) error {
+	inner := trackMetadataInner{
+		OwnerID:           t.OwnerID,
+		IsUnlisted:        t.IsUnlisted,
+		IsDownloadable:    t.IsDownloadable,
+		IsOriginalAvail:   t.IsOriginalAvailable,
+		IsStreamGated:     t.IsStreamGated,
+		IsDownloadGated:   t.IsDownloadGated,
+	}
+	if t.Title != nil {
+		inner.Title = *t.Title
+	}
+	if t.Description != nil {
+		inner.Description = *t.Description
+	}
+	if t.Duration != nil {
+		inner.Duration = *t.Duration
+	}
+	if t.Genre != nil {
+		inner.Genre = *t.Genre
+	}
+	if t.Mood != nil {
+		inner.Mood = *t.Mood
+	}
+	if t.Tags != nil {
+		inner.Tags = *t.Tags
+	}
+	if t.CoverArt != nil {
+		inner.CoverArt = *t.CoverArt
+	}
+	if t.CoverArtSizes != nil {
+		inner.CoverArtSizes = *t.CoverArtSizes
+	}
+	if t.PreviewCID != nil {
+		inner.PreviewCID = *t.PreviewCID
+	}
+	if t.ReleaseDate != nil {
+		inner.ReleaseDate = *t.ReleaseDate
+	}
+	if t.License != nil {
+		inner.License = *t.License
+	}
+	if t.ISRC != nil {
+		inner.ISRC = *t.ISRC
+	}
+	if t.ISWC != nil {
+		inner.ISWC = *t.ISWC
+	}
+	if t.BPM != nil {
+		inner.BPM = t.BPM
+	}
+	if t.MusicalKey != nil {
+		inner.MusicalKey = *t.MusicalKey
+	}
+	if len(t.RemixOf) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(t.RemixOf, &v); err == nil {
+			inner.RemixOf = v
+		}
+	}
+	if len(t.StemOf) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(t.StemOf, &v); err == nil {
+			inner.StemOf = v
+		}
+	}
+	if len(t.StreamConditions) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(t.StreamConditions, &v); err == nil {
+			inner.StreamConditions = v
+		}
+	}
+	if len(t.DownloadConditions) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(t.DownloadConditions, &v); err == nil {
+			inner.DownloadConditions = v
+		}
+	}
+
+	// Use metadata_multihash as the CID in the wrapper; fall back to a placeholder.
+	cid := "genesis-import"
+	if t.MetadataMultihash != nil && *t.MetadataMultihash != "" {
+		cid = *t.MetadataMultihash
+	}
+
+	// track_cid: pull from track_segments if available, otherwise leave empty.
+	// The DP will store it; streaming won't work without a real CID but the
+	// metadata record will be correct.
+	if len(t.TrackSegments) > 0 {
+		var segs []struct {
+			MultiHash string `json:"multihash"`
+		}
+		if err := json.Unmarshal(t.TrackSegments, &segs); err == nil && len(segs) > 0 {
+			inner.TrackCID = segs[0].MultiHash
+		}
+	}
+
+	wrapper := trackMetadataWrapper{CID: cid, Data: inner}
+	metaJSON, err := json.Marshal(wrapper)
+	if err != nil {
+		return fmt.Errorf("marshal track metadata: %w", err)
+	}
+
+	return r.submitManageEntity(ctx, &corev1.ManageEntityLegacy{
+		UserId:     t.OwnerID,
+		EntityType: "Track",
+		EntityId:   t.TrackID,
+		Action:     "Create",
+		Metadata:   string(metaJSON),
+	})
+}

--- a/cmd/genesis-replay/users.go
+++ b/cmd/genesis-replay/users.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+// userMetadataWrapper is the CID-wrapped format the DP expects for User CREATE.
+// User CREATE uses parse_metadata(..., Action.UPDATE, ...) internally, which
+// requires the same {"cid": "...", "data": {...}} envelope as tracks and playlists.
+type userMetadataWrapper struct {
+	CID  string       `json:"cid"`
+	Data userMetadata `json:"data"`
+}
+
+// userMetadata mirrors the fields the discovery provider expects for User CREATE/UPDATE.
+type userMetadata struct {
+	Name                  string `json:"name,omitempty"`
+	Handle                string `json:"handle,omitempty"`
+	Bio                   string `json:"bio,omitempty"`
+	Location              string `json:"location,omitempty"`
+	Wallet                string `json:"wallet,omitempty"`
+	ProfilePicture        string `json:"profile_picture,omitempty"`
+	ProfilePictureSizes   string `json:"profile_picture_sizes,omitempty"`
+	CoverPhoto            string `json:"cover_photo,omitempty"`
+	CoverPhotoSizes       string `json:"cover_photo_sizes,omitempty"`
+	TwitterHandle         string `json:"twitter_handle,omitempty"`
+	InstagramHandle       string `json:"instagram_handle,omitempty"`
+	Website               string `json:"website,omitempty"`
+	IsVerified            bool   `json:"is_verified,omitempty"`
+	AllowAiAttribution    bool   `json:"allow_ai_attribution,omitempty"`
+	SplUsdcPayoutWallet   string `json:"spl_usdc_payout_wallet,omitempty"`
+}
+
+// sourceUser is a row from the discovery provider's users table.
+type sourceUser struct {
+	UserID              int64
+	Wallet              *string
+	Handle              *string
+	Name                *string
+	Bio                 *string
+	Location            *string
+	ProfilePicture      *string
+	ProfilePictureSizes *string
+	CoverPhoto          *string
+	CoverPhotoSizes     *string
+	TwitterHandle       *string
+	InstagramHandle     *string
+	Website             *string
+	IsVerified          bool
+}
+
+func (r *Replayer) replayUsers(ctx context.Context) error {
+	const countQ = `SELECT count(*) FROM users WHERE is_current = true AND is_deactivated = false AND is_available = true`
+	const selectQ = `
+		SELECT
+			user_id, wallet, handle, name, bio, location,
+			profile_picture, profile_picture_sizes,
+			cover_photo, cover_photo_sizes,
+			twitter_handle, instagram_handle, website,
+			is_verified
+		FROM users
+		WHERE is_current = true AND is_deactivated = false AND is_available = true
+		ORDER BY user_id
+		LIMIT $1 OFFSET $2`
+
+	var total int64
+	if err := r.srcDB.QueryRow(ctx, countQ).Scan(&total); err != nil {
+		return fmt.Errorf("count users: %w", err)
+	}
+	r.logger.Info("replaying users", zap.Int64("total", total))
+
+	sem := make(chan struct{}, r.cfg.Concurrency)
+	batchStart := time.Now()
+	var processed int64
+
+	for offset := int64(0); offset < total; offset += int64(r.cfg.BatchSize) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		rows, err := r.srcDB.Query(ctx, selectQ, r.cfg.BatchSize, offset)
+		if err != nil {
+			return fmt.Errorf("query users at offset %d: %w", offset, err)
+		}
+
+		users, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (sourceUser, error) {
+			var u sourceUser
+			err := row.Scan(
+				&u.UserID, &u.Wallet, &u.Handle, &u.Name, &u.Bio, &u.Location,
+				&u.ProfilePicture, &u.ProfilePictureSizes,
+				&u.CoverPhoto, &u.CoverPhotoSizes,
+				&u.TwitterHandle, &u.InstagramHandle, &u.Website,
+				&u.IsVerified,
+			)
+			return u, err
+		})
+		if err != nil {
+			return fmt.Errorf("scan users: %w", err)
+		}
+
+		for _, u := range users {
+			if ctx.Err() != nil {
+				break
+			}
+			u := u // capture
+
+			sem <- struct{}{}
+			go func() {
+				defer func() { <-sem }()
+				if err := r.submitUser(ctx, u); err != nil {
+					if ctx.Err() == nil {
+						r.logger.Warn("user tx error", zap.Int64("user_id", u.UserID), zap.Error(err))
+						r.stats["users"].Errors++
+					}
+				} else {
+					r.stats["users"].Submitted++
+				}
+			}()
+
+			processed++
+		}
+
+		if processed%10000 == 0 {
+			r.logProgress("users", processed, total, batchStart)
+		}
+	}
+
+	// drain
+	for i := 0; i < r.cfg.Concurrency; i++ {
+		sem <- struct{}{}
+	}
+
+	r.logProgress("users", processed, total, batchStart)
+	return nil
+}
+
+func (r *Replayer) submitUser(ctx context.Context, u sourceUser) error {
+	meta := userMetadata{
+		IsVerified: u.IsVerified,
+	}
+	if u.Wallet != nil {
+		meta.Wallet = *u.Wallet
+	}
+	if u.Handle != nil {
+		meta.Handle = *u.Handle
+	}
+	if u.Name != nil {
+		meta.Name = *u.Name
+	}
+	if u.Bio != nil {
+		meta.Bio = *u.Bio
+	}
+	if u.Location != nil {
+		meta.Location = *u.Location
+	}
+	if u.ProfilePicture != nil {
+		meta.ProfilePicture = *u.ProfilePicture
+	}
+	if u.ProfilePictureSizes != nil {
+		meta.ProfilePictureSizes = *u.ProfilePictureSizes
+	}
+	if u.CoverPhoto != nil {
+		meta.CoverPhoto = *u.CoverPhoto
+	}
+	if u.CoverPhotoSizes != nil {
+		meta.CoverPhotoSizes = *u.CoverPhotoSizes
+	}
+	if u.TwitterHandle != nil {
+		meta.TwitterHandle = *u.TwitterHandle
+	}
+	if u.InstagramHandle != nil {
+		meta.InstagramHandle = *u.InstagramHandle
+	}
+	if u.Website != nil {
+		meta.Website = *u.Website
+	}
+
+	cid := "genesis-import"
+	wrapper := userMetadataWrapper{CID: cid, Data: meta}
+	metaJSON, err := json.Marshal(wrapper)
+	if err != nil {
+		return fmt.Errorf("marshal user metadata: %w", err)
+	}
+
+	return r.submitManageEntity(ctx, &corev1.ManageEntityLegacy{
+		UserId:     u.UserID,
+		EntityType: "User",
+		EntityId:   u.UserID,
+		Action:     "Create",
+		Metadata:   string(metaJSON),
+	})
+}

--- a/cmd/genesis-replay/verify.go
+++ b/cmd/genesis-replay/verify.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+)
+
+func verifyCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "verify",
+		Usage: "Diff entities and plays between two discovery-provider databases",
+		Description: `Streams both databases in sorted order and performs a merge comparison.
+Plays are compared by per-track aggregate count rather than individual rows,
+so the command is safe to run against a full production dataset.
+
+Exit code 0 = all checks pass; 1 = mismatches found; 2 = fatal error.`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "src",
+				Usage:    "Source (reference) PostgreSQL DSN",
+				EnvVars:  []string{"GENESIS_SRC_DSN"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "dst",
+				Usage:    "Destination PostgreSQL DSN",
+				EnvVars:  []string{"GENESIS_DEST_DSN"},
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:    "max-samples",
+				Usage:   "Maximum mismatch rows to print per entity type",
+				EnvVars: []string{"GENESIS_MAX_SAMPLES"},
+				Value:   10,
+			},
+			&cli.BoolFlag{
+				Name:    "skip-plays",
+				Usage:   "Skip play-count verification",
+				EnvVars: []string{"GENESIS_SKIP_PLAYS"},
+			},
+		},
+		Action: runVerify,
+	}
+}
+
+// ---- result type ------------------------------------------------------------
+
+type diffResult struct {
+	entity    string
+	srcCount  int64
+	dstCount  int64
+	missing   int64  // in src, absent from dst
+	extra     int64  // in dst, absent from src
+	different int64  // same key, differing values
+	samples   []string
+}
+
+func (r *diffResult) ok() bool {
+	return r.missing == 0 && r.extra == 0 && r.different == 0
+}
+
+// ---- entry point ------------------------------------------------------------
+
+func runVerify(c *cli.Context) error {
+	logger, _ := zap.NewProduction()
+	defer logger.Sync()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	maxSamples := c.Int("max-samples")
+
+	src, err := pgxpool.New(ctx, c.String("src"))
+	if err != nil {
+		return fmt.Errorf("connect src: %w", err)
+	}
+	defer src.Close()
+
+	dst, err := pgxpool.New(ctx, c.String("dst"))
+	if err != nil {
+		return fmt.Errorf("connect dst: %w", err)
+	}
+	defer dst.Close()
+
+	v := &verifier{src: src, dst: dst, maxSamples: maxSamples, logger: logger}
+
+	type check struct {
+		name string
+		skip bool
+		fn   func(context.Context) (*diffResult, error)
+	}
+	checks := []check{
+		{"users", false, v.verifyUsers},
+		{"tracks", false, v.verifyTracks},
+		{"playlists", false, v.verifyPlaylists},
+		{"follows", false, v.verifyFollows},
+		{"saves", false, v.verifySaves},
+		{"reposts", false, v.verifyReposts},
+		{"plays", c.Bool("skip-plays"), v.verifyPlays},
+	}
+
+	// Run all checks first, then print everything at once.
+	results := make([]*diffResult, len(checks))
+	allOK := true
+	for i, chk := range checks {
+		if chk.skip {
+			results[i] = &diffResult{entity: chk.name}
+			continue
+		}
+		logger.Info("verifying", zap.String("entity", chk.name))
+		r, err := chk.fn(ctx)
+		if err != nil {
+			return fmt.Errorf("verify %s: %w", chk.name, err)
+		}
+		results[i] = r
+		if !r.ok() {
+			allOK = false
+		}
+	}
+
+	// Summary table.
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "entity\tsrc\tdst\tmissing\textra\tdifferent\tstatus")
+	fmt.Fprintln(tw, "------\t---\t---\t-------\t-----\t---------\t------")
+	for i, r := range results {
+		if checks[i].skip {
+			fmt.Fprintf(tw, "%s\t-\t-\t-\t-\t-\tSKIPPED\n", r.entity)
+			continue
+		}
+		status := "OK"
+		if !r.ok() {
+			status = "FAIL"
+		}
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			r.entity, r.srcCount, r.dstCount, r.missing, r.extra, r.different, status)
+	}
+	tw.Flush()
+
+	// Per-entity sample mismatches.
+	for _, r := range results {
+		if len(r.samples) > 0 {
+			fmt.Printf("\n--- %s mismatches (sample) ---\n", r.entity)
+			for _, s := range r.samples {
+				fmt.Println(" ", s)
+			}
+		}
+	}
+
+	if !allOK {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// ---- verifier ---------------------------------------------------------------
+
+type verifier struct {
+	src        *pgxpool.Pool
+	dst        *pgxpool.Pool
+	maxSamples int
+	logger     *zap.Logger
+}
+
+// compareStreams opens both queries and performs a streaming merge comparison.
+// Both queries MUST return rows in the same ascending key order.
+// keyLen is the number of leading columns forming the primary key;
+// remaining columns are value fields checked for equality.
+//
+// Memory usage is O(maxSamples) — only two rows are held in memory at a time.
+func (v *verifier) compareStreams(ctx context.Context, name, srcQ, dstQ string, keyLen int) (*diffResult, error) {
+	res := &diffResult{entity: name}
+
+	srcRows, err := v.src.Query(ctx, srcQ)
+	if err != nil {
+		return nil, fmt.Errorf("src: %w", err)
+	}
+	defer srcRows.Close()
+
+	dstRows, err := v.dst.Query(ctx, dstQ)
+	if err != nil {
+		return nil, fmt.Errorf("dst: %w", err)
+	}
+	defer dstRows.Close()
+
+	// Lazy-load state: advance the cursor, then load values on demand.
+	// This lets us "put back" the row that's ahead without re-reading the DB.
+	hasSrc := srcRows.Next()
+	hasDst := dstRows.Next()
+	var srcVals, dstVals []any // nil means "not yet loaded for this position"
+
+	for hasSrc || hasDst {
+		// Load current values if not yet read.
+		if hasSrc && srcVals == nil {
+			if srcVals, err = srcRows.Values(); err != nil {
+				return nil, fmt.Errorf("src scan: %w", err)
+			}
+			res.srcCount++
+		}
+		if hasDst && dstVals == nil {
+			if dstVals, err = dstRows.Values(); err != nil {
+				return nil, fmt.Errorf("dst scan: %w", err)
+			}
+			res.dstCount++
+		}
+
+		switch {
+		case !hasDst:
+			// dst exhausted — everything remaining in src is missing.
+			res.missing++
+			v.addSample(res, fmt.Sprintf("MISSING key=%s", rowKey(srcVals, keyLen)))
+			srcVals = nil
+			hasSrc = srcRows.Next()
+
+		case !hasSrc:
+			// src exhausted — everything remaining in dst is extra.
+			res.extra++
+			v.addSample(res, fmt.Sprintf("EXTRA   key=%s", rowKey(dstVals, keyLen)))
+			dstVals = nil
+			hasDst = dstRows.Next()
+
+		default:
+			srcKey := rowKey(srcVals, keyLen)
+			dstKey := rowKey(dstVals, keyLen)
+
+			switch {
+			case srcKey < dstKey:
+				// src row not in dst.
+				res.missing++
+				v.addSample(res, fmt.Sprintf("MISSING key=%s", srcKey))
+				srcVals = nil        // advance src
+				hasSrc = srcRows.Next()
+				// dstVals stays — it hasn't been "used" yet, just peeked at.
+				// But res.dstCount was already incremented when we loaded it;
+				// undo that so counts only reflect actually-compared dst rows.
+				res.dstCount--
+
+			case srcKey > dstKey:
+				// dst row not in src.
+				res.extra++
+				v.addSample(res, fmt.Sprintf("EXTRA   key=%s", dstKey))
+				dstVals = nil        // advance dst
+				hasDst = dstRows.Next()
+				res.srcCount-- // undo premature src count
+
+			default:
+				// Keys match — compare values.
+				if diff := rowValueDiff(srcVals, dstVals, keyLen); diff != "" {
+					res.different++
+					v.addSample(res, fmt.Sprintf("DIFF    key=%s %s", srcKey, diff))
+				}
+				srcVals = nil
+				dstVals = nil
+				hasSrc = srcRows.Next()
+				hasDst = dstRows.Next()
+			}
+		}
+	}
+
+	if err := srcRows.Err(); err != nil {
+		return nil, fmt.Errorf("src rows: %w", err)
+	}
+	if err := dstRows.Err(); err != nil {
+		return nil, fmt.Errorf("dst rows: %w", err)
+	}
+	return res, nil
+}
+
+func (v *verifier) addSample(r *diffResult, s string) {
+	if len(r.samples) < v.maxSamples {
+		r.samples = append(r.samples, s)
+	}
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+// rowKey formats the first keyLen values as a colon-separated string.
+// Integers are zero-padded to 20 digits so lexicographic order matches numeric order.
+func rowKey(vals []any, keyLen int) string {
+	parts := make([]string, keyLen)
+	for i := range keyLen {
+		switch n := vals[i].(type) {
+		case int32:
+			parts[i] = fmt.Sprintf("%020d", n)
+		case int64:
+			parts[i] = fmt.Sprintf("%020d", n)
+		default:
+			parts[i] = fmt.Sprintf("%v", n)
+		}
+	}
+	return strings.Join(parts, ":")
+}
+
+// rowValueDiff returns a description of value differences, or "" if equal.
+func rowValueDiff(src, dst []any, keyLen int) string {
+	var diffs []string
+	for i := keyLen; i < len(src); i++ {
+		sv := fmt.Sprintf("%v", src[i])
+		dv := fmt.Sprintf("%v", dst[i])
+		if sv != dv {
+			diffs = append(diffs, fmt.Sprintf("col%d: %q→%q", i, sv, dv))
+		}
+	}
+	return strings.Join(diffs, ", ")
+}
+
+// ---- entity checks ----------------------------------------------------------
+
+func (v *verifier) verifyUsers(ctx context.Context) (*diffResult, error) {
+	q := `SELECT user_id,
+	             COALESCE(handle,''), COALESCE(name,''),
+	             COALESCE(bio,''), COALESCE(location,'')
+	      FROM users
+	      WHERE is_current = true AND is_deactivated = false AND is_available = true
+	      ORDER BY user_id`
+	return v.compareStreams(ctx, "users", q, q, 1)
+}
+
+func (v *verifier) verifyTracks(ctx context.Context) (*diffResult, error) {
+	q := `SELECT track_id, owner_id, COALESCE(title,''), COALESCE(genre,'')
+	      FROM tracks
+	      WHERE is_current = true AND is_delete = false AND is_available = true
+	      ORDER BY track_id`
+	return v.compareStreams(ctx, "tracks", q, q, 1)
+}
+
+func (v *verifier) verifyPlaylists(ctx context.Context) (*diffResult, error) {
+	q := `SELECT playlist_id, playlist_owner_id, COALESCE(playlist_name,''), is_album
+	      FROM playlists
+	      WHERE is_current = true AND is_delete = false
+	      ORDER BY playlist_id`
+	return v.compareStreams(ctx, "playlists", q, q, 1)
+}
+
+func (v *verifier) verifyFollows(ctx context.Context) (*diffResult, error) {
+	q := `SELECT follower_user_id, followee_user_id
+	      FROM follows
+	      WHERE is_current = true AND is_delete = false
+	      ORDER BY follower_user_id, followee_user_id`
+	return v.compareStreams(ctx, "follows", q, q, 2)
+}
+
+func (v *verifier) verifySaves(ctx context.Context) (*diffResult, error) {
+	// Normalize 'album' → 'playlist': the DP stores album saves under the playlist type.
+	q := `SELECT user_id, save_item_id,
+	             CASE save_type WHEN 'album' THEN 'playlist' ELSE save_type END
+	      FROM saves
+	      WHERE is_current = true AND is_delete = false
+	      ORDER BY user_id, save_item_id`
+	return v.compareStreams(ctx, "saves", q, q, 2)
+}
+
+func (v *verifier) verifyReposts(ctx context.Context) (*diffResult, error) {
+	q := `SELECT user_id, repost_item_id, repost_type
+	      FROM reposts
+	      WHERE is_current = true AND is_delete = false
+	      ORDER BY user_id, repost_item_id`
+	return v.compareStreams(ctx, "reposts", q, q, 2)
+}
+
+// verifyPlays compares per-track play counts rather than individual play rows.
+// Memory and query cost scale with the number of distinct tracks, not plays.
+func (v *verifier) verifyPlays(ctx context.Context) (*diffResult, error) {
+	q := `SELECT play_item_id::bigint, count(*)::bigint
+	      FROM plays
+	      GROUP BY play_item_id
+	      ORDER BY play_item_id`
+	return v.compareStreams(ctx, "plays", q, q, 1)
+}

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
 	github.com/shirou/gopsutil/v4 v4.25.1
 	github.com/tus/tusd/v2 v2.8.0
+	github.com/urfave/cli/v2 v2.27.6
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/mod v0.24.0
@@ -119,6 +120,7 @@ require (
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.0.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
@@ -207,14 +209,15 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/supranational/blst v0.3.13 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
-	github.com/urfave/cli/v2 v2.27.6 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -571,7 +571,6 @@ github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rubenv/sql-migrate v1.7.0 h1:HtQq1xyTN2ISmQDggnh0c9U3JlP8apWh8YO2jzlXpTI=
 github.com/rubenv/sql-migrate v1.7.0/go.mod h1:S4wtDEG1CKn+0ShpTtzWhFpHHI5PvCUtiGI+C+Z2THE=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -133,6 +133,7 @@ type Config struct {
 	EnableETL                       bool
 	EnableExplorer                  bool
 	EnableGRPCReflection            bool
+	GenesisMigration                bool
 }
 
 func (c *Config) IsDev() bool {
@@ -192,6 +193,7 @@ func ReadConfig() (*Config, error) {
 	cfg.EnableETL = GetEnvWithDefault("OPENAUDIO_ETL_ENABLED", "false") == "true"
 	cfg.EnableExplorer = GetEnvWithDefault("OPENAUDIO_EXPLORER_ENABLED", "false") == "true"
 	cfg.EnableGRPCReflection = GetEnvWithDefault("OPENAUDIO_GRPC_REFLECTION_ENABLED", "false") == "true"
+	cfg.GenesisMigration = GetEnvWithDefault("OPENAUDIO_GENESIS_MIGRATION", "false") == "true"
 
 	ssRpcServers := ""
 	switch cfg.Environment {

--- a/pkg/core/config/genesis/dev-v2.json
+++ b/pkg/core/config/genesis/dev-v2.json
@@ -1,0 +1,46 @@
+{
+  "genesis_time": "2026-01-01T00:00:00.0000Z",
+  "chain_id": "audius-mainnet-v2",
+  "initial_height": "0",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "104857600",
+      "max_gas": "10000000"
+    },
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "10485760"
+    },
+    "validator": {
+      "pub_key_types": ["ed25519"]
+    },
+    "version": {
+      "app": "0"
+    },
+    "synchrony": {
+      "precision": "100000000",
+      "message_delay": "500000000"
+    },
+    "feature": {
+      "vote_extensions_enable_height": "0",
+      "pbts_enable_height": "0"
+    }
+  },
+  "validators": [
+    {
+      "address": "FFAD25668E060A357BBE534C8B7E5B4E1274368B",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "6wdF9AgylXFnTfTdlEp98dzlgPNIooHOmfUT4qaWpmM="
+      },
+      "power": "100",
+      "name": "bootstrap-validator"
+    }
+  ],
+  "app_state": {
+    "genesis_migration_address": "0xF7Bd9D733fAD4e2f0594bb88180cef8D8D03dEbB",
+    "genesis_migration_end_height": 0
+  },
+  "app_hash": ""
+}

--- a/pkg/core/config/genesis/genesis.go
+++ b/pkg/core/config/genesis/genesis.go
@@ -19,8 +19,34 @@ var stageGenesis embed.FS
 //go:embed prod.json
 var prodGenesis embed.FS
 
+//go:embed prod-v2.json
+var prodV2Genesis embed.FS
+
+//go:embed dev-v2.json
+var devV2Genesis embed.FS
+
 func Read(environment string) (*types.GenesisDoc, error) {
 	switch environment {
+	case "dev-v2":
+		data, err := devV2Genesis.ReadFile("dev-v2.json")
+		if err != nil {
+			return nil, fmt.Errorf("failed to read embedded file: %v", err)
+		}
+		genDoc, err := types.GenesisDocFromJSON(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal dev-v2.json into genesis: %v", err)
+		}
+		return genDoc, nil
+	case "prod-v2", "mainnet-v2":
+		data, err := prodV2Genesis.ReadFile("prod-v2.json")
+		if err != nil {
+			return nil, fmt.Errorf("failed to read embedded file: %v", err)
+		}
+		genDoc, err := types.GenesisDocFromJSON(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal prod-v2.json into genesis: %v", err)
+		}
+		return genDoc, nil
 	case "prod", "production", "mainnet":
 		data, err := prodGenesis.ReadFile("prod.json")
 		if err != nil {

--- a/pkg/core/config/genesis/prod-v2.json
+++ b/pkg/core/config/genesis/prod-v2.json
@@ -1,0 +1,46 @@
+{
+  "genesis_time": "2026-01-01T00:00:00.0000Z",
+  "chain_id": "audius-mainnet-v2",
+  "initial_height": "0",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "104857600",
+      "max_gas": "10000000"
+    },
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "10485760"
+    },
+    "validator": {
+      "pub_key_types": ["ed25519"]
+    },
+    "version": {
+      "app": "0"
+    },
+    "synchrony": {
+      "precision": "100000000",
+      "message_delay": "500000000"
+    },
+    "feature": {
+      "vote_extensions_enable_height": "0",
+      "pbts_enable_height": "0"
+    }
+  },
+  "validators": [
+    {
+      "address": "FFAD25668E060A357BBE534C8B7E5B4E1274368B",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "6wdF9AgylXFnTfTdlEp98dzlgPNIooHOmfUT4qaWpmM="
+      },
+      "power": "100",
+      "name": "bootstrap-validator"
+    }
+  ],
+  "app_state": {
+    "genesis_migration_address": "0xb72ebdec11CAe2C112d31418aB2D92D5805a5A92",
+    "genesis_migration_end_height": 0
+  },
+  "app_hash": ""
+}

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -45,8 +45,11 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 		return nil, nil, fmt.Errorf("reading env config: %v", err)
 	}
 
-	// gather genesis doc based on environment
-	genDoc, err := genesis.Read(envConfig.Environment)
+	// gather genesis doc: OPENAUDIO_GENESIS overrides OPENAUDIO_ENV for genesis selection,
+	// allowing e.g. OPENAUDIO_ENV=dev + OPENAUDIO_GENESIS=prod-v2 to run dev infrastructure
+	// against the prod-v2 chain.
+	genesisNetwork := GetEnvWithDefault("OPENAUDIO_GENESIS", envConfig.Environment)
+	genDoc, err := genesis.Read(genesisNetwork)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading genesis: %v", err)
 	}

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -143,7 +143,11 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 	// don't recheck mempool transactions, rely on CheckTx and Propose step
 	cometConfig.Mempool.Recheck = false
 	cometConfig.Mempool.Broadcast = false
-	cometConfig.Consensus.TimeoutCommit = 400 * time.Millisecond
+	timeoutCommit := 400 * time.Millisecond
+	if envConfig.GenesisMigration {
+		timeoutCommit = 10 * time.Millisecond
+	}
+	cometConfig.Consensus.TimeoutCommit = timeoutCommit
 	cometConfig.Consensus.TimeoutPropose = 400 * time.Millisecond
 	cometConfig.Consensus.TimeoutProposeDelta = 75 * time.Millisecond
 	cometConfig.Consensus.TimeoutPrevote = 300 * time.Millisecond

--- a/pkg/core/db/models.go
+++ b/pkg/core/db/models.go
@@ -191,6 +191,16 @@ type CoreEtlTxValidatorRegistration struct {
 	CreatedAt    pgtype.Timestamptz
 }
 
+type CoreGenesisState struct {
+	ChainID            string
+	MigrationAddress   string
+	MigrationEndHeight pgtype.Int8
+	SnapshotTimestamp  pgtype.Timestamptz
+	EntityCounts       []byte
+	CompletedAt        pgtype.Timestamptz
+	CreatedAt          pgtype.Timestamptz
+}
+
 type CoreMead struct {
 	ID                int64
 	Address           string

--- a/pkg/core/db/sql/migrations/00032_genesis_state.sql
+++ b/pkg/core/db/sql/migrations/00032_genesis_state.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+create table if not exists core_genesis_state (
+    chain_id             text primary key,
+    migration_address    text not null,
+    migration_end_height bigint,
+    snapshot_timestamp   timestamptz,
+    entity_counts        jsonb not null default '{}',
+    completed_at         timestamptz,
+    created_at           timestamptz not null default now()
+);
+
+-- +migrate Down
+drop table if exists core_genesis_state;

--- a/pkg/core/server/abci.go
+++ b/pkg/core/server/abci.go
@@ -261,8 +261,59 @@ func (s *Server) CheckTx(_ context.Context, check *abcitypes.CheckTxRequest) (*a
 	return &abcitypes.CheckTxResponse{Code: 1}, nil
 }
 
-func (s *Server) InitChain(_ context.Context, chain *abcitypes.InitChainRequest) (*abcitypes.InitChainResponse, error) {
+// genesisMigrationAppState is the JSON structure embedded in the genesis app_state field.
+type genesisMigrationAppState struct {
+	GenesisMigrationAddress   string `json:"genesis_migration_address"`
+	GenesisMigrationEndHeight int64  `json:"genesis_migration_end_height"`
+}
+
+func (s *Server) InitChain(ctx context.Context, chain *abcitypes.InitChainRequest) (*abcitypes.InitChainResponse, error) {
+	if len(chain.AppStateBytes) == 0 {
+		return &abcitypes.InitChainResponse{}, nil
+	}
+
+	var appState genesisMigrationAppState
+	if err := json.Unmarshal(chain.AppStateBytes, &appState); err != nil {
+		return nil, fmt.Errorf("InitChain: parse app_state: %w", err)
+	}
+
+	if appState.GenesisMigrationAddress != "" && appState.GenesisMigrationAddress != "0x0000000000000000000000000000000000000000" {
+		s.genesisMigrationAddress = strings.ToLower(appState.GenesisMigrationAddress)
+		s.genesisMigrationEndHeight = appState.GenesisMigrationEndHeight
+		s.logger.Info("genesis migration authority set",
+			zap.String("address", s.genesisMigrationAddress),
+			zap.Int64("end_height", s.genesisMigrationEndHeight),
+		)
+
+		_, err := s.pool.Exec(ctx,
+			`INSERT INTO core_genesis_state (chain_id, migration_address, migration_end_height, entity_counts)
+			 VALUES ($1, $2, $3, '{}')
+			 ON CONFLICT (chain_id) DO UPDATE
+			   SET migration_address = EXCLUDED.migration_address,
+			       migration_end_height = EXCLUDED.migration_end_height`,
+			chain.ChainId,
+			s.genesisMigrationAddress,
+			s.genesisMigrationEndHeight,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("InitChain: upsert core_genesis_state: %w", err)
+		}
+	}
+
 	return &abcitypes.InitChainResponse{}, nil
+}
+
+// IsMigrationAuthority returns true if the given address is the active genesis migration
+// authority at the given block height. Used by the connect RPC layer to expose migration
+// state to the discovery provider.
+func (s *Server) IsMigrationAuthority(address string, blockHeight int64) bool {
+	if s.genesisMigrationAddress == "" {
+		return false
+	}
+	if s.genesisMigrationEndHeight > 0 && blockHeight > s.genesisMigrationEndHeight {
+		return false
+	}
+	return strings.ToLower(address) == s.genesisMigrationAddress
 }
 
 func (s *Server) PrepareProposal(ctx context.Context, proposal *abcitypes.PrepareProposalRequest) (*abcitypes.PrepareProposalResponse, error) {

--- a/pkg/core/server/auditor.go
+++ b/pkg/core/server/auditor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	v1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
@@ -109,8 +108,14 @@ func (s *Server) isValidRollup(ctx context.Context, timestamp time.Time, height 
 		return false, nil
 	} else if myRollup.BlockEnd != rollup.BlockEnd {
 		return false, nil
-	} else if !reflect.DeepEqual(myRollup.Reports, rollup.Reports) {
+	} else if len(myRollup.Reports) != len(rollup.Reports) {
 		return false, nil
+	} else {
+		for i, r := range myRollup.Reports {
+			if !proto.Equal(r, rollup.Reports[i]) {
+				return false, nil
+			}
+		}
 	}
 	return true, nil
 }

--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -76,6 +76,13 @@ type Server struct {
 	remoteHeadMu        sync.Mutex
 
 	onManagementKeysChanged func(trackID string)
+
+	// Genesis migration authority — set from genesis app_state on InitChain.
+	// During block heights 1..genesisMigrationEndHeight this address may sign
+	// ManageEntity transactions on behalf of any entity (ownership check bypassed).
+	// Zero value means no migration authority is active.
+	genesisMigrationAddress   string
+	genesisMigrationEndHeight int64
 }
 
 func NewServer(lc *lifecycle.Lifecycle, config *config.Config, cconfig *cconfig.Config, logger *zap.Logger, pool *pgxpool.Pool, ethService *eth.EthService, posChannel chan pos.PoSRequest) (*Server, error) {


### PR DESCRIPTION
## Summary

- **Fix**: Replace `reflect.DeepEqual` with `proto.Equal` for rollup report comparison in the auditor
- **Add prod-v2 genesis chain**: Embeds `prod-v2.json` and `dev-v2.json` genesis configs. Adds `OPENAUDIO_GENESIS` env var to select the genesis independently of `OPENAUDIO_ENV`. Introduces a genesis migration authority — an address in genesis `app_state` whose `ManageEntity` transactions bypass ownership checks during migration. Tracks state in a new `core_genesis_state` table.
- **Add `OPENAUDIO_GENESIS_MIGRATION` mode**: Reduces `TimeoutCommit` from 400ms to 10ms on a single-validator bootstrap chain, enabling ~100 blocks/second for fast entity ingestion.
- **Add `genesis-replay` tool**: Replays all historical Audius entities (users, tracks, playlists, follows, saves, reposts, plays) from a discovery-provider postgres DB to a bootstrap Core chain via synthetic `ManageEntity` and `TrackPlay` transactions. Achieves ~1800 tx/s using direct h2c gRPC with 500 concurrent submissions.

## Test plan

- [ ] `go build ./...` passes
- [ ] `make test-unit` passes
- [ ] For integration: `cd cmd/genesis-replay && make up && make test-integration`
- [ ] Verify `OPENAUDIO_GENESIS=prod-v2` boots a node against the prod-v2 genesis
- [ ] Verify `OPENAUDIO_GENESIS_MIGRATION=true` reduces block time on a single-validator devnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)