### PR TITLE
etl: fix social handler dispatch to use wildcard entity type matching

### DIFF
--- a/pkg/etl/db/sql/migrations/0007_subscription_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0007_subscription_tables.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS subscriptions;

--- a/pkg/etl/db/sql/migrations/0007_subscription_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0007_subscription_tables.up.sql
@@ -1,0 +1,17 @@
+-- Subscriptions table matching discovery-provider schema.
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  blockhash character varying,
+  blocknumber integer REFERENCES blocks(number) ON DELETE CASCADE,
+  subscriber_id integer NOT NULL,
+  user_id integer NOT NULL,
+  is_current boolean NOT NULL,
+  is_delete boolean NOT NULL,
+  created_at timestamp without time zone NOT NULL,
+  txhash character varying NOT NULL DEFAULT '',
+  CONSTRAINT subscriptions_pkey PRIMARY KEY (subscriber_id, user_id, txhash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_blocknumber ON subscriptions (blocknumber);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_subscriber_id ON subscriptions (subscriber_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions (user_id);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -87,18 +87,14 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.PlaylistUpdate())
 		e.dispatcher.Register(em.PlaylistDelete())
 	}
-	if e.config.IsDataTypeEnabled(em.EntityTypeFollow) {
-		e.dispatcher.Register(em.Follow())
-		e.dispatcher.Register(em.Unfollow())
-	}
-	if e.config.IsDataTypeEnabled(em.EntityTypeSave) {
-		e.dispatcher.Register(em.Save())
-		e.dispatcher.Register(em.Unsave())
-	}
-	if e.config.IsDataTypeEnabled(em.EntityTypeRepost) {
-		e.dispatcher.Register(em.Repost())
-		e.dispatcher.Register(em.Unrepost())
-	}
+	// Social features use wildcard entity type — actual txs carry the entity
+	// being acted on (User for Follow, Track/Playlist for Save/Repost).
+	e.dispatcher.Register(em.Follow())
+	e.dispatcher.Register(em.Unfollow())
+	e.dispatcher.Register(em.Save())
+	e.dispatcher.Register(em.Unsave())
+	e.dispatcher.Register(em.Repost())
+	e.dispatcher.Register(em.Unrepost())
 	if e.config.IsDataTypeEnabled(em.EntityTypeDeveloperApp) {
 		e.dispatcher.Register(em.DeveloperAppCreate())
 		e.dispatcher.Register(em.DeveloperAppUpdate())

--- a/pkg/etl/processors/entity_manager/handler.go
+++ b/pkg/etl/processors/entity_manager/handler.go
@@ -262,6 +262,11 @@ func (d *Dispatcher) Register(h Handler) {
 	d.handlers[handlerKey(h.EntityType(), h.Action())] = h
 }
 
+// EntityTypeAny is a wildcard entity type for handlers that match any entity type
+// for a given action (e.g., social features: Follow matches entity_type "User",
+// Save matches "Track" or "Playlist").
+const EntityTypeAny = "*"
+
 // Dispatch routes a ManageEntity transaction to the appropriate handler.
 // Returns nil if no handler is registered (unhandled entity/action pairs are silently skipped).
 // Returns a ValidationError if the handler rejects the transaction.
@@ -270,14 +275,21 @@ func (d *Dispatcher) Dispatch(ctx context.Context, params *Params) error {
 	key := handlerKey(params.EntityType, params.Action)
 	h, ok := d.handlers[key]
 	if !ok {
-		return nil
+		// Fall back to wildcard entity type match
+		h, ok = d.handlers[handlerKey(EntityTypeAny, params.Action)]
+		if !ok {
+			return nil
+		}
 	}
 	return h.Handle(ctx, params)
 }
 
 // HasHandler returns true if a handler is registered for the given entity_type and action.
 func (d *Dispatcher) HasHandler(entityType, action string) bool {
-	_, ok := d.handlers[handlerKey(entityType, action)]
+	if _, ok := d.handlers[handlerKey(entityType, action)]; ok {
+		return true
+	}
+	_, ok := d.handlers[handlerKey(EntityTypeAny, action)]
 	return ok
 }
 

--- a/pkg/etl/processors/entity_manager/social_follow.go
+++ b/pkg/etl/processors/entity_manager/social_follow.go
@@ -10,7 +10,7 @@ import (
 
 type followHandler struct{}
 
-func (h *followHandler) EntityType() string { return EntityTypeFollow }
+func (h *followHandler) EntityType() string { return EntityTypeAny }
 func (h *followHandler) Action() string     { return ActionFollow }
 
 func (h *followHandler) Handle(ctx context.Context, params *Params) error {
@@ -49,7 +49,7 @@ func validateFollow(ctx context.Context, params *Params) error {
 
 type unfollowHandler struct{}
 
-func (h *unfollowHandler) EntityType() string { return EntityTypeFollow }
+func (h *unfollowHandler) EntityType() string { return EntityTypeAny }
 func (h *unfollowHandler) Action() string     { return ActionUnfollow }
 
 func (h *unfollowHandler) Handle(ctx context.Context, params *Params) error {
@@ -77,7 +77,6 @@ func validateUnfollow(ctx context.Context, params *Params) error {
 // --- shared ---
 
 func insertFollow(ctx context.Context, params *Params, isDelete bool) error {
-	// Mark existing follow rows as not current
 	_, err := params.DBTX.Exec(ctx,
 		"UPDATE follows SET is_current = false WHERE follower_user_id = $1 AND followee_user_id = $2 AND is_current = true",
 		params.UserID, params.EntityID)
@@ -91,6 +90,24 @@ func insertFollow(ctx context.Context, params *Params, isDelete bool) error {
 			created_at, txhash, blocknumber
 		) VALUES ($1, $2, true, $3, $4, $5, $6)
 	`, params.UserID, params.EntityID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
+	if err != nil {
+		return err
+	}
+
+	// Python parity: Follow/Unfollow also creates/deletes a Subscription record
+	_, err = params.DBTX.Exec(ctx,
+		"UPDATE subscriptions SET is_current = false WHERE subscriber_id = $1 AND user_id = $2 AND is_current = true",
+		params.UserID, params.EntityID)
+	if err != nil {
+		return err
+	}
+	_, err = params.DBTX.Exec(ctx, `
+		INSERT INTO subscriptions (
+			subscriber_id, user_id, is_current, is_delete,
+			created_at, txhash, blocknumber
+		) VALUES ($1, $2, true, $3, $4, $5, $6)
+		ON CONFLICT DO NOTHING
+	`, params.UserID, params.EntityID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }
 
@@ -102,8 +119,5 @@ func followExists(ctx context.Context, dbtx db.DBTX, followerID, followeeID int6
 	return exists, err
 }
 
-// Follow returns the Follow handler.
-func Follow() Handler { return &followHandler{} }
-
-// Unfollow returns the Unfollow handler.
+func Follow() Handler   { return &followHandler{} }
 func Unfollow() Handler { return &unfollowHandler{} }

--- a/pkg/etl/processors/entity_manager/social_follow_test.go
+++ b/pkg/etl/processors/entity_manager/social_follow_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestFollow_TxType(t *testing.T) {
 	h := Follow()
-	if h.EntityType() != EntityTypeFollow {
-		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeFollow)
+	if h.EntityType() != EntityTypeAny {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeAny)
 	}
 	if h.Action() != ActionFollow {
 		t.Errorf("Action() = %q, want %q", h.Action(), ActionFollow)
@@ -22,7 +22,7 @@ func TestFollow_Success(t *testing.T) {
 	seedUser(t, pool, uid1, "0xfollower", "follower")
 	seedUser(t, pool, uid2, "0xfollowee", "followee")
 
-	params := buildParams(t, pool, EntityTypeFollow, ActionFollow, uid1, uid2, "0xFollower", `{}`)
+	params := buildParams(t, pool, EntityTypeUser, ActionFollow, uid1, uid2, "0xFollower", `{}`)
 	mustHandle(t, Follow(), params)
 
 	var isDelete bool
@@ -41,7 +41,7 @@ func TestFollow_RejectsSelfFollow(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)
 	seedUser(t, pool, uid, "0xself", "self")
-	params := buildParams(t, pool, EntityTypeFollow, ActionFollow, uid, uid, "0xSelf", `{}`)
+	params := buildParams(t, pool, EntityTypeUser, ActionFollow, uid, uid, "0xSelf", `{}`)
 	mustReject(t, Follow(), params, "cannot follow themselves")
 }
 
@@ -49,7 +49,7 @@ func TestFollow_RejectsNonexistentFollowee(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)
 	seedUser(t, pool, uid, "0xfollower", "follower")
-	params := buildParams(t, pool, EntityTypeFollow, ActionFollow, uid, UserIDOffset+999, "0xFollower", `{}`)
+	params := buildParams(t, pool, EntityTypeUser, ActionFollow, uid, UserIDOffset+999, "0xFollower", `{}`)
 	mustReject(t, Follow(), params, "does not exist")
 }
 
@@ -60,10 +60,10 @@ func TestFollow_RejectsDuplicate(t *testing.T) {
 	seedUser(t, pool, uid1, "0xfollower", "follower")
 	seedUser(t, pool, uid2, "0xfollowee", "followee")
 
-	params := buildParams(t, pool, EntityTypeFollow, ActionFollow, uid1, uid2, "0xFollower", `{}`)
+	params := buildParams(t, pool, EntityTypeUser, ActionFollow, uid1, uid2, "0xFollower", `{}`)
 	mustHandle(t, Follow(), params)
 
-	params2 := buildParams(t, pool, EntityTypeFollow, ActionFollow, uid1, uid2, "0xFollower", `{}`)
+	params2 := buildParams(t, pool, EntityTypeUser, ActionFollow, uid1, uid2, "0xFollower", `{}`)
 	mustReject(t, Follow(), params2, "already exists")
 }
 
@@ -74,8 +74,8 @@ func TestUnfollow_Success(t *testing.T) {
 	seedUser(t, pool, uid1, "0xfollower", "follower")
 	seedUser(t, pool, uid2, "0xfollowee", "followee")
 
-	mustHandle(t, Follow(), buildParams(t, pool, EntityTypeFollow, ActionFollow, uid1, uid2, "0xFollower", `{}`))
-	mustHandle(t, Unfollow(), buildParams(t, pool, EntityTypeFollow, ActionUnfollow, uid1, uid2, "0xFollower", `{}`))
+	mustHandle(t, Follow(), buildParams(t, pool, EntityTypeUser, ActionFollow, uid1, uid2, "0xFollower", `{}`))
+	mustHandle(t, Unfollow(), buildParams(t, pool, EntityTypeUser, ActionUnfollow, uid1, uid2, "0xFollower", `{}`))
 
 	var isDelete bool
 	err := pool.QueryRow(context.Background(),
@@ -95,6 +95,6 @@ func TestUnfollow_RejectsNoActiveFollow(t *testing.T) {
 	uid2 := int64(UserIDOffset + 2)
 	seedUser(t, pool, uid1, "0xfollower", "follower")
 	seedUser(t, pool, uid2, "0xfollowee", "followee")
-	params := buildParams(t, pool, EntityTypeFollow, ActionUnfollow, uid1, uid2, "0xFollower", `{}`)
+	params := buildParams(t, pool, EntityTypeUser, ActionUnfollow, uid1, uid2, "0xFollower", `{}`)
 	mustReject(t, Unfollow(), params, "no active follow")
 }

--- a/pkg/etl/processors/entity_manager/social_repost.go
+++ b/pkg/etl/processors/entity_manager/social_repost.go
@@ -11,7 +11,7 @@ import (
 
 type repostHandler struct{}
 
-func (h *repostHandler) EntityType() string { return EntityTypeRepost }
+func (h *repostHandler) EntityType() string { return EntityTypeAny }
 func (h *repostHandler) Action() string     { return ActionRepost }
 
 func (h *repostHandler) Handle(ctx context.Context, params *Params) error {
@@ -25,7 +25,10 @@ func validateRepost(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	repostType := repostTypeFromEntityType(params.MetadataString("type"))
+	repostType := repostTypeFromEntityType(params.EntityType)
+	if repostType == "" {
+		repostType = repostTypeFromEntityType(params.MetadataString("type"))
+	}
 	if repostType == "" {
 		repostType = inferRepostType(ctx, params.DBTX, params.EntityID)
 	}
@@ -51,7 +54,7 @@ func validateRepost(ctx context.Context, params *Params) error {
 
 type unrepostHandler struct{}
 
-func (h *unrepostHandler) EntityType() string { return EntityTypeRepost }
+func (h *unrepostHandler) EntityType() string { return EntityTypeAny }
 func (h *unrepostHandler) Action() string     { return ActionUnrepost }
 
 func (h *unrepostHandler) Handle(ctx context.Context, params *Params) error {
@@ -65,7 +68,10 @@ func validateUnrepost(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	repostType := repostTypeFromEntityType(params.MetadataString("type"))
+	repostType := repostTypeFromEntityType(params.EntityType)
+	if repostType == "" {
+		repostType = repostTypeFromEntityType(params.MetadataString("type"))
+	}
 	if repostType == "" {
 		repostType = inferRepostType(ctx, params.DBTX, params.EntityID)
 	}
@@ -85,7 +91,10 @@ func validateUnrepost(ctx context.Context, params *Params) error {
 // --- shared ---
 
 func insertRepost(ctx context.Context, params *Params, isDelete bool) error {
-	repostType := repostTypeFromEntityType(params.MetadataString("type"))
+	repostType := repostTypeFromEntityType(params.EntityType)
+	if repostType == "" {
+		repostType = repostTypeFromEntityType(params.MetadataString("type"))
+	}
 	if repostType == "" {
 		repostType = inferRepostType(ctx, params.DBTX, params.EntityID)
 	}
@@ -116,7 +125,6 @@ func repostExists(ctx context.Context, dbtx db.DBTX, userID, itemID int64, repos
 	return exists, err
 }
 
-// repostTypeFromEntityType maps the metadata "type" field to the reposttype enum value.
 func repostTypeFromEntityType(entityType string) string {
 	switch strings.ToLower(entityType) {
 	case "track":
@@ -129,7 +137,6 @@ func repostTypeFromEntityType(entityType string) string {
 	return ""
 }
 
-// inferRepostType checks if the entity ID corresponds to a track or playlist.
 func inferRepostType(ctx context.Context, dbtx db.DBTX, entityID int64) string {
 	var exists bool
 	_ = dbtx.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM tracks WHERE track_id = $1)", entityID).Scan(&exists)
@@ -170,8 +177,5 @@ func validateRepostTarget(ctx context.Context, dbtx db.DBTX, entityID int64, rep
 	return nil
 }
 
-// Repost returns the Repost handler.
-func Repost() Handler { return &repostHandler{} }
-
-// Unrepost returns the Unrepost handler.
+func Repost() Handler   { return &repostHandler{} }
 func Unrepost() Handler { return &unrepostHandler{} }

--- a/pkg/etl/processors/entity_manager/social_repost_test.go
+++ b/pkg/etl/processors/entity_manager/social_repost_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestRepost_TxType(t *testing.T) {
 	h := Repost()
-	if h.EntityType() != EntityTypeRepost {
-		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeRepost)
+	if h.EntityType() != EntityTypeAny {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeAny)
 	}
 	if h.Action() != ActionRepost {
 		t.Errorf("Action() = %q, want %q", h.Action(), ActionRepost)
@@ -24,7 +24,7 @@ func TestRepost_Track_Success(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	params := buildParams(t, pool, EntityTypeRepost, ActionRepost, uid, tid, "0xReposter", meta)
+	params := buildParams(t, pool, EntityTypeTrack, ActionRepost, uid, tid, "0xReposter", meta)
 	mustHandle(t, Repost(), params)
 
 	var isDelete bool
@@ -48,8 +48,8 @@ func TestRepost_RejectsDuplicate(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	mustHandle(t, Repost(), buildParams(t, pool, EntityTypeRepost, ActionRepost, uid, tid, "0xReposter", meta))
-	mustReject(t, Repost(), buildParams(t, pool, EntityTypeRepost, ActionRepost, uid, tid, "0xReposter", meta), "already exists")
+	mustHandle(t, Repost(), buildParams(t, pool, EntityTypeTrack, ActionRepost, uid, tid, "0xReposter", meta))
+	mustReject(t, Repost(), buildParams(t, pool, EntityTypeTrack, ActionRepost, uid, tid, "0xReposter", meta), "already exists")
 }
 
 func TestUnrepost_Success(t *testing.T) {
@@ -61,8 +61,8 @@ func TestUnrepost_Success(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	mustHandle(t, Repost(), buildParams(t, pool, EntityTypeRepost, ActionRepost, uid, tid, "0xReposter", meta))
-	mustHandle(t, Unrepost(), buildParams(t, pool, EntityTypeRepost, ActionUnrepost, uid, tid, "0xReposter", meta))
+	mustHandle(t, Repost(), buildParams(t, pool, EntityTypeTrack, ActionRepost, uid, tid, "0xReposter", meta))
+	mustHandle(t, Unrepost(), buildParams(t, pool, EntityTypeTrack, ActionUnrepost, uid, tid, "0xReposter", meta))
 
 	var isDelete bool
 	err := pool.QueryRow(context.Background(),
@@ -85,5 +85,5 @@ func TestUnrepost_RejectsNoActiveRepost(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	mustReject(t, Unrepost(), buildParams(t, pool, EntityTypeRepost, ActionUnrepost, uid, tid, "0xReposter", meta), "no active repost")
+	mustReject(t, Unrepost(), buildParams(t, pool, EntityTypeTrack, ActionUnrepost, uid, tid, "0xReposter", meta), "no active repost")
 }

--- a/pkg/etl/processors/entity_manager/social_save.go
+++ b/pkg/etl/processors/entity_manager/social_save.go
@@ -11,7 +11,7 @@ import (
 
 type saveHandler struct{}
 
-func (h *saveHandler) EntityType() string { return EntityTypeSave }
+func (h *saveHandler) EntityType() string { return EntityTypeAny }
 func (h *saveHandler) Action() string     { return ActionSave }
 
 func (h *saveHandler) Handle(ctx context.Context, params *Params) error {
@@ -25,9 +25,12 @@ func validateSave(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	saveType := saveTypeFromEntityType(params.MetadataString("type"))
+	// Use tx entity_type first (e.g. "Track", "Playlist"), then metadata, then DB inference
+	saveType := saveTypeFromEntityType(params.EntityType)
 	if saveType == "" {
-		// Fallback: infer from the entity being saved
+		saveType = saveTypeFromEntityType(params.MetadataString("type"))
+	}
+	if saveType == "" {
 		saveType = inferSaveType(ctx, params.DBTX, params.EntityID)
 	}
 	if saveType == "" {
@@ -52,7 +55,7 @@ func validateSave(ctx context.Context, params *Params) error {
 
 type unsaveHandler struct{}
 
-func (h *unsaveHandler) EntityType() string { return EntityTypeSave }
+func (h *unsaveHandler) EntityType() string { return EntityTypeAny }
 func (h *unsaveHandler) Action() string     { return ActionUnsave }
 
 func (h *unsaveHandler) Handle(ctx context.Context, params *Params) error {
@@ -66,7 +69,10 @@ func validateUnsave(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	saveType := saveTypeFromEntityType(params.MetadataString("type"))
+	saveType := saveTypeFromEntityType(params.EntityType)
+	if saveType == "" {
+		saveType = saveTypeFromEntityType(params.MetadataString("type"))
+	}
 	if saveType == "" {
 		saveType = inferSaveType(ctx, params.DBTX, params.EntityID)
 	}
@@ -86,7 +92,10 @@ func validateUnsave(ctx context.Context, params *Params) error {
 // --- shared ---
 
 func insertSave(ctx context.Context, params *Params, isDelete bool) error {
-	saveType := saveTypeFromEntityType(params.MetadataString("type"))
+	saveType := saveTypeFromEntityType(params.EntityType)
+	if saveType == "" {
+		saveType = saveTypeFromEntityType(params.MetadataString("type"))
+	}
 	if saveType == "" {
 		saveType = inferSaveType(ctx, params.DBTX, params.EntityID)
 	}
@@ -117,7 +126,6 @@ func saveExists(ctx context.Context, dbtx db.DBTX, userID, itemID int64, saveTyp
 	return exists, err
 }
 
-// saveTypeFromEntityType maps the metadata "type" field to the savetype enum value.
 func saveTypeFromEntityType(entityType string) string {
 	switch strings.ToLower(entityType) {
 	case "track":
@@ -130,7 +138,6 @@ func saveTypeFromEntityType(entityType string) string {
 	return ""
 }
 
-// inferSaveType checks if the entity ID corresponds to a track or playlist.
 func inferSaveType(ctx context.Context, dbtx db.DBTX, entityID int64) string {
 	var exists bool
 	_ = dbtx.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM tracks WHERE track_id = $1)", entityID).Scan(&exists)
@@ -172,8 +179,5 @@ func validateSaveTarget(ctx context.Context, dbtx db.DBTX, entityID int64, saveT
 	return nil
 }
 
-// Save returns the Save handler.
-func Save() Handler { return &saveHandler{} }
-
-// Unsave returns the Unsave handler.
+func Save() Handler   { return &saveHandler{} }
 func Unsave() Handler { return &unsaveHandler{} }

--- a/pkg/etl/processors/entity_manager/social_save_test.go
+++ b/pkg/etl/processors/entity_manager/social_save_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestSave_TxType(t *testing.T) {
 	h := Save()
-	if h.EntityType() != EntityTypeSave {
-		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeSave)
+	if h.EntityType() != EntityTypeAny {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeAny)
 	}
 	if h.Action() != ActionSave {
 		t.Errorf("Action() = %q, want %q", h.Action(), ActionSave)
@@ -24,7 +24,7 @@ func TestSave_Track_Success(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	params := buildParams(t, pool, EntityTypeSave, ActionSave, uid, tid, "0xSaver", meta)
+	params := buildParams(t, pool, EntityTypeTrack, ActionSave, uid, tid, "0xSaver", meta)
 	mustHandle(t, Save(), params)
 
 	var isDelete bool
@@ -48,8 +48,8 @@ func TestSave_RejectsDuplicate(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	mustHandle(t, Save(), buildParams(t, pool, EntityTypeSave, ActionSave, uid, tid, "0xSaver", meta))
-	mustReject(t, Save(), buildParams(t, pool, EntityTypeSave, ActionSave, uid, tid, "0xSaver", meta), "already exists")
+	mustHandle(t, Save(), buildParams(t, pool, EntityTypeTrack, ActionSave, uid, tid, "0xSaver", meta))
+	mustReject(t, Save(), buildParams(t, pool, EntityTypeTrack, ActionSave, uid, tid, "0xSaver", meta), "already exists")
 }
 
 func TestUnsave_Success(t *testing.T) {
@@ -61,8 +61,8 @@ func TestUnsave_Success(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	mustHandle(t, Save(), buildParams(t, pool, EntityTypeSave, ActionSave, uid, tid, "0xSaver", meta))
-	mustHandle(t, Unsave(), buildParams(t, pool, EntityTypeSave, ActionUnsave, uid, tid, "0xSaver", meta))
+	mustHandle(t, Save(), buildParams(t, pool, EntityTypeTrack, ActionSave, uid, tid, "0xSaver", meta))
+	mustHandle(t, Unsave(), buildParams(t, pool, EntityTypeTrack, ActionUnsave, uid, tid, "0xSaver", meta))
 
 	var isDelete bool
 	err := pool.QueryRow(context.Background(),
@@ -85,5 +85,5 @@ func TestUnsave_RejectsNoActiveSave(t *testing.T) {
 	seedTrack(t, pool, tid, UserIDOffset+2)
 
 	meta := `{"type":"track"}`
-	mustReject(t, Unsave(), buildParams(t, pool, EntityTypeSave, ActionUnsave, uid, tid, "0xSaver", meta), "no active save")
+	mustReject(t, Unsave(), buildParams(t, pool, EntityTypeTrack, ActionUnsave, uid, tid, "0xSaver", meta), "no active save")
 }


### PR DESCRIPTION
Social features (Follow, Save, Repost) receive the entity being acted on as
entity_type (User, Track, Playlist), not the action name. Add EntityTypeAny
wildcard with dispatcher fallback so these handlers match any entity_type for
their action. Also derive save/repost type from params.EntityType first,
matching Python discovery-provider behavior.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>