### PR TITLE
etl: add Subscribe/Unsubscribe handlers

### DIFF
--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -95,6 +95,8 @@ func (e *Indexer) Run() error {
 	e.dispatcher.Register(em.Unsave())
 	e.dispatcher.Register(em.Repost())
 	e.dispatcher.Register(em.Unrepost())
+	e.dispatcher.Register(em.Subscribe())
+	e.dispatcher.Register(em.Unsubscribe())
 	if e.config.IsDataTypeEnabled(em.EntityTypeDeveloperApp) {
 		e.dispatcher.Register(em.DeveloperAppCreate())
 		e.dispatcher.Register(em.DeveloperAppUpdate())

--- a/pkg/etl/processors/entity_manager/social_subscription.go
+++ b/pkg/etl/processors/entity_manager/social_subscription.go
@@ -1,0 +1,97 @@
+package entity_manager
+
+import (
+	"context"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+)
+
+type subscribeHandler struct{}
+
+func (h *subscribeHandler) EntityType() string { return EntityTypeAny }
+func (h *subscribeHandler) Action() string     { return ActionSubscribe }
+
+func (h *subscribeHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateSubscribe(ctx, params); err != nil {
+		return err
+	}
+	return insertSubscription(ctx, params, false)
+}
+
+func validateSubscribe(ctx context.Context, params *Params) error {
+	if params.UserID == params.EntityID {
+		return NewValidationError("user cannot subscribe to themselves")
+	}
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+	exists, err := userExists(ctx, params.DBTX, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return NewValidationError("subscription target user %d does not exist", params.EntityID)
+	}
+	dup, err := subscriptionExists(ctx, params.DBTX, params.UserID, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if dup {
+		return NewValidationError("subscription already exists from %d to %d", params.UserID, params.EntityID)
+	}
+	return nil
+}
+
+type unsubscribeHandler struct{}
+
+func (h *unsubscribeHandler) EntityType() string { return EntityTypeAny }
+func (h *unsubscribeHandler) Action() string     { return ActionUnsubscribe }
+
+func (h *unsubscribeHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateUnsubscribe(ctx, params); err != nil {
+		return err
+	}
+	return insertSubscription(ctx, params, true)
+}
+
+func validateUnsubscribe(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+	dup, err := subscriptionExists(ctx, params.DBTX, params.UserID, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if !dup {
+		return NewValidationError("no active subscription from %d to %d", params.UserID, params.EntityID)
+	}
+	return nil
+}
+
+func insertSubscription(ctx context.Context, params *Params, isDelete bool) error {
+	_, err := params.DBTX.Exec(ctx,
+		"UPDATE subscriptions SET is_current = false WHERE subscriber_id = $1 AND user_id = $2 AND is_current = true",
+		params.UserID, params.EntityID)
+	if err != nil {
+		return err
+	}
+
+	_, err = params.DBTX.Exec(ctx, `
+		INSERT INTO subscriptions (
+			subscriber_id, user_id, is_current, is_delete,
+			created_at, txhash, blocknumber
+		) VALUES ($1, $2, true, $3, $4, $5, $6)
+	`, params.UserID, params.EntityID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
+	return err
+}
+
+func subscriptionExists(ctx context.Context, dbtx db.DBTX, subscriberID, userID int64) (bool, error) {
+	var exists bool
+	err := dbtx.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM subscriptions WHERE subscriber_id = $1 AND user_id = $2 AND is_current = true AND is_delete = false)",
+		subscriberID, userID).Scan(&exists)
+	return exists, err
+}
+
+func Subscribe() Handler   { return &subscribeHandler{} }
+func Unsubscribe() Handler { return &unsubscribeHandler{} }

--- a/pkg/etl/processors/entity_manager/social_subscription_test.go
+++ b/pkg/etl/processors/entity_manager/social_subscription_test.go
@@ -1,0 +1,97 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSubscribe_TxType(t *testing.T) {
+	h := Subscribe()
+	if h.EntityType() != EntityTypeAny {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeAny)
+	}
+	if h.Action() != ActionSubscribe {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionSubscribe)
+	}
+}
+
+func TestSubscribe_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid1 := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid1, "0xsubscriber", "subscriber")
+	seedUser(t, pool, uid2, "0xpublisher", "publisher")
+
+	params := buildParams(t, pool, EntityTypeUser, ActionSubscribe, uid1, uid2, "0xSubscriber", `{}`)
+	mustHandle(t, Subscribe(), params)
+
+	var isDelete bool
+	err := pool.QueryRow(context.Background(),
+		"SELECT is_delete FROM subscriptions WHERE subscriber_id = $1 AND user_id = $2 AND is_current = true",
+		uid1, uid2).Scan(&isDelete)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if isDelete {
+		t.Error("expected is_delete = false")
+	}
+}
+
+func TestSubscribe_RejectsSelfSubscription(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xself", "self")
+	params := buildParams(t, pool, EntityTypeUser, ActionSubscribe, uid, uid, "0xSelf", `{}`)
+	mustReject(t, Subscribe(), params, "cannot subscribe to themselves")
+}
+
+func TestSubscribe_RejectsNonexistentTarget(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xsubscriber", "subscriber")
+	params := buildParams(t, pool, EntityTypeUser, ActionSubscribe, uid, UserIDOffset+999, "0xSubscriber", `{}`)
+	mustReject(t, Subscribe(), params, "does not exist")
+}
+
+func TestSubscribe_RejectsDuplicate(t *testing.T) {
+	pool := setupTestDB(t)
+	uid1 := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid1, "0xsubscriber", "subscriber")
+	seedUser(t, pool, uid2, "0xpublisher", "publisher")
+
+	mustHandle(t, Subscribe(), buildParams(t, pool, EntityTypeUser, ActionSubscribe, uid1, uid2, "0xSubscriber", `{}`))
+	mustReject(t, Subscribe(), buildParams(t, pool, EntityTypeUser, ActionSubscribe, uid1, uid2, "0xSubscriber", `{}`), "already exists")
+}
+
+func TestUnsubscribe_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid1 := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid1, "0xsubscriber", "subscriber")
+	seedUser(t, pool, uid2, "0xpublisher", "publisher")
+
+	mustHandle(t, Subscribe(), buildParams(t, pool, EntityTypeUser, ActionSubscribe, uid1, uid2, "0xSubscriber", `{}`))
+	mustHandle(t, Unsubscribe(), buildParams(t, pool, EntityTypeUser, ActionUnsubscribe, uid1, uid2, "0xSubscriber", `{}`))
+
+	var isDelete bool
+	err := pool.QueryRow(context.Background(),
+		"SELECT is_delete FROM subscriptions WHERE subscriber_id = $1 AND user_id = $2 AND is_current = true",
+		uid1, uid2).Scan(&isDelete)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !isDelete {
+		t.Error("expected is_delete = true")
+	}
+}
+
+func TestUnsubscribe_RejectsNoActiveSubscription(t *testing.T) {
+	pool := setupTestDB(t)
+	uid1 := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid1, "0xsubscriber", "subscriber")
+	seedUser(t, pool, uid2, "0xpublisher", "publisher")
+	params := buildParams(t, pool, EntityTypeUser, ActionUnsubscribe, uid1, uid2, "0xSubscriber", `{}`)
+	mustReject(t, Unsubscribe(), params, "no active subscription")
+}


### PR DESCRIPTION
Subscription handlers allow users to subscribe to other users' content updates.
Uses the same wildcard entity type pattern as Follow/Save/Repost since the
on-chain tx entity_type is the target user, not "Subscription".

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>