### PR TITLE
etl: add Share handler

### DIFF
--- a/pkg/etl/db/sql/migrations/0008_share_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0008_share_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS shares;
+DROP TYPE IF EXISTS sharetype;

--- a/pkg/etl/db/sql/migrations/0008_share_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0008_share_tables.up.sql
@@ -1,0 +1,21 @@
+-- Shares table matching discovery-provider schema.
+
+DO $$ BEGIN
+  CREATE TYPE sharetype AS ENUM ('track', 'playlist', 'album');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS shares (
+  blockhash character varying,
+  blocknumber integer REFERENCES blocks(number) ON DELETE CASCADE,
+  user_id integer NOT NULL,
+  share_item_id integer NOT NULL,
+  share_type sharetype NOT NULL,
+  created_at timestamp without time zone NOT NULL,
+  txhash character varying NOT NULL DEFAULT '',
+  slot integer,
+  CONSTRAINT shares_pkey PRIMARY KEY (user_id, share_item_id, share_type, txhash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_shares_blocknumber ON shares (blocknumber);
+CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares (user_id);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -97,6 +97,7 @@ func (e *Indexer) Run() error {
 	e.dispatcher.Register(em.Unrepost())
 	e.dispatcher.Register(em.Subscribe())
 	e.dispatcher.Register(em.Unsubscribe())
+	e.dispatcher.Register(em.Share())
 	if e.config.IsDataTypeEnabled(em.EntityTypeDeveloperApp) {
 		e.dispatcher.Register(em.DeveloperAppCreate())
 		e.dispatcher.Register(em.DeveloperAppUpdate())

--- a/pkg/etl/processors/entity_manager/social_share.go
+++ b/pkg/etl/processors/entity_manager/social_share.go
@@ -1,0 +1,72 @@
+package entity_manager
+
+import (
+	"context"
+	"strings"
+)
+
+type shareHandler struct{}
+
+func (h *shareHandler) EntityType() string { return EntityTypeAny }
+func (h *shareHandler) Action() string     { return ActionShare }
+
+func (h *shareHandler) Handle(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+
+	shareType := shareTypeFromEntityType(params.EntityType)
+	if shareType == "" {
+		shareType = shareTypeFromEntityType(params.MetadataString("type"))
+	}
+	if shareType == "" {
+		return NewValidationError("cannot determine share type for entity %d", params.EntityID)
+	}
+
+	if err := validateShareTarget(ctx, params, shareType); err != nil {
+		return err
+	}
+
+	_, err := params.DBTX.Exec(ctx, `
+		INSERT INTO shares (
+			user_id, share_item_id, share_type, created_at, txhash, blocknumber
+		) VALUES ($1, $2, $3::sharetype, $4, $5, $6)
+	`, params.UserID, params.EntityID, shareType, params.BlockTime, params.TxHash, params.BlockNumber)
+	return err
+}
+
+func shareTypeFromEntityType(entityType string) string {
+	switch strings.ToLower(entityType) {
+	case "track":
+		return "track"
+	case "playlist":
+		return "playlist"
+	case "album":
+		return "album"
+	}
+	return ""
+}
+
+func validateShareTarget(ctx context.Context, params *Params, shareType string) error {
+	var exists bool
+	switch shareType {
+	case "track":
+		e, err := trackExistsActive(ctx, params.DBTX, params.EntityID)
+		if err != nil {
+			return err
+		}
+		exists = e
+	case "playlist", "album":
+		e, err := playlistExistsActive(ctx, params.DBTX, params.EntityID)
+		if err != nil {
+			return err
+		}
+		exists = e
+	}
+	if !exists {
+		return NewValidationError("%s %d does not exist", shareType, params.EntityID)
+	}
+	return nil
+}
+
+func Share() Handler { return &shareHandler{} }

--- a/pkg/etl/processors/entity_manager/social_share_test.go
+++ b/pkg/etl/processors/entity_manager/social_share_test.go
@@ -1,0 +1,63 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestShare_TxType(t *testing.T) {
+	h := Share()
+	if h.EntityType() != EntityTypeAny {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeAny)
+	}
+	if h.Action() != ActionShare {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionShare)
+	}
+}
+
+func TestShare_Track_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xsharer", "sharer")
+	seedUser(t, pool, UserIDOffset+2, "0xtrackowner", "trackowner")
+	seedTrack(t, pool, tid, UserIDOffset+2)
+
+	params := buildParams(t, pool, EntityTypeTrack, ActionShare, uid, tid, "0xSharer", `{}`)
+	mustHandle(t, Share(), params)
+
+	var count int
+	err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM shares WHERE user_id = $1 AND share_item_id = $2",
+		uid, tid).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 share row, got %d", count)
+	}
+}
+
+func TestShare_AllowsDuplicates(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 2)
+	seedUser(t, pool, uid, "0xsharer", "sharer")
+	seedUser(t, pool, UserIDOffset+2, "0xtrackowner", "trackowner")
+	seedTrack(t, pool, tid, UserIDOffset+2)
+
+	// Shares allow duplicates (unlike saves/reposts)
+	mustHandle(t, Share(), buildParams(t, pool, EntityTypeTrack, ActionShare, uid, tid, "0xSharer", `{}`))
+	// Second share with different txhash should succeed
+	params2 := buildParams(t, pool, EntityTypeTrack, ActionShare, uid, tid, "0xSharer", `{}`)
+	params2.TxHash = "txhash-share-dup"
+	mustHandle(t, Share(), params2)
+}
+
+func TestShare_RejectsNonexistentTarget(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xsharer", "sharer")
+	params := buildParams(t, pool, EntityTypeTrack, ActionShare, uid, TrackIDOffset+999, "0xSharer", `{}`)
+	mustReject(t, Share(), params, "does not exist")
+}


### PR DESCRIPTION
Share handler records content shares (track/playlist/album). Unlike
Save/Repost, shares allow duplicates and have no Unshare counterpart.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>