### PR TITLE
etl: add Track Download handler

### DIFF
--- a/pkg/etl/db/sql/migrations/0009_track_download_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0009_track_download_tables.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS track_downloads;

--- a/pkg/etl/db/sql/migrations/0009_track_download_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0009_track_download_tables.up.sql
@@ -1,0 +1,17 @@
+-- Track downloads table matching discovery-provider schema.
+
+CREATE TABLE IF NOT EXISTS track_downloads (
+  txhash character varying NOT NULL,
+  blocknumber integer REFERENCES blocks(number) ON DELETE CASCADE,
+  parent_track_id integer NOT NULL,
+  track_id integer NOT NULL,
+  user_id integer NOT NULL,
+  city character varying,
+  region character varying,
+  country character varying,
+  created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT track_downloads_pkey PRIMARY KEY (parent_track_id, track_id, txhash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_track_downloads_user_id ON track_downloads (user_id);
+CREATE INDEX IF NOT EXISTS idx_track_downloads_track_id ON track_downloads (track_id);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -79,6 +79,7 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.TrackCreate())
 		e.dispatcher.Register(em.TrackUpdate())
 		e.dispatcher.Register(em.TrackDelete())
+		e.dispatcher.Register(em.TrackDownload())
 		e.dispatcher.Register(em.TrackMute())
 		e.dispatcher.Register(em.TrackUnmute())
 	}

--- a/pkg/etl/processors/entity_manager/track_download.go
+++ b/pkg/etl/processors/entity_manager/track_download.go
@@ -1,0 +1,78 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type trackDownloadHandler struct{}
+
+func (h *trackDownloadHandler) EntityType() string { return EntityTypeTrack }
+func (h *trackDownloadHandler) Action() string     { return ActionDownload }
+
+func (h *trackDownloadHandler) Handle(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+
+	trackID := params.EntityID
+
+	exists, err := trackExistsActive(ctx, params.DBTX, trackID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return NewValidationError("track %d does not exist", trackID)
+	}
+
+	// Determine parent_track_id: if this is a stem, use the parent; otherwise same as track_id
+	parentTrackID := trackID
+	var stemOfRaw []byte
+	err = params.DBTX.QueryRow(ctx,
+		"SELECT stem_of FROM tracks WHERE track_id = $1 AND is_current = true LIMIT 1",
+		trackID).Scan(&stemOfRaw)
+	if err == nil && stemOfRaw != nil {
+		var stemOf map[string]any
+		if json.Unmarshal(stemOfRaw, &stemOf) == nil {
+			if pid, ok := stemOf["parent_track_id"]; ok {
+				if pidFloat, ok := pid.(float64); ok {
+					parentTrackID = int64(pidFloat)
+				}
+			}
+		}
+	}
+
+	// Check for duplicate download
+	var dup bool
+	err = params.DBTX.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM track_downloads WHERE parent_track_id = $1 AND track_id = $2 AND txhash = $3)",
+		parentTrackID, trackID, params.TxHash).Scan(&dup)
+	if err != nil {
+		return err
+	}
+	if dup {
+		return nil // silently skip duplicate
+	}
+
+	city := params.MetadataString("city")
+	region := params.MetadataString("region")
+	country := params.MetadataString("country")
+
+	_, err = params.DBTX.Exec(ctx, `
+		INSERT INTO track_downloads (
+			txhash, blocknumber, parent_track_id, track_id, user_id,
+			city, region, country
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, params.TxHash, params.BlockNumber, parentTrackID, trackID, params.UserID,
+		nilIfEmpty(city), nilIfEmpty(region), nilIfEmpty(country))
+	return err
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func TrackDownload() Handler { return &trackDownloadHandler{} }

--- a/pkg/etl/processors/entity_manager/track_download_test.go
+++ b/pkg/etl/processors/entity_manager/track_download_test.go
@@ -1,0 +1,74 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTrackDownload_TxType(t *testing.T) {
+	h := TrackDownload()
+	if h.EntityType() != EntityTypeTrack {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeTrack)
+	}
+	if h.Action() != ActionDownload {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionDownload)
+	}
+}
+
+func TestTrackDownload_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	ownerID := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid, "0xdownloader", "downloader")
+	seedUser(t, pool, ownerID, "0xtrackowner", "trackowner")
+	seedTrack(t, pool, tid, ownerID)
+
+	meta := `{"city":"San Francisco","region":"CA","country":"US"}`
+	params := buildParams(t, pool, EntityTypeTrack, ActionDownload, uid, tid, "0xDownloader", meta)
+	mustHandle(t, TrackDownload(), params)
+
+	var city, region, country string
+	err := pool.QueryRow(context.Background(),
+		"SELECT city, region, country FROM track_downloads WHERE track_id = $1 AND user_id = $2",
+		tid, uid).Scan(&city, &region, &country)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if city != "San Francisco" || region != "CA" || country != "US" {
+		t.Errorf("got city=%q region=%q country=%q", city, region, country)
+	}
+}
+
+func TestTrackDownload_SkipsDuplicate(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 2)
+	ownerID := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid, "0xdownloader", "downloader")
+	seedUser(t, pool, ownerID, "0xtrackowner", "trackowner")
+	seedTrack(t, pool, tid, ownerID)
+
+	params := buildParams(t, pool, EntityTypeTrack, ActionDownload, uid, tid, "0xDownloader", `{}`)
+	mustHandle(t, TrackDownload(), params)
+	// Same txhash should silently skip
+	mustHandle(t, TrackDownload(), params)
+
+	var count int
+	err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM track_downloads WHERE track_id = $1", tid).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 download, got %d", count)
+	}
+}
+
+func TestTrackDownload_RejectsNonexistentTrack(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xdownloader", "downloader")
+	params := buildParams(t, pool, EntityTypeTrack, ActionDownload, uid, TrackIDOffset+999, "0xDownloader", `{}`)
+	mustReject(t, TrackDownload(), params, "does not exist")
+}


### PR DESCRIPTION
Records track downloads with optional geo metadata (city, region, country).
Resolves parent_track_id for stems and deduplicates by txhash.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>