### PR TITLE
etl: add Event Create/Update/Delete handlers

### DIFF
--- a/pkg/etl/db/sql/migrations/0010_event_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0010_event_tables.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS events;

--- a/pkg/etl/db/sql/migrations/0010_event_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0010_event_tables.up.sql
@@ -1,0 +1,21 @@
+-- Events table matching discovery-provider schema.
+
+CREATE TABLE IF NOT EXISTS events (
+  event_id integer NOT NULL,
+  event_type character varying NOT NULL,
+  user_id integer NOT NULL,
+  entity_type character varying,
+  entity_id integer,
+  end_date timestamp without time zone,
+  event_data jsonb,
+  is_deleted boolean NOT NULL DEFAULT false,
+  created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  txhash character varying NOT NULL DEFAULT '',
+  blockhash character varying NOT NULL DEFAULT '',
+  blocknumber integer REFERENCES blocks(number) ON DELETE CASCADE,
+  CONSTRAINT events_pkey PRIMARY KEY (event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_user_id ON events (user_id);
+CREATE INDEX IF NOT EXISTS idx_events_entity ON events (entity_id, entity_type);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -110,6 +110,11 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.GrantApprove())
 		e.dispatcher.Register(em.GrantReject())
 	}
+	if e.config.IsDataTypeEnabled(em.EntityTypeEvent) {
+		e.dispatcher.Register(em.EventCreate())
+		e.dispatcher.Register(em.EventUpdate())
+		e.dispatcher.Register(em.EventDelete())
+	}
 	if e.config.IsDataTypeEnabled(em.EntityTypeNotification) {
 		e.dispatcher.Register(em.NotificationCreate())
 		e.dispatcher.Register(em.NotificationView())

--- a/pkg/etl/processors/entity_manager/event_create.go
+++ b/pkg/etl/processors/entity_manager/event_create.go
@@ -1,0 +1,126 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+type eventCreateHandler struct{}
+
+func (h *eventCreateHandler) EntityType() string { return EntityTypeEvent }
+func (h *eventCreateHandler) Action() string     { return ActionCreate }
+
+func (h *eventCreateHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateCreateEvent(ctx, params); err != nil {
+		return err
+	}
+
+	eventType := params.MetadataString("event_type")
+	entityType := params.MetadataString("entity_type")
+	entityID, _ := params.MetadataInt64("entity_id")
+	endDateStr := params.MetadataString("end_date")
+
+	var eventDataJSON []byte
+	if ed, ok := params.MetadataJSON("event_data"); ok {
+		eventDataJSON, _ = json.Marshal(ed)
+	}
+
+	_, err := params.DBTX.Exec(ctx, `
+		INSERT INTO events (
+			event_id, event_type, user_id, entity_type, entity_id,
+			end_date, event_data, is_deleted,
+			created_at, updated_at, txhash, blocknumber
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, false, $8, $8, $9, $10)
+	`, params.EntityID, eventType, params.UserID, entityType, entityID,
+		endDateStr, eventDataJSON, params.BlockTime, params.TxHash, params.BlockNumber)
+	return err
+}
+
+func validateCreateEvent(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+
+	exists, err := eventExists(ctx, params.DBTX, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return NewValidationError("event %d already exists", params.EntityID)
+	}
+
+	eventType := params.MetadataString("event_type")
+	if eventType == "" {
+		return NewValidationError("missing required field: event_type")
+	}
+	endDateStr := params.MetadataString("end_date")
+	if endDateStr == "" {
+		return NewValidationError("missing required field: end_date")
+	}
+
+	endDate, err := time.Parse(time.RFC3339, endDateStr)
+	if err != nil {
+		endDate, err = time.Parse("2006-01-02T15:04:05", endDateStr)
+		if err != nil {
+			return NewValidationError("end_date is not a valid iso format")
+		}
+	}
+	if endDate.Before(params.BlockTime) {
+		return NewValidationError("end_date cannot be in the past")
+	}
+
+	userOK, err := userExists(ctx, params.DBTX, params.UserID)
+	if err != nil {
+		return err
+	}
+	if !userOK {
+		return NewValidationError("user %d does not exist", params.UserID)
+	}
+
+	entityType := params.MetadataString("entity_type")
+	entityID, hasEntityID := params.MetadataInt64("entity_id")
+	if entityType == "track" && hasEntityID {
+		trackOK, err := trackExistsActive(ctx, params.DBTX, entityID)
+		if err != nil {
+			return err
+		}
+		if !trackOK {
+			return NewValidationError("track %d does not exist", entityID)
+		}
+		ownerID, err := trackOwner(ctx, params.DBTX, entityID)
+		if err != nil {
+			return err
+		}
+		if ownerID != params.UserID {
+			return NewValidationError("user %d is not the owner of track %d", params.UserID, entityID)
+		}
+	}
+
+	if eventType == "remix_contest" {
+		if !hasEntityID || entityType == "" {
+			return NewValidationError("for remix competitions, entity_id and entity_type must be provided")
+		}
+		var contestExists bool
+		err := params.DBTX.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM events WHERE entity_id = $1 AND event_type = 'remix_contest' AND is_deleted = false AND end_date > $2)",
+			entityID, params.BlockTime).Scan(&contestExists)
+		if err != nil {
+			return err
+		}
+		if contestExists {
+			return NewValidationError("an existing remix contest for entity_id %d already exists", entityID)
+		}
+		var remixOf []byte
+		_ = params.DBTX.QueryRow(ctx,
+			"SELECT remix_of FROM tracks WHERE track_id = $1 AND is_current = true LIMIT 1",
+			entityID).Scan(&remixOf)
+		if remixOf != nil && string(remixOf) != "null" && string(remixOf) != "" {
+			return NewValidationError("track %d is a remix and cannot host a remix contest", entityID)
+		}
+	}
+
+	return nil
+}
+
+func EventCreate() Handler { return &eventCreateHandler{} }

--- a/pkg/etl/processors/entity_manager/event_delete.go
+++ b/pkg/etl/processors/entity_manager/event_delete.go
@@ -1,0 +1,46 @@
+package entity_manager
+
+import "context"
+
+type eventDeleteHandler struct{}
+
+func (h *eventDeleteHandler) EntityType() string { return EntityTypeEvent }
+func (h *eventDeleteHandler) Action() string     { return ActionDelete }
+
+func (h *eventDeleteHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateDeleteEvent(ctx, params); err != nil {
+		return err
+	}
+
+	_, err := params.DBTX.Exec(ctx, `
+		UPDATE events SET is_deleted = true, updated_at = $1, txhash = $2, blocknumber = $3
+		WHERE event_id = $4
+	`, params.BlockTime, params.TxHash, params.BlockNumber, params.EntityID)
+	return err
+}
+
+func validateDeleteEvent(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+
+	exists, err := eventExists(ctx, params.DBTX, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return NewValidationError("cannot delete event %d that does not exist", params.EntityID)
+	}
+
+	ownerID, err := eventOwner(ctx, params.DBTX, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if ownerID != params.UserID {
+		return NewValidationError("only event owner can delete event %d", params.EntityID)
+	}
+
+	return nil
+}
+
+func EventDelete() Handler { return &eventDeleteHandler{} }

--- a/pkg/etl/processors/entity_manager/event_queries.go
+++ b/pkg/etl/processors/entity_manager/event_queries.go
@@ -1,0 +1,41 @@
+package entity_manager
+
+import (
+	"context"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+)
+
+func eventExists(ctx context.Context, dbtx db.DBTX, eventID int64) (bool, error) {
+	var exists bool
+	err := dbtx.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM events WHERE event_id = $1 AND is_deleted = false)",
+		eventID).Scan(&exists)
+	return exists, err
+}
+
+func eventOwner(ctx context.Context, dbtx db.DBTX, eventID int64) (int64, error) {
+	var ownerID int64
+	err := dbtx.QueryRow(ctx,
+		"SELECT user_id FROM events WHERE event_id = $1 AND is_deleted = false",
+		eventID).Scan(&ownerID)
+	return ownerID, err
+}
+
+func eventTypeAndEndDate(ctx context.Context, dbtx db.DBTX, eventID int64) (string, *time.Time, error) {
+	var evtType string
+	var endDate *time.Time
+	err := dbtx.QueryRow(ctx,
+		"SELECT event_type, end_date FROM events WHERE event_id = $1 AND is_deleted = false",
+		eventID).Scan(&evtType, &endDate)
+	return evtType, endDate, err
+}
+
+func trackOwner(ctx context.Context, dbtx db.DBTX, trackID int64) (int64, error) {
+	var ownerID int64
+	err := dbtx.QueryRow(ctx,
+		"SELECT owner_id FROM tracks WHERE track_id = $1 AND is_current = true LIMIT 1",
+		trackID).Scan(&ownerID)
+	return ownerID, err
+}

--- a/pkg/etl/processors/entity_manager/event_test.go
+++ b/pkg/etl/processors/entity_manager/event_test.go
@@ -1,0 +1,191 @@
+package entity_manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestEventCreate_TxType(t *testing.T) {
+	h := EventCreate()
+	if h.EntityType() != EntityTypeEvent {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeEvent)
+	}
+	if h.Action() != ActionCreate {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionCreate)
+	}
+}
+
+func TestEventCreate_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedTrack(t, pool, tid, uid)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + endDate + `","event_data":{}}`
+	params := buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 1, "0xEventowner", meta)
+	mustHandle(t, EventCreate(), params)
+
+	var eventType string
+	err := pool.QueryRow(context.Background(),
+		"SELECT event_type FROM events WHERE event_id = $1",
+		1).Scan(&eventType)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if eventType != "remix_contest" {
+		t.Errorf("event_type = %q, want remix_contest", eventType)
+	}
+}
+
+func TestEventCreate_RejectsDuplicate(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedTrack(t, pool, tid, uid)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 1, "0xEventowner", meta))
+	mustReject(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 1, "0xEventowner", meta), "already exists")
+}
+
+func TestEventCreate_RejectsMissingEventType(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"end_date":"` + endDate + `"}`
+	mustReject(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 100, "0xEventowner", meta), "missing required field: event_type")
+}
+
+func TestEventCreate_RejectsMissingEndDate(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+
+	meta := `{"event_type":"remix_contest"}`
+	mustReject(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 101, "0xEventowner", meta), "missing required field: end_date")
+}
+
+func TestEventCreate_RejectsPastEndDate(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedTrack(t, pool, tid, uid)
+
+	pastDate := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + pastDate + `"}`
+	mustReject(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 102, "0xEventowner", meta), "end_date cannot be in the past")
+}
+
+func TestEventCreate_RejectsRemixOfRemix(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	parentTrackID := int64(TrackIDOffset + 1)
+	remixTrackID := int64(TrackIDOffset + 2)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedTrack(t, pool, parentTrackID, uid)
+
+	// Seed a track that is a remix of parentTrackID
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO tracks (track_id, owner_id, is_current, is_delete, track_segments, remix_of, created_at, updated_at, txhash)
+		VALUES ($1, $2, true, false, '[]', $3, now(), now(), '')
+	`, remixTrackID, uid, fmt.Sprintf(`{"tracks":[{"parent_track_id":%d}]}`, parentTrackID))
+	if err != nil {
+		t.Fatalf("seed remix track: %v", err)
+	}
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(remixTrackID) + `,"end_date":"` + endDate + `"}`
+	mustReject(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 103, "0xEventowner", meta), "remix and cannot host a remix contest")
+}
+
+func TestEventUpdate_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedTrack(t, pool, tid, uid)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 2, "0xEventowner", meta))
+
+	newEndDate := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+	updateMeta := `{"end_date":"` + newEndDate + `"}`
+	mustHandle(t, EventUpdate(), buildParams(t, pool, EntityTypeEvent, ActionUpdate, uid, 2, "0xEventowner", updateMeta))
+}
+
+func TestEventUpdate_RejectsNonOwner(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedUser(t, pool, uid2, "0xother", "other")
+	seedTrack(t, pool, tid, uid)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 3, "0xEventowner", meta))
+
+	mustReject(t, EventUpdate(), buildParams(t, pool, EntityTypeEvent, ActionUpdate, uid2, 3, "0xOther", `{}`), "only event owner")
+}
+
+func TestEventUpdate_RejectsNonexistent(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+
+	mustReject(t, EventUpdate(), buildParams(t, pool, EntityTypeEvent, ActionUpdate, uid, 999, "0xEventowner", `{}`), "does not exist")
+}
+
+func TestEventDelete_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedTrack(t, pool, tid, uid)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 4, "0xEventowner", meta))
+	mustHandle(t, EventDelete(), buildParams(t, pool, EntityTypeEvent, ActionDelete, uid, 4, "0xEventowner", `{}`))
+
+	var isDeleted bool
+	err := pool.QueryRow(context.Background(),
+		"SELECT is_deleted FROM events WHERE event_id = $1", 4).Scan(&isDeleted)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !isDeleted {
+		t.Error("expected is_deleted = true")
+	}
+}
+
+func TestEventDelete_RejectsNonOwner(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	tid := int64(TrackIDOffset + 1)
+	seedUser(t, pool, uid, "0xeventowner", "eventowner")
+	seedUser(t, pool, uid2, "0xother", "other")
+	seedTrack(t, pool, tid, uid)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	meta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(tid) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(), buildParams(t, pool, EntityTypeEvent, ActionCreate, uid, 5, "0xEventowner", meta))
+
+	mustReject(t, EventDelete(), buildParams(t, pool, EntityTypeEvent, ActionDelete, uid2, 5, "0xOther", `{}`), "only event owner")
+}
+
+func itoa(n int64) string {
+	return fmt.Sprintf("%d", n)
+}

--- a/pkg/etl/processors/entity_manager/event_update.go
+++ b/pkg/etl/processors/entity_manager/event_update.go
@@ -1,0 +1,89 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+type eventUpdateHandler struct{}
+
+func (h *eventUpdateHandler) EntityType() string { return EntityTypeEvent }
+func (h *eventUpdateHandler) Action() string     { return ActionUpdate }
+
+func (h *eventUpdateHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateUpdateEvent(ctx, params); err != nil {
+		return err
+	}
+
+	// Build a single UPDATE with all changed fields
+	endDateStr := params.MetadataString("end_date")
+	var endDate *string
+	if endDateStr != "" {
+		endDate = &endDateStr
+	}
+
+	var eventDataJSON []byte
+	if ed, ok := params.MetadataJSON("event_data"); ok {
+		eventDataJSON, _ = json.Marshal(ed)
+	}
+
+	_, err := params.DBTX.Exec(ctx, `
+		UPDATE events SET
+			end_date = COALESCE($1, end_date),
+			event_data = COALESCE($2, event_data),
+			updated_at = $3, txhash = $4, blocknumber = $5
+		WHERE event_id = $6
+	`, endDate, eventDataJSON, params.BlockTime, params.TxHash, params.BlockNumber, params.EntityID)
+	return err
+}
+
+func validateUpdateEvent(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+
+	exists, err := eventExists(ctx, params.DBTX, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return NewValidationError("cannot update event %d that does not exist", params.EntityID)
+	}
+
+	ownerID, err := eventOwner(ctx, params.DBTX, params.EntityID)
+	if err != nil {
+		return err
+	}
+	if ownerID != params.UserID {
+		return NewValidationError("only event owner can update event %d", params.EntityID)
+	}
+
+	endDateStr := params.MetadataString("end_date")
+	if endDateStr != "" {
+		endDate, err := time.Parse(time.RFC3339, endDateStr)
+		if err != nil {
+			endDate, err = time.Parse("2006-01-02T15:04:05", endDateStr)
+			if err != nil {
+				return NewValidationError("end_date is not a valid iso format")
+			}
+		}
+
+		// For remix contests, new end_date must be >= current end_date
+		evtType, curEndDate, err := eventTypeAndEndDate(ctx, params.DBTX, params.EntityID)
+		if err != nil {
+			return err
+		}
+		if evtType == "remix_contest" && curEndDate != nil {
+			if endDate.Before(*curEndDate) {
+				return NewValidationError("end_date cannot be before the current end_date of the remix contest")
+			}
+		} else if endDate.Before(params.BlockTime) {
+			return NewValidationError("end_date cannot be in the past")
+		}
+	}
+
+	return nil
+}
+
+func EventUpdate() Handler { return &eventUpdateHandler{} }


### PR DESCRIPTION
Event handlers support remix contests and general events with end_date
validation, ownership checks, and remix contest rules (no duplicate
active contests, no contests on remix tracks).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>