### PR TITLE
etl: add EncryptedEmail and EmailAccess handlers

### DIFF
--- a/pkg/etl/db/sql/migrations/0011_email_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0011_email_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS email_access;
+DROP TABLE IF EXISTS encrypted_emails;

--- a/pkg/etl/db/sql/migrations/0011_email_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0011_email_tables.up.sql
@@ -1,0 +1,19 @@
+-- Encrypted email tables matching discovery-provider schema.
+
+CREATE TABLE IF NOT EXISTS encrypted_emails (
+  email_owner_user_id integer NOT NULL,
+  encrypted_email text NOT NULL,
+  created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT encrypted_emails_pkey PRIMARY KEY (email_owner_user_id)
+);
+
+CREATE TABLE IF NOT EXISTS email_access (
+  email_owner_user_id integer NOT NULL,
+  receiving_user_id integer NOT NULL,
+  grantor_user_id integer NOT NULL,
+  encrypted_key text NOT NULL,
+  created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT email_access_pkey PRIMARY KEY (email_owner_user_id, receiving_user_id, grantor_user_id)
+);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -115,6 +115,12 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.EventUpdate())
 		e.dispatcher.Register(em.EventDelete())
 	}
+	if e.config.IsDataTypeEnabled(em.EntityTypeEncryptedEmail) {
+		e.dispatcher.Register(em.EncryptedEmailCreate())
+	}
+	if e.config.IsDataTypeEnabled(em.EntityTypeEmailAccess) {
+		e.dispatcher.Register(em.EmailAccessUpdate())
+	}
 	if e.config.IsDataTypeEnabled(em.EntityTypeNotification) {
 		e.dispatcher.Register(em.NotificationCreate())
 		e.dispatcher.Register(em.NotificationView())

--- a/pkg/etl/processors/entity_manager/email.go
+++ b/pkg/etl/processors/entity_manager/email.go
@@ -1,0 +1,160 @@
+package entity_manager
+
+import "context"
+
+type encryptedEmailHandler struct{}
+
+func (h *encryptedEmailHandler) EntityType() string { return EntityTypeEncryptedEmail }
+func (h *encryptedEmailHandler) Action() string     { return ActionAddEmail }
+
+func (h *encryptedEmailHandler) Handle(ctx context.Context, params *Params) error {
+	if params.Metadata == nil {
+		return NewValidationError("email metadata must be a dictionary")
+	}
+
+	ownerID, ok := params.MetadataInt64("email_owner_user_id")
+	if !ok {
+		return NewValidationError("missing required field: email_owner_user_id")
+	}
+	encryptedEmail := params.MetadataString("encrypted_email")
+	if encryptedEmail == "" {
+		return NewValidationError("missing required field: encrypted_email")
+	}
+	grantList, err := parseAccessGrants(params)
+	if err != nil {
+		return err
+	}
+
+	var exists bool
+	err = params.DBTX.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM encrypted_emails WHERE email_owner_user_id = $1)",
+		ownerID).Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil // silently skip if already exists
+	}
+
+	_, err = params.DBTX.Exec(ctx,
+		"INSERT INTO encrypted_emails (email_owner_user_id, encrypted_email) VALUES ($1, $2)",
+		ownerID, encryptedEmail)
+	if err != nil {
+		return err
+	}
+
+	for _, g := range grantList {
+		_, err = params.DBTX.Exec(ctx, `
+			INSERT INTO email_access (email_owner_user_id, receiving_user_id, grantor_user_id, encrypted_key)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (email_owner_user_id, receiving_user_id, grantor_user_id) DO NOTHING
+		`, ownerID, g.receivingUserID, g.grantorUserID, g.encryptedKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type emailAccessHandler struct{}
+
+func (h *emailAccessHandler) EntityType() string { return EntityTypeEmailAccess }
+func (h *emailAccessHandler) Action() string     { return ActionUpdate }
+
+func (h *emailAccessHandler) Handle(ctx context.Context, params *Params) error {
+	if params.Metadata == nil {
+		return NewValidationError("email metadata must be a dictionary")
+	}
+
+	ownerID, ok := params.MetadataInt64("email_owner_user_id")
+	if !ok {
+		return NewValidationError("missing required field: email_owner_user_id")
+	}
+	grantList, err := parseAccessGrants(params)
+	if err != nil {
+		return err
+	}
+
+	for _, g := range grantList {
+		// Verify grantor has access before granting to another user
+		var grantorHasAccess bool
+		err := params.DBTX.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM email_access WHERE email_owner_user_id = $1 AND receiving_user_id = $2)",
+			ownerID, g.grantorUserID).Scan(&grantorHasAccess)
+		if err != nil {
+			return err
+		}
+		if !grantorHasAccess {
+			return NewValidationError("grantor %d does not have access to the email", g.grantorUserID)
+		}
+
+		_, err = params.DBTX.Exec(ctx, `
+			INSERT INTO email_access (email_owner_user_id, receiving_user_id, grantor_user_id, encrypted_key)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (email_owner_user_id, receiving_user_id, grantor_user_id) DO NOTHING
+		`, ownerID, g.receivingUserID, g.grantorUserID, g.encryptedKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type accessGrant struct {
+	receivingUserID int64
+	grantorUserID   int64
+	encryptedKey    string
+}
+
+// parseAccessGrants extracts and validates access_grants from metadata.
+func parseAccessGrants(params *Params) ([]accessGrant, error) {
+	grants, ok := params.MetadataJSON("access_grants")
+	if !ok {
+		return nil, NewValidationError("missing required field: access_grants")
+	}
+	grantSlice, ok := grants.([]any)
+	if !ok {
+		return nil, NewValidationError("access_grants must be a list")
+	}
+
+	result := make([]accessGrant, 0, len(grantSlice))
+	for _, g := range grantSlice {
+		gMap, ok := g.(map[string]any)
+		if !ok {
+			return nil, NewValidationError("each access grant must be a dict")
+		}
+		receivingRaw, ok := gMap["receiving_user_id"]
+		if !ok {
+			return nil, NewValidationError("each access grant must contain receiving_user_id")
+		}
+		grantorRaw, ok := gMap["grantor_user_id"]
+		if !ok {
+			return nil, NewValidationError("each access grant must contain grantor_user_id")
+		}
+		encKey, ok := gMap["encrypted_key"].(string)
+		if !ok || encKey == "" {
+			return nil, NewValidationError("each access grant must contain encrypted_key")
+		}
+
+		receivingID, ok := receivingRaw.(float64)
+		if !ok {
+			return nil, NewValidationError("receiving_user_id must be a number")
+		}
+		grantorID, ok := grantorRaw.(float64)
+		if !ok {
+			return nil, NewValidationError("grantor_user_id must be a number")
+		}
+
+		result = append(result, accessGrant{
+			receivingUserID: int64(receivingID),
+			grantorUserID:   int64(grantorID),
+			encryptedKey:    encKey,
+		})
+	}
+	return result, nil
+}
+
+func EncryptedEmailCreate() Handler { return &encryptedEmailHandler{} }
+func EmailAccessUpdate() Handler    { return &emailAccessHandler{} }

--- a/pkg/etl/processors/entity_manager/email_test.go
+++ b/pkg/etl/processors/entity_manager/email_test.go
@@ -1,0 +1,168 @@
+package entity_manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestEncryptedEmailCreate_TxType(t *testing.T) {
+	h := EncryptedEmailCreate()
+	if h.EntityType() != EntityTypeEncryptedEmail {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeEncryptedEmail)
+	}
+	if h.Action() != ActionAddEmail {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionAddEmail)
+	}
+}
+
+func TestEncryptedEmailCreate_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xemailowner", "emailowner")
+
+	meta := `{
+		"email_owner_user_id": ` + fmt.Sprintf("%d", uid) + `,
+		"encrypted_email": "encrypted-data-here",
+		"access_grants": [
+			{"receiving_user_id": ` + fmt.Sprintf("%d", uid) + `, "grantor_user_id": ` + fmt.Sprintf("%d", uid) + `, "encrypted_key": "key1"}
+		]
+	}`
+	params := buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner", meta)
+	mustHandle(t, EncryptedEmailCreate(), params)
+
+	var encEmail string
+	err := pool.QueryRow(context.Background(),
+		"SELECT encrypted_email FROM encrypted_emails WHERE email_owner_user_id = $1", uid).Scan(&encEmail)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if encEmail != "encrypted-data-here" {
+		t.Errorf("encrypted_email = %q", encEmail)
+	}
+
+	var count int
+	err = pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM email_access WHERE email_owner_user_id = $1", uid).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 access record, got %d", count)
+	}
+}
+
+func TestEncryptedEmailCreate_SkipsDuplicate(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xemailowner", "emailowner")
+
+	meta := `{
+		"email_owner_user_id": ` + fmt.Sprintf("%d", uid) + `,
+		"encrypted_email": "encrypted-data-here",
+		"access_grants": []
+	}`
+	params := buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner", meta)
+	mustHandle(t, EncryptedEmailCreate(), params)
+	// Second call should silently skip
+	mustHandle(t, EncryptedEmailCreate(), params)
+}
+
+func TestEmailAccessUpdate_TxType(t *testing.T) {
+	h := EmailAccessUpdate()
+	if h.EntityType() != EntityTypeEmailAccess {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeEmailAccess)
+	}
+	if h.Action() != ActionUpdate {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionUpdate)
+	}
+}
+
+func TestEmailAccessUpdate_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	seedUser(t, pool, uid, "0xemailowner", "emailowner")
+	seedUser(t, pool, uid2, "0xreceiver", "receiver")
+
+	// First create the email with an initial grant to uid
+	createMeta := `{
+		"email_owner_user_id": ` + fmt.Sprintf("%d", uid) + `,
+		"encrypted_email": "encrypted-data",
+		"access_grants": [
+			{"receiving_user_id": ` + fmt.Sprintf("%d", uid) + `, "grantor_user_id": ` + fmt.Sprintf("%d", uid) + `, "encrypted_key": "key1"}
+		]
+	}`
+	mustHandle(t, EncryptedEmailCreate(), buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner", createMeta))
+
+	// Now grant access to uid2 via uid (grantor)
+	grantMeta := `{
+		"email_owner_user_id": ` + fmt.Sprintf("%d", uid) + `,
+		"access_grants": [
+			{"receiving_user_id": ` + fmt.Sprintf("%d", uid2) + `, "grantor_user_id": ` + fmt.Sprintf("%d", uid) + `, "encrypted_key": "key2"}
+		]
+	}`
+	mustHandle(t, EmailAccessUpdate(), buildParams(t, pool, EntityTypeEmailAccess, ActionUpdate, uid, uid, "0xEmailowner", grantMeta))
+
+	var count int
+	err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM email_access WHERE email_owner_user_id = $1", uid).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 access records, got %d", count)
+	}
+}
+
+func TestEncryptedEmailCreate_RejectsMissingFields(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xemailowner", "emailowner")
+
+	mustReject(t, EncryptedEmailCreate(), buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner",
+		`{"encrypted_email":"x","access_grants":[]}`), "missing required field: email_owner_user_id")
+	mustReject(t, EncryptedEmailCreate(), buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner",
+		fmt.Sprintf(`{"email_owner_user_id":%d,"access_grants":[]}`, uid)), "missing required field: encrypted_email")
+	mustReject(t, EncryptedEmailCreate(), buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner",
+		fmt.Sprintf(`{"email_owner_user_id":%d,"encrypted_email":"x"}`, uid)), "missing required field: access_grants")
+}
+
+func TestEncryptedEmailCreate_RejectsMalformedGrant(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xemailowner", "emailowner")
+
+	// Grant missing encrypted_key
+	meta := fmt.Sprintf(`{"email_owner_user_id":%d,"encrypted_email":"x","access_grants":[{"receiving_user_id":%d,"grantor_user_id":%d}]}`, uid, uid, uid)
+	mustReject(t, EncryptedEmailCreate(), buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner", meta), "encrypted_key")
+}
+
+func TestEmailAccessUpdate_RejectsUnauthorizedGrantor(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	uid2 := int64(UserIDOffset + 2)
+	uid3 := int64(UserIDOffset + 3)
+	seedUser(t, pool, uid, "0xemailowner", "emailowner")
+	seedUser(t, pool, uid2, "0xreceiver", "receiver")
+	seedUser(t, pool, uid3, "0xbadgrantor", "badgrantor")
+
+	// Create email with grant only to uid
+	createMeta := `{
+		"email_owner_user_id": ` + fmt.Sprintf("%d", uid) + `,
+		"encrypted_email": "encrypted-data",
+		"access_grants": [
+			{"receiving_user_id": ` + fmt.Sprintf("%d", uid) + `, "grantor_user_id": ` + fmt.Sprintf("%d", uid) + `, "encrypted_key": "key1"}
+		]
+	}`
+	mustHandle(t, EncryptedEmailCreate(), buildParams(t, pool, EntityTypeEncryptedEmail, ActionAddEmail, uid, uid, "0xEmailowner", createMeta))
+
+	// uid3 tries to grant but doesn't have access
+	grantMeta := `{
+		"email_owner_user_id": ` + fmt.Sprintf("%d", uid) + `,
+		"access_grants": [
+			{"receiving_user_id": ` + fmt.Sprintf("%d", uid2) + `, "grantor_user_id": ` + fmt.Sprintf("%d", uid3) + `, "encrypted_key": "key2"}
+		]
+	}`
+	mustReject(t, EmailAccessUpdate(), buildParams(t, pool, EntityTypeEmailAccess, ActionUpdate, uid3, uid, "0xBadgrantor", grantMeta), "does not have access")
+}


### PR DESCRIPTION
EncryptedEmail (AddEmail) stores encrypted user emails with initial
access grants. EmailAccess (Update) enables chain-of-custody access
delegation where grantors must already have access to grant others.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>