### PR TITLE
etl: add Tip reaction handler

### DIFF
--- a/pkg/etl/db/sql/migrations/0013_tip_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0013_tip_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS reactions;
+DROP TABLE IF EXISTS user_tips;

--- a/pkg/etl/db/sql/migrations/0013_tip_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0013_tip_tables.up.sql
@@ -1,0 +1,28 @@
+-- Tip-related tables matching discovery-provider schema.
+
+CREATE TABLE IF NOT EXISTS user_tips (
+  slot integer NOT NULL,
+  signature character varying NOT NULL,
+  sender_user_id integer NOT NULL,
+  receiver_user_id integer NOT NULL,
+  amount bigint NOT NULL,
+  created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT user_tips_pkey PRIMARY KEY (slot, signature)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_tips_sender ON user_tips (sender_user_id);
+CREATE INDEX IF NOT EXISTS idx_user_tips_receiver ON user_tips (receiver_user_id);
+
+CREATE TABLE IF NOT EXISTS reactions (
+  id serial NOT NULL,
+  reaction_value integer NOT NULL,
+  sender_wallet character varying NOT NULL,
+  reaction_type character varying NOT NULL,
+  reacted_to character varying NOT NULL,
+  timestamp timestamp without time zone NOT NULL,
+  blocknumber integer NOT NULL REFERENCES blocks(number) ON DELETE CASCADE,
+  CONSTRAINT reactions_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_reactions_reacted_to_type ON reactions (reacted_to, reaction_type);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -115,6 +115,9 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.EventUpdate())
 		e.dispatcher.Register(em.EventDelete())
 	}
+	if e.config.IsDataTypeEnabled(em.EntityTypeTip) {
+		e.dispatcher.Register(em.TipReaction())
+	}
 	if e.config.IsDataTypeEnabled(em.EntityTypeDashboardWalletUser) {
 		e.dispatcher.Register(em.DashboardWalletCreate())
 		e.dispatcher.Register(em.DashboardWalletDelete())

--- a/pkg/etl/processors/entity_manager/tip_reaction.go
+++ b/pkg/etl/processors/entity_manager/tip_reaction.go
@@ -1,0 +1,60 @@
+package entity_manager
+
+import "context"
+
+type tipReactionHandler struct{}
+
+func (h *tipReactionHandler) EntityType() string { return EntityTypeTip }
+func (h *tipReactionHandler) Action() string     { return ActionUpdate }
+
+func (h *tipReactionHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateTipReaction(ctx, params); err != nil {
+		return err
+	}
+
+	reactedTo := params.MetadataString("reacted_to")
+	reactionValue, _ := params.MetadataInt64("reaction_value")
+
+	// Look up the tip sender's wallet
+	var senderUserID int64
+	err := params.DBTX.QueryRow(ctx,
+		"SELECT sender_user_id FROM user_tips WHERE signature = $1 AND receiver_user_id = $2 LIMIT 1",
+		reactedTo, params.UserID).Scan(&senderUserID)
+	if err != nil {
+		return NewValidationError("tip with signature %s for user %d not found", reactedTo, params.UserID)
+	}
+
+	senderWallet, err := getUserWallet(ctx, params.DBTX, senderUserID)
+	if err != nil || senderWallet == "" {
+		return NewValidationError("tip sender %d wallet not found", senderUserID)
+	}
+
+	_, err = params.DBTX.Exec(ctx, `
+		INSERT INTO reactions (reaction_value, sender_wallet, reaction_type, reacted_to, timestamp, blocknumber)
+		VALUES ($1, $2, 'tip', $3, $4, $5)
+	`, reactionValue, senderWallet, reactedTo, params.BlockTime, params.BlockNumber)
+	return err
+}
+
+func validateTipReaction(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+
+	reactedTo := params.MetadataString("reacted_to")
+	if reactedTo == "" {
+		return NewValidationError("reacted_to is required")
+	}
+
+	reactionValue, ok := params.MetadataInt64("reaction_value")
+	if !ok {
+		return NewValidationError("reaction_value is required")
+	}
+	if reactionValue < 1 || reactionValue > 4 {
+		return NewValidationError("reaction_value must be between 1 and 4")
+	}
+
+	return nil
+}
+
+func TipReaction() Handler { return &tipReactionHandler{} }

--- a/pkg/etl/processors/entity_manager/tip_reaction_test.go
+++ b/pkg/etl/processors/entity_manager/tip_reaction_test.go
@@ -1,0 +1,81 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTipReaction_TxType(t *testing.T) {
+	h := TipReaction()
+	if h.EntityType() != EntityTypeTip {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeTip)
+	}
+	if h.Action() != ActionUpdate {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionUpdate)
+	}
+}
+
+func TestTipReaction_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	senderUID := int64(UserIDOffset + 1)
+	receiverUID := int64(UserIDOffset + 2)
+	seedUser(t, pool, senderUID, "0xsender", "sender")
+	seedUser(t, pool, receiverUID, "0xreceiver", "receiver")
+
+	// Seed a tip
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO user_tips (slot, signature, sender_user_id, receiver_user_id, amount)
+		VALUES (1, 'tip-sig-123', $1, $2, 1000000)
+	`, senderUID, receiverUID)
+	if err != nil {
+		t.Fatalf("seed tip: %v", err)
+	}
+
+	meta := `{"reacted_to":"tip-sig-123","reaction_value":1}`
+	params := buildParams(t, pool, EntityTypeTip, ActionUpdate, receiverUID, 0, "0xReceiver", meta)
+	mustHandle(t, TipReaction(), params)
+
+	var reactionValue int
+	var senderWallet string
+	err = pool.QueryRow(context.Background(),
+		"SELECT reaction_value, sender_wallet FROM reactions WHERE reacted_to = 'tip-sig-123'").Scan(&reactionValue, &senderWallet)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if reactionValue != 1 {
+		t.Errorf("reaction_value = %d, want 1", reactionValue)
+	}
+	if senderWallet != "0xsender" {
+		t.Errorf("sender_wallet = %q, want 0xsender", senderWallet)
+	}
+}
+
+func TestTipReaction_RejectsInvalidValue(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xreceiver", "receiver")
+
+	meta := `{"reacted_to":"some-sig","reaction_value":5}`
+	params := buildParams(t, pool, EntityTypeTip, ActionUpdate, uid, 0, "0xReceiver", meta)
+	mustReject(t, TipReaction(), params, "must be between 1 and 4")
+}
+
+func TestTipReaction_RejectsTipNotFound(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xreceiver", "receiver")
+
+	meta := `{"reacted_to":"nonexistent-sig","reaction_value":1}`
+	params := buildParams(t, pool, EntityTypeTip, ActionUpdate, uid, 0, "0xReceiver", meta)
+	mustReject(t, TipReaction(), params, "tip with signature")
+}
+
+func TestTipReaction_RejectsMissingReactedTo(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xreceiver", "receiver")
+
+	meta := `{"reaction_value":1}`
+	params := buildParams(t, pool, EntityTypeTip, ActionUpdate, uid, 0, "0xReceiver", meta)
+	mustReject(t, TipReaction(), params, "reacted_to is required")
+}


### PR DESCRIPTION
Tip reaction handler (TIP + Update) records emoji reactions to tips.
Looks up tip sender via user_tips table signature and records a reaction
with validated value (1-4).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>