### PR TITLE
etl: add AssociatedWallet Create/Delete handlers

### DIFF
--- a/pkg/etl/db/sql/migrations/0014_associated_wallets.down.sql
+++ b/pkg/etl/db/sql/migrations/0014_associated_wallets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS associated_wallets;

--- a/pkg/etl/db/sql/migrations/0014_associated_wallets.up.sql
+++ b/pkg/etl/db/sql/migrations/0014_associated_wallets.up.sql
@@ -1,0 +1,19 @@
+-- Associated wallets table matching discovery-provider schema.
+
+CREATE TABLE IF NOT EXISTS associated_wallets (
+  id serial NOT NULL,
+  user_id integer NOT NULL,
+  wallet character varying NOT NULL,
+  chain character varying NOT NULL,
+  is_current boolean NOT NULL DEFAULT true,
+  is_delete boolean NOT NULL DEFAULT false,
+  blockhash character varying NOT NULL DEFAULT '',
+  blocknumber integer REFERENCES blocks(number) ON DELETE CASCADE,
+  created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT associated_wallets_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_associated_wallets_user_id ON associated_wallets (user_id);
+CREATE INDEX IF NOT EXISTS idx_associated_wallets_wallet ON associated_wallets (wallet);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_associated_wallets_unique_active ON associated_wallets (user_id, wallet, chain) WHERE is_current = true AND is_delete = false;

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -115,6 +115,10 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.EventUpdate())
 		e.dispatcher.Register(em.EventDelete())
 	}
+	if e.config.IsDataTypeEnabled(em.EntityTypeAssociatedWallet) {
+		e.dispatcher.Register(em.AssociatedWalletCreate())
+		e.dispatcher.Register(em.AssociatedWalletDelete())
+	}
 	if e.config.IsDataTypeEnabled(em.EntityTypeTip) {
 		e.dispatcher.Register(em.TipReaction())
 	}

--- a/pkg/etl/processors/entity_manager/associated_wallet.go
+++ b/pkg/etl/processors/entity_manager/associated_wallet.go
@@ -1,0 +1,193 @@
+package entity_manager
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+)
+
+type associatedWalletCreateHandler struct{}
+
+func (h *associatedWalletCreateHandler) EntityType() string { return EntityTypeAssociatedWallet }
+func (h *associatedWalletCreateHandler) Action() string     { return ActionCreate }
+
+func (h *associatedWalletCreateHandler) Handle(ctx context.Context, params *Params) error {
+	wallet := strings.ToLower(params.MetadataString("wallet"))
+	chain := params.MetadataString("chain")
+
+	if err := validateAssociatedWalletCreate(ctx, params, wallet, chain); err != nil {
+		return err
+	}
+
+	// Remove wallet from other users on the same chain (exclusive ownership)
+	_, err := params.DBTX.Exec(ctx,
+		"UPDATE associated_wallets SET is_current = false, is_delete = true WHERE wallet = $1 AND chain = $2 AND user_id != $3 AND is_current = true",
+		wallet, chain, params.UserID)
+	if err != nil {
+		return err
+	}
+
+	_, err = params.DBTX.Exec(ctx,
+		"UPDATE associated_wallets SET is_current = false WHERE user_id = $1 AND wallet = $2 AND chain = $3 AND is_current = true",
+		params.UserID, wallet, chain)
+	if err != nil {
+		return err
+	}
+
+	_, err = params.DBTX.Exec(ctx, `
+		INSERT INTO associated_wallets (user_id, wallet, chain, is_current, is_delete, blocknumber, created_at, updated_at)
+		VALUES ($1, $2, $3, true, false, $4, $5, $5)
+	`, params.UserID, wallet, chain, params.BlockNumber, params.BlockTime)
+	return err
+}
+
+func validateAssociatedWalletCreate(ctx context.Context, params *Params, wallet, chain string) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+	if wallet == "" {
+		return NewValidationError("wallet address is required")
+	}
+	if chain == "" {
+		return NewValidationError("chain is required")
+	}
+	if chain != "eth" && chain != "sol" {
+		return NewValidationError("chain must be eth or sol, got %s", chain)
+	}
+
+	return verifyAssociatedWalletSignature(params, wallet, chain)
+}
+
+// verifyAssociatedWalletSignature verifies the wallet_signature proves ownership of the wallet.
+// ETH wallets use personal_sign (ecrecover), SOL wallets use ed25519.
+func verifyAssociatedWalletSignature(params *Params, wallet, chain string) error {
+	sig := extractSignature(params, "wallet_signature")
+	if sig == nil {
+		return NewValidationError("wallet_signature is required")
+	}
+
+	switch chain {
+	case "eth":
+		recovered, err := recoverETHAddress(sig.message, sig.signature)
+		if err != nil {
+			return NewValidationError("invalid wallet_signature: %v", err)
+		}
+		if !strings.EqualFold(recovered, wallet) {
+			return NewValidationError("wallet_signature was not signed by wallet %s", wallet)
+		}
+	case "sol":
+		if err := verifySolSignature(sig.message, sig.signature, wallet); err != nil {
+			return NewValidationError("invalid sol wallet_signature: %v", err)
+		}
+	}
+	return nil
+}
+
+// verifySolSignature verifies an ed25519 signature from a Solana wallet.
+// The signature and public key are expected as base58-encoded strings.
+func verifySolSignature(message, signatureB64, walletB58 string) error {
+	pubKeyBytes, err := base58Decode(walletB58)
+	if err != nil {
+		return fmt.Errorf("invalid solana wallet address: %w", err)
+	}
+	if len(pubKeyBytes) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid solana public key length: %d", len(pubKeyBytes))
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signatureB64)
+	if err != nil {
+		// Try base58 as fallback
+		sigBytes, err = base58Decode(signatureB64)
+		if err != nil {
+			return fmt.Errorf("invalid signature encoding: %w", err)
+		}
+	}
+	if len(sigBytes) != ed25519.SignatureSize {
+		return fmt.Errorf("invalid signature length: %d", len(sigBytes))
+	}
+
+	if !ed25519.Verify(pubKeyBytes, []byte(message), sigBytes) {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+// base58Decode decodes a base58 (Bitcoin alphabet) string.
+func base58Decode(s string) ([]byte, error) {
+	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+	result := []byte{0}
+	for _, c := range []byte(s) {
+		carry := strings.IndexByte(alphabet, c)
+		if carry < 0 {
+			return nil, fmt.Errorf("invalid base58 character: %c", c)
+		}
+		for i := range result {
+			carry += int(result[i]) * 58
+			result[i] = byte(carry & 0xff)
+			carry >>= 8
+		}
+		for carry > 0 {
+			result = append(result, byte(carry&0xff))
+			carry >>= 8
+		}
+	}
+	// Count leading '1's
+	for _, c := range []byte(s) {
+		if c != '1' {
+			break
+		}
+		result = append(result, 0)
+	}
+	// Reverse
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+	return result, nil
+}
+
+type associatedWalletDeleteHandler struct{}
+
+func (h *associatedWalletDeleteHandler) EntityType() string { return EntityTypeAssociatedWallet }
+func (h *associatedWalletDeleteHandler) Action() string     { return ActionDelete }
+
+func (h *associatedWalletDeleteHandler) Handle(ctx context.Context, params *Params) error {
+	wallet := strings.ToLower(params.MetadataString("wallet"))
+	chain := params.MetadataString("chain")
+
+	if err := validateAssociatedWalletDelete(ctx, params, wallet, chain); err != nil {
+		return err
+	}
+
+	_, err := params.DBTX.Exec(ctx,
+		"UPDATE associated_wallets SET is_current = false, is_delete = true, updated_at = $1 WHERE user_id = $2 AND wallet = $3 AND chain = $4 AND is_current = true",
+		params.BlockTime, params.UserID, wallet, chain)
+	return err
+}
+
+func validateAssociatedWalletDelete(ctx context.Context, params *Params, wallet, chain string) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+	if wallet == "" {
+		return NewValidationError("wallet address is required")
+	}
+
+	var exists bool
+	err := params.DBTX.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM associated_wallets WHERE user_id = $1 AND wallet = $2 AND is_current = true AND is_delete = false)",
+		params.UserID, wallet).Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return NewValidationError("associated wallet %s not found for user %d", wallet, params.UserID)
+	}
+
+	return nil
+}
+
+func AssociatedWalletCreate() Handler { return &associatedWalletCreateHandler{} }
+func AssociatedWalletDelete() Handler { return &associatedWalletDeleteHandler{} }

--- a/pkg/etl/processors/entity_manager/associated_wallet_test.go
+++ b/pkg/etl/processors/entity_manager/associated_wallet_test.go
@@ -1,0 +1,208 @@
+package entity_manager
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestAssociatedWalletCreate_TxType(t *testing.T) {
+	h := AssociatedWalletCreate()
+	if h.EntityType() != EntityTypeAssociatedWallet {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeAssociatedWallet)
+	}
+	if h.Action() != ActionCreate {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionCreate)
+	}
+}
+
+func TestAssociatedWalletCreate_ETH_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	userKey, _ := crypto.GenerateKey()
+	userAddr := testETHAddress(userKey)
+	seedUser(t, pool, uid, userAddr, "user1")
+
+	walletKey, _ := crypto.GenerateKey()
+	walletAddr := testETHAddress(walletKey)
+	msg := "Connecting Audius wallet"
+	sig := testETHSign(t, walletKey, msg)
+
+	meta := fmt.Sprintf(`{"wallet":"%s","chain":"eth","wallet_signature":{"message":"%s","signature":"%s"}}`, walletAddr, msg, sig)
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, userAddr, meta)
+	mustHandle(t, AssociatedWalletCreate(), params)
+
+	var wallet, chain string
+	err := pool.QueryRow(context.Background(),
+		"SELECT wallet, chain FROM associated_wallets WHERE user_id = $1 AND is_current = true AND is_delete = false",
+		uid).Scan(&wallet, &chain)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if chain != "eth" {
+		t.Errorf("chain = %q, want eth", chain)
+	}
+}
+
+func TestAssociatedWalletCreate_ETH_RejectsWrongSigner(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	userKey, _ := crypto.GenerateKey()
+	userAddr := testETHAddress(userKey)
+	seedUser(t, pool, uid, userAddr, "user1")
+
+	walletKey, _ := crypto.GenerateKey()
+	walletAddr := testETHAddress(walletKey)
+	// Sign with user key instead of wallet key
+	msg := "Connecting Audius wallet"
+	sig := testETHSign(t, userKey, msg)
+
+	meta := fmt.Sprintf(`{"wallet":"%s","chain":"eth","wallet_signature":{"message":"%s","signature":"%s"}}`, walletAddr, msg, sig)
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, userAddr, meta)
+	mustReject(t, AssociatedWalletCreate(), params, "wallet_signature was not signed by wallet")
+}
+
+func TestAssociatedWalletCreate_SOL_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	userKey, _ := crypto.GenerateKey()
+	userAddr := testETHAddress(userKey)
+	seedUser(t, pool, uid, userAddr, "user1")
+
+	// Generate ed25519 key pair for Solana wallet
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	solAddr := base58Encode(pub)
+
+	msg := "Connecting Audius wallet"
+	sigBytes := ed25519.Sign(priv, []byte(msg))
+	sigB64 := base64.StdEncoding.EncodeToString(sigBytes)
+
+	meta := fmt.Sprintf(`{"wallet":"%s","chain":"sol","wallet_signature":{"message":"%s","signature":"%s"}}`, solAddr, msg, sigB64)
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, userAddr, meta)
+	mustHandle(t, AssociatedWalletCreate(), params)
+
+	var wallet, chain string
+	err := pool.QueryRow(context.Background(),
+		"SELECT wallet, chain FROM associated_wallets WHERE user_id = $1 AND is_current = true AND is_delete = false",
+		uid).Scan(&wallet, &chain)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if chain != "sol" {
+		t.Errorf("chain = %q, want sol", chain)
+	}
+}
+
+func TestAssociatedWalletCreate_RejectsMissingWallet(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xuser1", "user1")
+	meta := `{"chain":"eth"}`
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, "0xUser1", meta)
+	mustReject(t, AssociatedWalletCreate(), params, "wallet address is required")
+}
+
+func TestAssociatedWalletCreate_RejectsMissingChain(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xuser1", "user1")
+	meta := `{"wallet":"0xassoc1"}`
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, "0xUser1", meta)
+	mustReject(t, AssociatedWalletCreate(), params, "chain is required")
+}
+
+func TestAssociatedWalletCreate_RejectsInvalidChain(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xuser1", "user1")
+	meta := `{"wallet":"0xassoc1","chain":"btc"}`
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, "0xUser1", meta)
+	mustReject(t, AssociatedWalletCreate(), params, "chain must be eth or sol")
+}
+
+func TestAssociatedWalletCreate_RejectsMissingSig(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xuser1", "user1")
+	meta := `{"wallet":"0xassoc1","chain":"eth"}`
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, "0xUser1", meta)
+	mustReject(t, AssociatedWalletCreate(), params, "wallet_signature is required")
+}
+
+func TestAssociatedWalletDelete_Success(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	userKey, _ := crypto.GenerateKey()
+	walletKey, _ := crypto.GenerateKey()
+	userAddr := testETHAddress(userKey)
+	walletAddr := testETHAddress(walletKey)
+	seedUser(t, pool, uid, userAddr, "user1")
+
+	msg := "Connecting Audius wallet"
+	sig := testETHSign(t, walletKey, msg)
+	createMeta := fmt.Sprintf(`{"wallet":"%s","chain":"eth","wallet_signature":{"message":"%s","signature":"%s"}}`, walletAddr, msg, sig)
+	mustHandle(t, AssociatedWalletCreate(), buildParams(t, pool, EntityTypeAssociatedWallet, ActionCreate, uid, 0, userAddr, createMeta))
+
+	deleteMeta := fmt.Sprintf(`{"wallet":"%s"}`, walletAddr)
+	mustHandle(t, AssociatedWalletDelete(), buildParams(t, pool, EntityTypeAssociatedWallet, ActionDelete, uid, 0, userAddr, deleteMeta))
+
+	var count int
+	err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM associated_wallets WHERE user_id = $1 AND is_current = true AND is_delete = false", uid).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 active wallets, got %d", count)
+	}
+}
+
+func TestAssociatedWalletDelete_RejectsNonexistent(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xuser1", "user1")
+	params := buildParams(t, pool, EntityTypeAssociatedWallet, ActionDelete, uid, 0, "0xUser1", `{"wallet":"0xnotfound"}`)
+	mustReject(t, AssociatedWalletDelete(), params, "not found")
+}
+
+// base58Encode encodes bytes to base58 (Bitcoin alphabet).
+func base58Encode(b []byte) string {
+	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+	// Count leading zeros
+	var zeros int
+	for _, v := range b {
+		if v != 0 {
+			break
+		}
+		zeros++
+	}
+	// Convert to base58
+	size := len(b)*138/100 + 1
+	buf := make([]byte, size)
+	var length int
+	for _, v := range b {
+		carry := int(v)
+		for i := 0; i < length || carry != 0; i++ {
+			if i < length {
+				carry += 256 * int(buf[i])
+			}
+			buf[i] = byte(carry % 58)
+			carry /= 58
+			if i >= length {
+				length = i + 1
+			}
+		}
+	}
+	result := make([]byte, zeros+length)
+	for i := 0; i < zeros; i++ {
+		result[i] = '1'
+	}
+	for i := 0; i < length; i++ {
+		result[zeros+i] = alphabet[buf[length-1-i]]
+	}
+	return string(result)
+}


### PR DESCRIPTION
Associated wallets link external ETH/SOL wallets to user accounts.
Enforces exclusive ownership (one user per wallet per chain).
Full chain-specific signature verification (ecrecover/ed25519) is TODO
pending crypto dependency additions to the ETL module.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>