### PR TITLE
etl: add parity test tooling (snapshot/diff)

### DIFF
--- a/pkg/etl/parity/diff.go
+++ b/pkg/etl/parity/diff.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Diff compares domain table state after the ETL ran against the snapshot baseline.
+func Diff(ctx context.Context, pool *pgxpool.Pool) error {
+	// Read snapshot metadata
+	var maxBlock int64
+	err := pool.QueryRow(ctx,
+		`SELECT value_int FROM _parity_meta WHERE key = 'max_block'`).Scan(&maxBlock)
+	if err != nil {
+		return fmt.Errorf("reading snapshot max_block (did you run 'snapshot' first?): %w", err)
+	}
+
+	var snapshotTime string
+	err = pool.QueryRow(ctx,
+		`SELECT value_text FROM _parity_meta WHERE key = 'snapshot_time'`).Scan(&snapshotTime)
+	if err != nil {
+		return fmt.Errorf("reading snapshot_time: %w", err)
+	}
+
+	// Get current max block (after ETL ran)
+	var currentMaxBlock int64
+	pool.QueryRow(ctx, `SELECT COALESCE(MAX(number), 0) FROM blocks`).Scan(&currentMaxBlock)
+
+	// Get max ETL block
+	var etlMaxBlock int64
+	pool.QueryRow(ctx, `SELECT COALESCE(MAX(block_height), 0) FROM etl_blocks`).Scan(&etlMaxBlock)
+
+	fmt.Printf("=== ETL Parity Report ===\n")
+	fmt.Printf("Snapshot block:  %d\n", maxBlock)
+	fmt.Printf("Current block:   %d (blocks table)\n", currentMaxBlock)
+	fmt.Printf("ETL max block:   %d (etl_blocks table)\n", etlMaxBlock)
+	fmt.Printf("Blocks indexed:  %d\n", etlMaxBlock-maxBlock)
+	fmt.Printf("Snapshot time:   %s\n\n", snapshotTime)
+
+	// --- Raw Transaction Counts ---
+	fmt.Printf("--- Raw ManageEntity Transactions (block > %d) ---\n", maxBlock)
+	rows, err := pool.Query(ctx, `
+		SELECT entity_type, action, COUNT(*)
+		FROM etl_manage_entities
+		WHERE block_height > $1
+		GROUP BY entity_type, action
+		ORDER BY COUNT(*) DESC
+	`, maxBlock)
+	if err != nil {
+		return fmt.Errorf("query etl_manage_entities: %w", err)
+	}
+	defer rows.Close()
+
+	txCounts := map[string]int64{}
+	var totalTxs int64
+	fmt.Printf("%-20s %-15s %10s\n", "EntityType", "Action", "Count")
+	fmt.Printf("%-20s %-15s %10s\n", "----------", "------", "-----")
+	for rows.Next() {
+		var entityType, action string
+		var count int64
+		if err := rows.Scan(&entityType, &action, &count); err != nil {
+			return err
+		}
+		key := entityType + "/" + action
+		txCounts[key] = count
+		totalTxs += count
+		fmt.Printf("%-20s %-15s %10d\n", entityType, action, count)
+	}
+	fmt.Printf("%-20s %-15s %10d\n\n", "TOTAL", "", totalTxs)
+
+	// --- Domain Table Growth ---
+	fmt.Printf("--- Domain Table Growth (blocknumber > %d) ---\n", maxBlock)
+	fmt.Printf("%-30s %10s %10s %10s\n", "Table", "Baseline", "New Rows", "Total Now")
+	fmt.Printf("%-30s %10s %10s %10s\n", "-----", "--------", "--------", "---------")
+
+	for _, t := range tables {
+		// Get baseline from snapshot
+		var baseline int64
+		err := pool.QueryRow(ctx,
+			`SELECT COALESCE(value_int, 0) FROM _parity_meta WHERE key = $1`,
+			"count_"+t.Name).Scan(&baseline)
+		if err != nil {
+			baseline = -1
+		}
+
+		// Count total rows now
+		totalNow, err := countRows(ctx, pool, t.Name, "")
+		if err != nil {
+			fmt.Printf("%-30s %10s %10s %10s (table may not exist)\n", t.Name, "ERR", "-", "-")
+			continue
+		}
+
+		// Count new rows (added since snapshot)
+		var newRows int64
+		if t.BlocknumCol != "" {
+			newRows, _ = countRows(ctx, pool, t.Name, fmt.Sprintf("%s > %d", t.BlocknumCol, maxBlock))
+		} else if t.CreatedAtCol != "" {
+			newRows, _ = countRows(ctx, pool, t.Name, fmt.Sprintf("%s > '%s'", t.CreatedAtCol, snapshotTime))
+		}
+
+		fmt.Printf("%-30s %10d %10d %10d\n", t.Name, baseline, newRows, totalNow)
+	}
+
+	// --- Structural Integrity Checks ---
+	fmt.Println()
+	fmt.Printf("--- Structural Integrity (new rows, blocknumber > %d) ---\n", maxBlock)
+
+	checks := []struct {
+		name  string
+		query string
+	}{
+		{
+			"users: missing handle",
+			fmt.Sprintf("SELECT COUNT(*) FROM users WHERE blocknumber > %d AND is_current = true AND (handle IS NULL OR handle = '')", maxBlock),
+		},
+		{
+			"users: missing wallet",
+			fmt.Sprintf("SELECT COUNT(*) FROM users WHERE blocknumber > %d AND is_current = true AND (wallet IS NULL OR wallet = '')", maxBlock),
+		},
+		{
+			"tracks: missing owner_id",
+			fmt.Sprintf("SELECT COUNT(*) FROM tracks WHERE blocknumber > %d AND is_current = true AND owner_id = 0", maxBlock),
+		},
+		{
+			"tracks: owner not in users",
+			fmt.Sprintf(`SELECT COUNT(*) FROM tracks t WHERE t.blocknumber > %d AND t.is_current = true
+				AND NOT EXISTS (SELECT 1 FROM users u WHERE u.user_id = t.owner_id AND u.is_current = true)`, maxBlock),
+		},
+		{
+			"follows: followee not in users",
+			fmt.Sprintf(`SELECT COUNT(*) FROM follows f WHERE f.blocknumber > %d AND f.is_current = true AND f.is_delete = false
+				AND NOT EXISTS (SELECT 1 FROM users u WHERE u.user_id = f.followee_user_id AND u.is_current = true)`, maxBlock),
+		},
+		{
+			"saves: target track/playlist missing",
+			fmt.Sprintf(`SELECT COUNT(*) FROM saves s WHERE s.blocknumber > %d AND s.is_current = true AND s.is_delete = false
+				AND s.save_type = 'track'
+				AND NOT EXISTS (SELECT 1 FROM tracks t WHERE t.track_id = s.save_item_id AND t.is_current = true)`, maxBlock),
+		},
+	}
+
+	allPassed := true
+	for _, c := range checks {
+		var count int64
+		err := pool.QueryRow(ctx, c.query).Scan(&count)
+		if err != nil {
+			fmt.Printf("  %-45s  ERR (%v)\n", c.name, err)
+			continue
+		}
+		status := "✓"
+		if count > 0 {
+			status = fmt.Sprintf("WARN: %d", count)
+			allPassed = false
+		}
+		fmt.Printf("  %-45s  %s\n", c.name, status)
+	}
+
+	if allPassed {
+		fmt.Println("\nAll structural checks passed.")
+	} else {
+		fmt.Println("\nSome structural checks have warnings — review above.")
+	}
+
+	// --- Unhandled Transaction Types ---
+	fmt.Println()
+	fmt.Printf("--- Unhandled ManageEntity Types (block > %d) ---\n", maxBlock)
+
+	// Find entity_type/action combos that have etl_manage_entities rows
+	// but zero corresponding domain table rows
+	unhandledRows, err := pool.Query(ctx, `
+		SELECT entity_type, action, COUNT(*)
+		FROM etl_manage_entities
+		WHERE block_height > $1
+		GROUP BY entity_type, action
+		HAVING COUNT(*) > 0
+		ORDER BY COUNT(*) DESC
+	`, maxBlock)
+	if err == nil {
+		defer unhandledRows.Close()
+
+		// Build set of handled types from the tables list
+		handled := map[string]bool{}
+		for _, t := range tables {
+			if t.EntityType != "" && t.Action != "" {
+				handled[strings.ToLower(t.EntityType+"/"+t.Action)] = true
+			}
+		}
+
+		hasUnhandled := false
+		for unhandledRows.Next() {
+			var entityType, action string
+			var count int64
+			unhandledRows.Scan(&entityType, &action, &count)
+			key := strings.ToLower(entityType + "/" + action)
+			if !handled[key] {
+				if !hasUnhandled {
+					fmt.Printf("%-20s %-15s %10s\n", "EntityType", "Action", "Count")
+					fmt.Printf("%-20s %-15s %10s\n", "----------", "------", "-----")
+					hasUnhandled = true
+				}
+				fmt.Printf("%-20s %-15s %10d\n", entityType, action, count)
+			}
+		}
+		if !hasUnhandled {
+			fmt.Println("(none — all transaction types are handled)")
+		}
+	}
+
+	fmt.Println("\n=== Report Complete ===")
+	return nil
+}

--- a/pkg/etl/parity/main.go
+++ b/pkg/etl/parity/main.go
@@ -1,0 +1,69 @@
+// Parity test tool for comparing Go ETL output against existing discovery-provider data.
+//
+// Usage:
+//
+//	go run ./pkg/etl/parity snapshot --db "postgres://..."
+//	go run ./pkg/etl/parity diff --db "postgres://..."
+//	go run ./pkg/etl/parity cleanup --db "postgres://..."
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run ./pkg/etl/parity <snapshot|diff|cleanup> --db <postgres-url>\n")
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	dbURL := fs.String("db", os.Getenv("ETL_DB_URL"), "Postgres connection string")
+	fs.Parse(os.Args[2:])
+
+	if *dbURL == "" {
+		log.Fatal("--db is required (or set ETL_DB_URL)")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, *dbURL)
+	if err != nil {
+		log.Fatalf("connect to db: %v", err)
+	}
+	defer pool.Close()
+
+	switch cmd {
+	case "snapshot":
+		if err := Snapshot(ctx, pool); err != nil {
+			log.Fatalf("snapshot failed: %v", err)
+		}
+	case "diff":
+		if err := Diff(ctx, pool); err != nil {
+			log.Fatalf("diff failed: %v", err)
+		}
+	case "cleanup":
+		if err := Cleanup(ctx, pool); err != nil {
+			log.Fatalf("cleanup failed: %v", err)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\nUsage: go run ./pkg/etl/parity <snapshot|diff|cleanup> --db <url>\n", cmd)
+		os.Exit(1)
+	}
+}
+
+// Cleanup drops the _parity_meta table.
+func Cleanup(ctx context.Context, pool *pgxpool.Pool) error {
+	_, err := pool.Exec(ctx, `DROP TABLE IF EXISTS _parity_meta`)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Cleaned up _parity_meta table.")
+	return nil
+}

--- a/pkg/etl/parity/parity.go
+++ b/pkg/etl/parity/parity.go
@@ -1,0 +1,36 @@
+package main
+
+// domainTable defines a domain table to track, with its block-number column
+// and an optional filter for "active" rows.
+type domainTable struct {
+	Name           string
+	BlocknumCol    string // column holding blocknumber (empty if none)
+	ActiveFilter   string // WHERE clause for "active" rows (empty = all rows)
+	EntityType     string // maps to etl_manage_entities.entity_type (empty = skip cross-ref)
+	Action         string // maps to etl_manage_entities.action (empty = skip cross-ref)
+	CreatedAtCol   string // fallback column for time-based counting (empty = use blocknumcol)
+}
+
+// tables is the full list of domain tables we snapshot and diff.
+var tables = []domainTable{
+	{Name: "users", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true", EntityType: "User", Action: "Create"},
+	{Name: "tracks", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true", EntityType: "Track", Action: "Create"},
+	{Name: "playlists", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true", EntityType: "Playlist", Action: "Create"},
+	{Name: "follows", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true"},
+	{Name: "saves", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true"},
+	{Name: "reposts", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true"},
+	{Name: "subscriptions", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true"},
+	{Name: "comments", BlocknumCol: "blocknumber", ActiveFilter: "is_delete = false"},
+	{Name: "grants", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true"},
+	{Name: "developer_apps", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true"},
+	{Name: "muted_users", BlocknumCol: "blocknumber", ActiveFilter: "is_delete = false"},
+	{Name: "associated_wallets", BlocknumCol: "blocknumber", ActiveFilter: "is_current = true AND is_delete = false"},
+	{Name: "dashboard_wallet_users", BlocknumCol: "blocknumber", ActiveFilter: "is_delete = false"},
+	{Name: "shares", BlocknumCol: "blocknumber"},
+	{Name: "track_downloads", BlocknumCol: "blocknumber"},
+	{Name: "events", BlocknumCol: "blocknumber", ActiveFilter: "is_deleted = false"},
+	{Name: "encrypted_emails", BlocknumCol: "", CreatedAtCol: "created_at"},
+	{Name: "email_access", BlocknumCol: "", CreatedAtCol: "created_at"},
+	{Name: "reactions", BlocknumCol: "blocknumber"},
+	{Name: "notification", BlocknumCol: "blocknumber"},
+}

--- a/pkg/etl/parity/snapshot.go
+++ b/pkg/etl/parity/snapshot.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Snapshot captures the current state of domain tables and the max block height.
+func Snapshot(ctx context.Context, pool *pgxpool.Pool) error {
+	// Drop and recreate meta table (idempotent)
+	_, err := pool.Exec(ctx, `DROP TABLE IF EXISTS _parity_meta`)
+	if err != nil {
+		return fmt.Errorf("drop _parity_meta: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE _parity_meta (
+			key TEXT PRIMARY KEY,
+			value_int BIGINT,
+			value_text TEXT,
+			created_at TIMESTAMP NOT NULL DEFAULT NOW()
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create _parity_meta: %w", err)
+	}
+
+	// Record max block height
+	var maxBlock int64
+	err = pool.QueryRow(ctx, `SELECT COALESCE(MAX(number), 0) FROM blocks`).Scan(&maxBlock)
+	if err != nil {
+		return fmt.Errorf("query max block: %w", err)
+	}
+
+	_, err = pool.Exec(ctx,
+		`INSERT INTO _parity_meta (key, value_int) VALUES ('max_block', $1)`,
+		maxBlock)
+	if err != nil {
+		return fmt.Errorf("insert max_block: %w", err)
+	}
+
+	// Record snapshot time
+	_, err = pool.Exec(ctx,
+		`INSERT INTO _parity_meta (key, value_text) VALUES ('snapshot_time', $1)`,
+		time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("insert snapshot_time: %w", err)
+	}
+
+	fmt.Printf("=== Parity Snapshot ===\n")
+	fmt.Printf("Max block: %d\n", maxBlock)
+	fmt.Printf("Snapshot time: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+
+	// Count rows in each domain table
+	fmt.Printf("%-30s %10s\n", "Table", "Rows")
+	fmt.Printf("%-30s %10s\n", "-----", "----")
+
+	for _, t := range tables {
+		count, err := countRows(ctx, pool, t.Name, "")
+		if err != nil {
+			fmt.Printf("%-30s %10s (table may not exist)\n", t.Name, "ERR")
+			continue
+		}
+
+		_, err = pool.Exec(ctx,
+			`INSERT INTO _parity_meta (key, value_int) VALUES ($1, $2)`,
+			"count_"+t.Name, count)
+		if err != nil {
+			return fmt.Errorf("insert count for %s: %w", t.Name, err)
+		}
+
+		fmt.Printf("%-30s %10d\n", t.Name, count)
+	}
+
+	fmt.Printf("\nSnapshot complete. Run the ETL, then use 'diff' to compare.\n")
+	return nil
+}
+
+func countRows(ctx context.Context, pool *pgxpool.Pool, table, where string) (int64, error) {
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
+	if where != "" {
+		query += " WHERE " + where
+	}
+	var count int64
+	err := pool.QueryRow(ctx, query).Scan(&count)
+	return count, err
+}


### PR DESCRIPTION
Adds a CLI tool for comparing Go ETL output against existing
discovery-provider data. Three commands:
- snapshot: captures baseline row counts and max block height
- diff: compares domain table growth, validates structural integrity
- cleanup: drops parity metadata

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>