### PR TITLE
Add cross-cycle presence cache to reduce repair HeadObject calls

### DIFF
--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
+	"github.com/erni27/imcache"
 	"go.uber.org/zap"
 
 	"github.com/georgysavva/scany/v2/pgxscan"
@@ -92,6 +93,12 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 					logger.Error("failed to get last repair.go run", zap.Error(err))
 				}
 			}
+			// Cleanup cycles do full verification, so clear the cross-cycle
+			// presence cache to force fresh Attributes calls.
+			if tracker.CleanupMode {
+				ss.knownPresent.RemoveAll()
+			}
+
 			logger := logger.With(zap.Int("run", tracker.CursorI), zap.Bool("cleanupMode", tracker.CleanupMode))
 
 			saveTracker := func() {
@@ -134,7 +141,7 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 				logger.Warn("repair interrupted", zap.Error(err), zap.Duration("took", tracker.Duration))
 			} else {
 				tracker.FinishedAt = time.Now()
-				logger.Info("repair OK", zap.Duration("took", tracker.Duration))
+				logger.Info("repair OK", zap.Duration("took", tracker.Duration), zap.Int("known_present_size", ss.knownPresent.Len()))
 				ss.lastSuccessfulRepair = tracker
 				if tracker.CleanupMode {
 					ss.lastSuccessfulCleanup = tracker
@@ -339,6 +346,19 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		return nil
 	}
 
+	// Cross-cycle cache: skip Attributes for CIDs confirmed present in a
+	// previous cycle. Cleanup cycles bypass the cache because they need
+	// ModTime for over-replication decisions and run full blob validation.
+	if !tracker.CleanupMode {
+		if size, ok := ss.knownPresent.Get(key); ok {
+			tracker.SeenKeys[key] = seenKeyResult{alreadyHave: true, size: size}
+			tracker.Counters["already_have"]++
+			tracker.Counters["repair_known_present"]++
+			tracker.ContentSize += size
+			return nil
+		}
+	}
+
 	alreadyHave := true
 	attrs := &blob.Attributes{}
 	attrs, err := ss.bucket.Attributes(ctx, key)
@@ -369,6 +389,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 				logger.Error("deleting invalid CID", zap.Error(errVal))
 				if errDel := ss.bucket.Delete(ctx, key); errDel == nil {
 					tracker.Counters["delete_invalid_success"]++
+					ss.knownPresent.Remove(key)
 				} else {
 					tracker.Counters["delete_invalid_fail"]++
 					logger.Error("failed to delete invalid CID", zap.Error(errDel))
@@ -401,6 +422,9 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	}
 
 	if alreadyHave {
+		// Populate cross-cycle cache after all validation and cleanup has passed,
+		// so that corrupt or about-to-be-deleted blobs are never cached.
+		ss.knownPresent.Set(key, attrs.Size, imcache.WithNoExpiration())
 		tracker.Counters["already_have"]++
 		tracker.ContentSize += attrs.Size
 	}

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/server/signature"
+	"github.com/erni27/imcache"
 	"go.uber.org/zap"
 
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
@@ -105,12 +106,17 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 		return err
 	}
 
-	_, err = io.Copy(w, file)
+	n, err := io.Copy(w, file)
 	if err != nil {
 		return err
 	}
 
-	return w.Close()
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	ss.knownPresent.Set(key, n, imcache.WithNoExpiration())
+	return nil
 }
 
 func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
@@ -122,6 +128,8 @@ func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
 	err := ss.bucket.Delete(ctx, key)
 	if err != nil {
 		logger.Error("failed to delete", zap.Error(err))
+	} else {
+		ss.knownPresent.Remove(key)
 	}
 
 	return nil

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -128,6 +128,7 @@ type MediorumServer struct {
 	uploadOrigCidCache    *imcache.Cache[string, string]
 	imageCache            *imcache.Cache[string, []byte]
 	trackAccessInfoCache  *imcache.Cache[string, trackAccessInfo]
+	knownPresent          *imcache.Cache[string, int64]
 	failsPeerReachability bool
 
 	StartedAt time.Time
@@ -368,6 +369,7 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		uploadOrigCidCache:   imcache.New(imcache.WithMaxEntriesLimitOption[string, string](50_000, imcache.EvictionPolicyLRU)),
 		imageCache:           imcache.New(imcache.WithMaxEntriesLimitOption[string, []byte](10_000, imcache.EvictionPolicyLRU)),
 		trackAccessInfoCache: imcache.New(imcache.WithMaxEntriesLimitOption[string, trackAccessInfo](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, trackAccessInfo](5*time.Minute)),
+		knownPresent:         imcache.New(imcache.WithMaxEntriesLimitOption[string, int64](500_000, imcache.EvictionPolicyLRU)),
 
 		StartedAt:    time.Now().UTC(),
 		Config:       config,


### PR DESCRIPTION
## Summary

- Repair cycles call `bucket.Attributes` (HeadObject) for every locally-held CID. On S3-compatible backends, this is the dominant source of metadata API calls.
- Adds an `imcache` LRU cache (`knownPresent`, 500K entries, no TTL) that remembers confirmed-present keys across cycles. Non-cleanup cycles check the cache and skip `Attributes` on hit.
- Cleanup cycles (every 4th) call `RemoveAll()` and do full verification — they need `ModTime` for over-replication decisions and run blob integrity validation.
- Cache is populated after all validation and cleanup checks pass, so corrupt or about-to-be-deleted blobs are never cached.
- Populated on `replicateToMyBucket` writes. Invalidated on `dropFromMyBucket` and cleanup validation deletes.
- Scoped to the repair batch path only — `haveInMyBucket` and serving paths are unchanged.

### Design notes

- Uses `imcache` with `WithNoExpiration()` and LRU eviction, consistent with the four existing caches on `MediorumServer`. No new dependencies.
- Blobs deleted outside mediorum (manual storage console, backend-side loss) remain cached until the next cleanup cycle clears and re-verifies everything. This is an accepted tradeoff — cleanup runs every 4th cycle and is authoritative.
- The `knownPresent.Remove` inside the cleanup validation delete block is currently unreachable due to a pre-existing bug where `err` is checked instead of `errVal` (see #175). It becomes live when #175 merges.
- `repair_known_present` counter tracks cache hits per cycle. `known_present_size` is logged at cycle completion.