### PR TITLE
feat(repair): reduce qm_cids cleanup attr checks with presence index

### DIFF
--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -148,10 +148,18 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 	}
 	repairCleanupEvery := 4
 	if rce := os.Getenv("OPENAUDIO_REPAIR_CLEANUP_EVERY"); rce != "" {
-		if parsed, err := strconv.Atoi(rce); err == nil {
+		if parsed, err := strconv.Atoi(rce); err == nil && parsed > 0 {
 			repairCleanupEvery = parsed
 		} else {
 			logger.Warn("failed to parse OPENAUDIO_REPAIR_CLEANUP_EVERY, using default 4", zap.String("value", rce), zap.Error(err))
+		}
+	}
+	repairQmCidsCleanupEvery := 1
+	if rqce := os.Getenv("OPENAUDIO_REPAIR_QM_CIDS_CLEANUP_EVERY"); rqce != "" {
+		if parsed, err := strconv.Atoi(rqce); err == nil && parsed >= 0 {
+			repairQmCidsCleanupEvery = parsed
+		} else {
+			logger.Warn("failed to parse OPENAUDIO_REPAIR_QM_CIDS_CLEANUP_EVERY, using default 1", zap.String("value", rqce), zap.Error(err))
 		}
 	}
 
@@ -184,7 +192,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		RepairInterval:            repairInterval,
 		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
 		RepairCleanupEvery:        repairCleanupEvery,
-		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
+		RepairQmCidsCleanupEvery:  repairQmCidsCleanupEvery,
 	}
 
 	ss, err := server.New(lc, logger, config, posChannel, core, ethService)

--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -162,6 +162,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 			logger.Warn("failed to parse OPENAUDIO_REPAIR_QM_CIDS_CLEANUP_EVERY, using default 1", zap.String("value", rqce), zap.Error(err))
 		}
 	}
+	repairQmCidsUseListIndex := getenvWithDefault("OPENAUDIO_REPAIR_QM_CIDS_USE_LIST_INDEX", "false") == "true"
 
 	config := server.MediorumConfig{
 		Self: registrar.Peer{
@@ -193,6 +194,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
 		RepairCleanupEvery:        repairCleanupEvery,
 		RepairQmCidsCleanupEvery:  repairQmCidsCleanupEvery,
+		RepairQmCidsUseListIndex:  repairQmCidsUseListIndex,
 	}
 
 	ss, err := server.New(lc, logger, config, posChannel, core, ethService)

--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -146,6 +146,14 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 			logger.Warn("failed to parse OPENAUDIO_REPAIR_INTERVAL, using default 1h", zap.String("value", ri), zap.Error(err))
 		}
 	}
+	repairCleanupEvery := 4
+	if rce := os.Getenv("OPENAUDIO_REPAIR_CLEANUP_EVERY"); rce != "" {
+		if parsed, err := strconv.Atoi(rce); err == nil {
+			repairCleanupEvery = parsed
+		} else {
+			logger.Warn("failed to parse OPENAUDIO_REPAIR_CLEANUP_EVERY, using default 4", zap.String("value", rce), zap.Error(err))
+		}
+	}
 
 	config := server.MediorumConfig{
 		Self: registrar.Peer{
@@ -174,6 +182,8 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		DeadHosts:                 []string{},
 		RepairEnabled:             repairEnabled,
 		RepairInterval:            repairInterval,
+		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
+		RepairCleanupEvery:        repairCleanupEvery,
 		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
 	}
 

--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -163,38 +163,49 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		}
 	}
 	repairQmCidsUseListIndex := getenvWithDefault("OPENAUDIO_REPAIR_QM_CIDS_USE_LIST_INDEX", "false") == "true"
+	repairQmCidsListIndexShadowCompareEvery := 0
+	if rsce := os.Getenv("OPENAUDIO_REPAIR_QM_CIDS_LIST_INDEX_SHADOW_COMPARE_EVERY"); rsce != "" {
+		if parsed, err := strconv.Atoi(rsce); err == nil && parsed >= 0 {
+			repairQmCidsListIndexShadowCompareEvery = parsed
+		} else {
+			logger.Warn("failed to parse OPENAUDIO_REPAIR_QM_CIDS_LIST_INDEX_SHADOW_COMPARE_EVERY, using default 0", zap.String("value", rsce), zap.Error(err))
+		}
+	}
+	repairQmCidsListIndexDisableOnMismatch := getenvWithDefault("OPENAUDIO_REPAIR_QM_CIDS_LIST_INDEX_DISABLE_ON_MISMATCH", "true") == "true"
 
 	config := server.MediorumConfig{
 		Self: registrar.Peer{
 			Host:   httputil.RemoveTrailingSlash(strings.ToLower(nodeEndpoint)),
 			Wallet: strings.ToLower(walletAddress),
 		},
-		ListenPort:                "1991",
-		Peers:                     peers,
-		Signers:                   signers,
-		ReplicationFactor:         replicationFactor,
-		PrivateKey:                privateKeyHex,
-		Dir:                       dir,
-		PostgresDSN:               getenvWithDefault("dbUrl", "postgres://postgres:postgres@db:5432/audius_creator_node"),
-		BlobStoreDSN:              blobStoreDSN,
-		MoveFromBlobStoreDSN:      moveFromBlobStoreDSN,
-		TrustedNotifierID:         trustedNotifierID,
-		SPID:                      spID,
-		SPOwnerWallet:             spOwnerWallet,
-		GitSHA:                    os.Getenv("GIT_SHA"),
-		AudiusDockerCompose:       os.Getenv("AUDIUS_DOCKER_COMPOSE_GIT_SHA"),
-		AutoUpgradeEnabled:        os.Getenv("autoUpgradeEnabled") == "true",
-		StoreAll:                  os.Getenv("STORE_ALL") == "true",
-		VersionJson:               version.Version,
-		DiscoveryListensEndpoints: discoveryListensEndpoints(),
-		LogLevel:                  getenvWithDefault("OPENAUDIO_LOG_LEVEL", "info"),
-		DeadHosts:                 []string{},
-		RepairEnabled:             repairEnabled,
-		RepairInterval:            repairInterval,
-		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
-		RepairCleanupEvery:        repairCleanupEvery,
-		RepairQmCidsCleanupEvery:  repairQmCidsCleanupEvery,
-		RepairQmCidsUseListIndex:  repairQmCidsUseListIndex,
+		ListenPort:                              "1991",
+		Peers:                                   peers,
+		Signers:                                 signers,
+		ReplicationFactor:                       replicationFactor,
+		PrivateKey:                              privateKeyHex,
+		Dir:                                     dir,
+		PostgresDSN:                             getenvWithDefault("dbUrl", "postgres://postgres:postgres@db:5432/audius_creator_node"),
+		BlobStoreDSN:                            blobStoreDSN,
+		MoveFromBlobStoreDSN:                    moveFromBlobStoreDSN,
+		TrustedNotifierID:                       trustedNotifierID,
+		SPID:                                    spID,
+		SPOwnerWallet:                           spOwnerWallet,
+		GitSHA:                                  os.Getenv("GIT_SHA"),
+		AudiusDockerCompose:                     os.Getenv("AUDIUS_DOCKER_COMPOSE_GIT_SHA"),
+		AutoUpgradeEnabled:                      os.Getenv("autoUpgradeEnabled") == "true",
+		StoreAll:                                os.Getenv("STORE_ALL") == "true",
+		VersionJson:                             version.Version,
+		DiscoveryListensEndpoints:               discoveryListensEndpoints(),
+		LogLevel:                                getenvWithDefault("OPENAUDIO_LOG_LEVEL", "info"),
+		DeadHosts:                               []string{},
+		RepairEnabled:                           repairEnabled,
+		RepairInterval:                          repairInterval,
+		BlobStorageStreaming:                    os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
+		RepairCleanupEvery:                      repairCleanupEvery,
+		RepairQmCidsCleanupEvery:                repairQmCidsCleanupEvery,
+		RepairQmCidsUseListIndex:                repairQmCidsUseListIndex,
+		RepairQmCidsListIndexShadowCompareEvery: repairQmCidsListIndexShadowCompareEvery,
+		RepairQmCidsListIndexDisableOnMismatch:  repairQmCidsListIndexDisableOnMismatch,
 	}
 
 	ss, err := server.New(lc, logger, config, posChannel, core, ethService)

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -32,19 +32,20 @@ type seenKeyResult struct {
 }
 
 type RepairTracker struct {
-	StartedAt        time.Time `gorm:"primaryKey;not null"`
-	UpdatedAt        time.Time `gorm:"not null"`
-	FinishedAt       time.Time
-	CleanupMode      bool                     `gorm:"not null"`
-	CursorI          int                      `gorm:"not null"`
-	CursorUploadID   string                   `gorm:"not null"`
-	CursorPreviewCID string                   ``
-	CursorQmCID      string                   `gorm:"not null"`
-	Counters         map[string]int           `gorm:"not null;serializer:json"`
-	ContentSize      int64                    `gorm:"not null"`
-	Duration         time.Duration            `gorm:"not null"`
-	AbortedReason    string                   `gorm:"not null"`
-	SeenKeys         map[string]seenKeyResult `gorm:"-" json:"-"`
+	StartedAt         time.Time `gorm:"primaryKey;not null"`
+	UpdatedAt         time.Time `gorm:"not null"`
+	FinishedAt        time.Time
+	CleanupMode       bool                     `gorm:"not null"`
+	QmCidsCleanupMode bool                     `gorm:"not null;default:false"`
+	CursorI           int                      `gorm:"not null"`
+	CursorUploadID    string                   `gorm:"not null"`
+	CursorPreviewCID  string                   ``
+	CursorQmCID       string                   `gorm:"not null"`
+	Counters          map[string]int           `gorm:"not null;serializer:json"`
+	ContentSize       int64                    `gorm:"not null"`
+	Duration          time.Duration            `gorm:"not null"`
+	AbortedReason     string                   `gorm:"not null"`
+	SeenKeys          map[string]seenKeyResult `gorm:"-" json:"-"`
 }
 
 func (ss *MediorumServer) startRepairer(ctx context.Context) error {

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -485,7 +485,7 @@ func (ss *MediorumServer) repairCidWithPresenceIndex(
 				} else {
 					shadowMismatch := shadowAlreadyHave != alreadyHave
 					if !shadowMismatch && shadowAlreadyHave {
-						shadowMismatch = shadowBlobSize != blobSize || !shadowBlobModTime.Equal(blobModTime)
+						shadowMismatch = shadowBlobSize != blobSize || !repairPresenceIndexModTimesEquivalent(shadowBlobModTime, blobModTime)
 					}
 					resolvedFromShadowCompare = true
 					if shadowMismatch {

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/labstack/echo/v4"
-	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 	"golang.org/x/exp/slices"
 	"gorm.io/gorm"
@@ -73,6 +72,8 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 		zap.Int("cleanupEvery", repairCleanupEvery),
 		zap.Int("qmCidsCleanupEvery", repairQmCidsCleanupEvery),
 		zap.Bool("qmCidsUseListIndex", ss.Config.RepairQmCidsUseListIndex),
+		zap.Int("qmCidsListIndexShadowCompareEvery", ss.Config.RepairQmCidsListIndexShadowCompareEvery),
+		zap.Bool("qmCidsListIndexDisableOnMismatch", ss.Config.RepairQmCidsListIndexDisableOnMismatch),
 	)
 
 	// wait a minute on startup to determine healthy peers
@@ -205,6 +206,17 @@ func (ss *MediorumServer) qmCidsCleanupModeForRun(tracker *RepairTracker) bool {
 	return shouldRunQmCidsCleanup(priorSuccessfulCleanups+1, cleanupEvery)
 }
 
+func (ss *MediorumServer) bucketPresenceForRepair(ctx context.Context, key string) (bool, int64, time.Time, error) {
+	attrs, err := ss.bucket.Attributes(ctx, key)
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound || strings.Contains(err.Error(), "notFound") {
+			return false, 0, time.Time{}, nil
+		}
+		return false, 0, time.Time{}, err
+	}
+	return true, attrs.Size, attrs.ModTime, nil
+}
+
 func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker) error {
 	saveTracker := func() {
 		tracker.UpdatedAt = time.Now()
@@ -308,10 +320,12 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 		if err != nil {
 			ss.logger.Warn("failed to build qm_cids repair presence index; falling back to per-key bucket attributes", zap.Error(err))
 			tracker.Counters["qm_cids_list_index_build_fail"]++
+			tracker.Counters["qm_cids_list_index_build_duration_ms"] = int(time.Since(indexStartedAt).Milliseconds())
 		} else {
 			qmCidsPresenceIndex = index
 			tracker.Counters["qm_cids_list_index_build_success"]++
 			tracker.Counters["qm_cids_list_index_entries"] = index.Len()
+			tracker.Counters["qm_cids_list_index_build_duration_ms"] = int(time.Since(indexStartedAt).Milliseconds())
 			tracker.Duration += time.Since(indexStartedAt)
 		}
 	}
@@ -442,32 +456,68 @@ func (ss *MediorumServer) repairCidWithPresenceIndex(
 	alreadyHave := false
 	blobSize := int64(0)
 	blobModTime := time.Time{}
+	var err error
+	resolvedFromShadowCompare := false
 	if presenceIndex != nil {
-		tracker.Counters["qm_cids_list_index_lookup"]++
-		if entry, ok := presenceIndex.Lookup(key); ok {
-			alreadyHave = true
-			blobSize = entry.Size
-			blobModTime = entry.ModTime
-			tracker.Counters["qm_cids_list_index_present"]++
+		if presenceIndex.ShouldUsePerKeyAttrsFallback() {
+			tracker.Counters["qm_cids_list_index_fallback_lookup"]++
+			ss.repairSourceEvidence.recordListIndexFallback(source)
 		} else {
-			tracker.Counters["qm_cids_list_index_missing"]++
+			tracker.Counters["qm_cids_list_index_lookup"]++
+			if entry, ok := presenceIndex.Lookup(key); ok {
+				alreadyHave = true
+				blobSize = entry.Size
+				blobModTime = entry.ModTime
+				tracker.Counters["qm_cids_list_index_present"]++
+			} else {
+				tracker.Counters["qm_cids_list_index_missing"]++
+			}
+
+			if presenceIndex.ShouldShadowCompare(key) {
+				tracker.Counters["qm_cids_list_index_shadow_compare_total"]++
+				ss.repairSourceEvidence.recordShadowAttrCall(source)
+
+				shadowAlreadyHave, shadowBlobSize, shadowBlobModTime, err := ss.bucketPresenceForRepair(ctx, key)
+				if err != nil {
+					tracker.Counters["read_attrs_fail"]++
+					tracker.Counters["qm_cids_list_index_shadow_compare_fail"]++
+					logger.Error("shadow compare exist check failed", zap.Error(err))
+				} else {
+					shadowMismatch := shadowAlreadyHave != alreadyHave
+					if !shadowMismatch && shadowAlreadyHave {
+						shadowMismatch = shadowBlobSize != blobSize || !shadowBlobModTime.Equal(blobModTime)
+					}
+					resolvedFromShadowCompare = true
+					if shadowMismatch {
+						tracker.Counters["qm_cids_list_index_shadow_mismatch"]++
+						ss.repairSourceEvidence.recordListIndexShadowMismatch(source)
+						alreadyHave = shadowAlreadyHave
+						blobSize = shadowBlobSize
+						blobModTime = shadowBlobModTime
+						if presenceIndex.disableOnShadowMismatch {
+							presenceIndex.EnablePerKeyAttrsFallback()
+							tracker.Counters["qm_cids_list_index_fallback_triggered"]++
+							ss.repairSourceEvidence.recordListIndexFallback(source)
+						}
+					} else {
+						tracker.Counters["qm_cids_list_index_shadow_match"]++
+					}
+				}
+			}
+		}
+	}
+	if (presenceIndex == nil || presenceIndex.ShouldUsePerKeyAttrsFallback()) && !resolvedFromShadowCompare {
+		ss.repairSourceEvidence.recordAttrCall(source)
+		alreadyHave, blobSize, blobModTime, err = ss.bucketPresenceForRepair(ctx, key)
+		if err != nil {
+			tracker.Counters["read_attrs_fail"]++
+			logger.Error("exist check failed", zap.Error(err))
+			alreadyHave = false
+			blobSize = 0
+			blobModTime = time.Time{}
 		}
 	} else {
-		ss.repairSourceEvidence.recordAttrCall(source)
-		attrs, err := ss.bucket.Attributes(ctx, key)
-		if err != nil {
-			if gcerrors.Code(err) == gcerrors.NotFound || strings.Contains(err.Error(), "notFound") {
-				alreadyHave = false
-			} else {
-				tracker.Counters["read_attrs_fail"]++
-				logger.Error("exist check failed", zap.Error(err))
-				alreadyHave = false
-			}
-		} else {
-			alreadyHave = true
-			blobSize = attrs.Size
-			blobModTime = attrs.ModTime
-		}
+		// already populated by the presence index path
 	}
 
 	// Store result for future duplicate checks within this cycle.
@@ -484,11 +534,12 @@ func (ss *MediorumServer) repairCidWithPresenceIndex(
 				logger.Error("deleting invalid CID", zap.Error(errVal))
 				if errDel := ss.bucket.Delete(ctx, key); errDel == nil {
 					tracker.Counters["delete_invalid_success"]++
+					tracker.SeenKeys[key] = seenKeyResult{alreadyHave: false}
 				} else {
 					tracker.Counters["delete_invalid_fail"]++
 					logger.Error("failed to delete invalid CID", zap.Error(errDel))
 				}
-				return err
+				return nil
 			}
 
 			if errClose != nil {

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -22,6 +22,7 @@ import (
 const (
 	abortContextCanceled      = "CONTEXT_CANCELED"
 	defaultRepairCleanupEvery = 4
+	defaultQmCidsCleanupEvery = 1
 )
 
 // seenKeyResult stores the outcome of a previous Attributes check for the same
@@ -62,7 +63,16 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 	if repairCleanupEvery <= 0 {
 		repairCleanupEvery = defaultRepairCleanupEvery
 	}
-	logger.Info("repair configured", zap.Duration("interval", repairInterval), zap.Int("cleanupEvery", repairCleanupEvery))
+	repairQmCidsCleanupEvery := ss.Config.RepairQmCidsCleanupEvery
+	if repairQmCidsCleanupEvery < 0 {
+		repairQmCidsCleanupEvery = defaultQmCidsCleanupEvery
+	}
+	logger.Info(
+		"repair configured",
+		zap.Duration("interval", repairInterval),
+		zap.Int("cleanupEvery", repairCleanupEvery),
+		zap.Int("qmCidsCleanupEvery", repairQmCidsCleanupEvery),
+	)
 
 	// wait a minute on startup to determine healthy peers
 	ticker := time.NewTicker(1 * time.Minute)
@@ -92,7 +102,12 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 					logger.Error("failed to get last repair.go run", zap.Error(err))
 				}
 			}
-			logger := logger.With(zap.Int("run", tracker.CursorI), zap.Bool("cleanupMode", tracker.CleanupMode))
+			tracker.QmCidsCleanupMode = ss.qmCidsCleanupModeForRun(&tracker)
+			logger := logger.With(
+				zap.Int("run", tracker.CursorI),
+				zap.Bool("cleanupMode", tracker.CleanupMode),
+				zap.Bool("qmCidsCleanupMode", tracker.QmCidsCleanupMode),
+			)
 
 			saveTracker := func() {
 				tracker.UpdatedAt = time.Now()
@@ -156,6 +171,37 @@ func nextRepairCursor(lastCursor int, cleanupEvery int) (int, bool) {
 		cursor = 1
 	}
 	return cursor, cursor == 1
+}
+
+func shouldRunQmCidsCleanup(cleanupOrdinal int64, cleanupEvery int) bool {
+	if cleanupEvery < 0 {
+		cleanupEvery = defaultQmCidsCleanupEvery
+	}
+	if cleanupEvery == 0 {
+		return false
+	}
+	if cleanupOrdinal <= 0 {
+		cleanupOrdinal = 1
+	}
+	return (cleanupOrdinal-1)%int64(cleanupEvery) == 0
+}
+
+func (ss *MediorumServer) qmCidsCleanupModeForRun(tracker *RepairTracker) bool {
+	if tracker == nil || !tracker.CleanupMode {
+		return false
+	}
+	cleanupEvery := ss.Config.RepairQmCidsCleanupEvery
+	if cleanupEvery < 0 {
+		cleanupEvery = defaultQmCidsCleanupEvery
+	}
+	var priorSuccessfulCleanups int64
+	if err := ss.crud.DB.Model(&RepairTracker{}).
+		Where("cleanup_mode = true and started_at < ? and finished_at is not null and finished_at != ? and aborted_reason = ?", tracker.StartedAt, time.Time{}, "").
+		Count(&priorSuccessfulCleanups).Error; err != nil {
+		ss.logger.Warn("failed to count prior successful cleanup runs for qm_cids cleanup cadence", zap.Error(err))
+		return shouldRunQmCidsCleanup(1, cleanupEvery)
+	}
+	return shouldRunQmCidsCleanup(priorSuccessfulCleanups+1, cleanupEvery)
 }
 
 func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker) error {
@@ -253,6 +299,8 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 		saveTracker()
 	}
 
+	qmCidsCleanupMode := tracker.CleanupMode && tracker.QmCidsCleanupMode
+
 	// scroll older qm_cids table and repair
 	for {
 		// abort if context is canceled
@@ -292,7 +340,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			}
 
 			tracker.CursorQmCID = cid
-			ss.repairCid(ctx, cid, nil, tracker, repairSourceQmCID)
+			ss.repairCidWithCleanupMode(ctx, cid, nil, tracker, repairSourceQmCID, qmCidsCleanupMode)
 		}
 
 		tracker.Duration += time.Since(startIter)
@@ -307,7 +355,18 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		return nil
 	}
 
-	logger := ss.logger.With(zap.String("task", "repair"), zap.String("cid", cid), zap.Bool("cleanup", tracker.CleanupMode))
+	return ss.repairCidWithCleanupMode(ctx, cid, placementHosts, tracker, source, tracker.CleanupMode)
+}
+
+func (ss *MediorumServer) repairCidWithCleanupMode(
+	ctx context.Context,
+	cid string,
+	placementHosts []string,
+	tracker *RepairTracker,
+	source string,
+	cleanupMode bool,
+) error {
+	logger := ss.logger.With(zap.String("task", "repair"), zap.String("cid", cid), zap.Bool("cleanup", cleanupMode))
 	ss.repairSourceEvidence.recordCall(source)
 
 	preferredHosts, isMine := ss.rendezvousAllHosts(cid)
@@ -326,7 +385,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	}
 
 	// fast path: do zero bucket ops if we know we don't care about this cid
-	if !tracker.CleanupMode && !isMine {
+	if !cleanupMode && !isMine {
 		ss.repairSourceEvidence.recordFastSkipNotMine(source)
 		return nil
 	}
@@ -376,11 +435,11 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 
 	// in cleanup mode do some extra checks:
 	// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
-	if tracker.CleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
+	if cleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
 		if r, errRead := ss.bucket.NewReader(ctx, key, nil); errRead == nil {
 			errVal := cidutil.ValidateCID(cid, r)
 			errClose := r.Close()
-			if err != nil {
+			if errVal != nil {
 				tracker.Counters["delete_invalid_needed"]++
 				logger.Error("deleting invalid CID", zap.Error(errVal))
 				if errDel := ss.bucket.Delete(ctx, key); errDel == nil {
@@ -404,7 +463,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 
 	// delete derived image variants since they'll be dynamically resized
 	if strings.HasSuffix(cid, ".jpg") && !strings.HasSuffix(cid, "original.jpg") {
-		if tracker.CleanupMode && alreadyHave {
+		if cleanupMode && alreadyHave {
 			err := ss.dropFromMyBucket(cid)
 			if err != nil {
 				logger.Error("delete_resized_image_failed", zap.Error(err))

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	abortContextCanceled = "CONTEXT_CANCELED"
+	abortContextCanceled      = "CONTEXT_CANCELED"
+	defaultRepairCleanupEvery = 4
 )
 
 // seenKeyResult stores the outcome of a previous Attributes check for the same
@@ -31,19 +32,19 @@ type seenKeyResult struct {
 }
 
 type RepairTracker struct {
-	StartedAt      time.Time `gorm:"primaryKey;not null"`
-	UpdatedAt      time.Time `gorm:"not null"`
-	FinishedAt     time.Time
-	CleanupMode    bool           `gorm:"not null"`
-	CursorI        int            `gorm:"not null"`
-	CursorUploadID string         `gorm:"not null"`
-	CursorPreviewCID string       ``
-	CursorQmCID    string         `gorm:"not null"`
-	Counters       map[string]int `gorm:"not null;serializer:json"`
-	ContentSize    int64          `gorm:"not null"`
-	Duration       time.Duration  `gorm:"not null"`
-	AbortedReason  string         `gorm:"not null"`
-	SeenKeys       map[string]seenKeyResult `gorm:"-" json:"-"`
+	StartedAt        time.Time `gorm:"primaryKey;not null"`
+	UpdatedAt        time.Time `gorm:"not null"`
+	FinishedAt       time.Time
+	CleanupMode      bool                     `gorm:"not null"`
+	CursorI          int                      `gorm:"not null"`
+	CursorUploadID   string                   `gorm:"not null"`
+	CursorPreviewCID string                   ``
+	CursorQmCID      string                   `gorm:"not null"`
+	Counters         map[string]int           `gorm:"not null;serializer:json"`
+	ContentSize      int64                    `gorm:"not null"`
+	Duration         time.Duration            `gorm:"not null"`
+	AbortedReason    string                   `gorm:"not null"`
+	SeenKeys         map[string]seenKeyResult `gorm:"-" json:"-"`
 }
 
 func (ss *MediorumServer) startRepairer(ctx context.Context) error {
@@ -56,7 +57,11 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 	}
 
 	repairInterval := ss.Config.RepairInterval
-	logger.Info("repair configured", zap.Duration("interval", repairInterval))
+	repairCleanupEvery := ss.Config.RepairCleanupEvery
+	if repairCleanupEvery <= 0 {
+		repairCleanupEvery = defaultRepairCleanupEvery
+	}
+	logger.Info("repair configured", zap.Duration("interval", repairInterval), zap.Int("cleanupEvery", repairCleanupEvery))
 
 	// wait a minute on startup to determine healthy peers
 	ticker := time.NewTicker(1 * time.Minute)
@@ -79,13 +84,7 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 					tracker = lastRun
 				} else {
 					// run the next job
-					tracker.CursorI = lastRun.CursorI + 1
-
-					// every few runs, run cleanup mode
-					if tracker.CursorI > 4 {
-						tracker.CursorI = 1
-					}
-					tracker.CleanupMode = tracker.CursorI == 1
+					tracker.CursorI, tracker.CleanupMode = nextRepairCursor(lastRun.CursorI, repairCleanupEvery)
 				}
 			} else {
 				if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -145,6 +144,17 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+func nextRepairCursor(lastCursor int, cleanupEvery int) (int, bool) {
+	if cleanupEvery <= 0 {
+		cleanupEvery = defaultRepairCleanupEvery
+	}
+	cursor := lastCursor + 1
+	if cursor > cleanupEvery {
+		cursor = 1
+	}
+	return cursor, cursor == 1
 }
 
 func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker) error {

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -199,14 +199,14 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			}
 
 			tracker.CursorUploadID = u.ID
-			ss.repairCid(ctx, u.OrigFileCID, u.PlacementHosts, tracker)
+			ss.repairCid(ctx, u.OrigFileCID, u.PlacementHosts, tracker, repairSourceUploadOrig)
 			// images are resized dynamically
 			// so only consider audio TranscodeResults for repair
 			if u.Template != JobTemplateAudio {
 				continue
 			}
 			for _, cid := range u.TranscodeResults {
-				ss.repairCid(ctx, cid, u.PlacementHosts, tracker)
+				ss.repairCid(ctx, cid, u.PlacementHosts, tracker, repairSourceUploadTranscode)
 			}
 		}
 
@@ -246,7 +246,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			}
 
 			tracker.CursorPreviewCID = u.CID
-			ss.repairCid(ctx, u.CID, nil, tracker)
+			ss.repairCid(ctx, u.CID, nil, tracker, repairSourceAudioPreview)
 		}
 
 		tracker.Duration += time.Since(startIter)
@@ -292,7 +292,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			}
 
 			tracker.CursorQmCID = cid
-			ss.repairCid(ctx, cid, nil, tracker)
+			ss.repairCid(ctx, cid, nil, tracker, repairSourceQmCID)
 		}
 
 		tracker.Duration += time.Since(startIter)
@@ -302,12 +302,13 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 	return ctx.Err()
 }
 
-func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHosts []string, tracker *RepairTracker) error {
+func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHosts []string, tracker *RepairTracker, source string) error {
 	if cid == "" {
 		return nil
 	}
 
 	logger := ss.logger.With(zap.String("task", "repair"), zap.String("cid", cid), zap.Bool("cleanup", tracker.CleanupMode))
+	ss.repairSourceEvidence.recordCall(source)
 
 	preferredHosts, isMine := ss.rendezvousAllHosts(cid)
 
@@ -326,6 +327,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 
 	// fast path: do zero bucket ops if we know we don't care about this cid
 	if !tracker.CleanupMode && !isMine {
+		ss.repairSourceEvidence.recordFastSkipNotMine(source)
 		return nil
 	}
 
@@ -342,6 +344,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		tracker.SeenKeys = map[string]seenKeyResult{}
 	}
 	if prev, seen := tracker.SeenKeys[key]; seen {
+		ss.repairSourceEvidence.recordCycle(source, true)
 		tracker.Counters["repair_deduped"]++
 		if prev.alreadyHave {
 			tracker.Counters["already_have"]++
@@ -349,9 +352,11 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		}
 		return nil
 	}
+	ss.repairSourceEvidence.recordCycle(source, false)
 
 	alreadyHave := true
 	attrs := &blob.Attributes{}
+	ss.repairSourceEvidence.recordAttrCall(source)
 	attrs, err := ss.bucket.Attributes(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound || strings.Contains(err.Error(), "notFound") {
@@ -418,6 +423,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 
 	// get blobs that I should have (regardless of health of other nodes)
 	if isMine && !alreadyHave && ss.diskHasSpace() {
+		ss.repairSourceEvidence.recordPullMineNeeded(source)
 		tracker.Counters["pull_mine_needed"]++
 
 		success := false

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -72,6 +72,7 @@ func (ss *MediorumServer) startRepairer(ctx context.Context) error {
 		zap.Duration("interval", repairInterval),
 		zap.Int("cleanupEvery", repairCleanupEvery),
 		zap.Int("qmCidsCleanupEvery", repairQmCidsCleanupEvery),
+		zap.Bool("qmCidsUseListIndex", ss.Config.RepairQmCidsUseListIndex),
 	)
 
 	// wait a minute on startup to determine healthy peers
@@ -300,6 +301,20 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 	}
 
 	qmCidsCleanupMode := tracker.CleanupMode && tracker.QmCidsCleanupMode
+	var qmCidsPresenceIndex *repairPresenceIndex
+	if qmCidsCleanupMode && ss.Config.RepairQmCidsUseListIndex {
+		indexStartedAt := time.Now()
+		index, err := ss.buildRepairPresenceIndex(ctx)
+		if err != nil {
+			ss.logger.Warn("failed to build qm_cids repair presence index; falling back to per-key bucket attributes", zap.Error(err))
+			tracker.Counters["qm_cids_list_index_build_fail"]++
+		} else {
+			qmCidsPresenceIndex = index
+			tracker.Counters["qm_cids_list_index_build_success"]++
+			tracker.Counters["qm_cids_list_index_entries"] = index.Len()
+			tracker.Duration += time.Since(indexStartedAt)
+		}
+	}
 
 	// scroll older qm_cids table and repair
 	for {
@@ -340,7 +355,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			}
 
 			tracker.CursorQmCID = cid
-			ss.repairCidWithCleanupMode(ctx, cid, nil, tracker, repairSourceQmCID, qmCidsCleanupMode)
+			ss.repairCidWithPresenceIndex(ctx, cid, nil, tracker, repairSourceQmCID, qmCidsCleanupMode, qmCidsPresenceIndex)
 		}
 
 		tracker.Duration += time.Since(startIter)
@@ -365,6 +380,18 @@ func (ss *MediorumServer) repairCidWithCleanupMode(
 	tracker *RepairTracker,
 	source string,
 	cleanupMode bool,
+) error {
+	return ss.repairCidWithPresenceIndex(ctx, cid, placementHosts, tracker, source, cleanupMode, nil)
+}
+
+func (ss *MediorumServer) repairCidWithPresenceIndex(
+	ctx context.Context,
+	cid string,
+	placementHosts []string,
+	tracker *RepairTracker,
+	source string,
+	cleanupMode bool,
+	presenceIndex *repairPresenceIndex,
 ) error {
 	logger := ss.logger.With(zap.String("task", "repair"), zap.String("cid", cid), zap.Bool("cleanup", cleanupMode))
 	ss.repairSourceEvidence.recordCall(source)
@@ -412,26 +439,39 @@ func (ss *MediorumServer) repairCidWithCleanupMode(
 		return nil
 	}
 	ss.repairSourceEvidence.recordCycle(source, false)
-
-	alreadyHave := true
-	attrs := &blob.Attributes{}
-	ss.repairSourceEvidence.recordAttrCall(source)
-	attrs, err := ss.bucket.Attributes(ctx, key)
-	if err != nil {
-		if gcerrors.Code(err) == gcerrors.NotFound || strings.Contains(err.Error(), "notFound") {
-			attrs = &blob.Attributes{}
-			alreadyHave = false
+	alreadyHave := false
+	blobSize := int64(0)
+	blobModTime := time.Time{}
+	if presenceIndex != nil {
+		tracker.Counters["qm_cids_list_index_lookup"]++
+		if entry, ok := presenceIndex.Lookup(key); ok {
+			alreadyHave = true
+			blobSize = entry.Size
+			blobModTime = entry.ModTime
+			tracker.Counters["qm_cids_list_index_present"]++
 		} else {
-			tracker.Counters["read_attrs_fail"]++
-			logger.Error("exist check failed", zap.Error(err))
-			// Log the error but continue with repair (treat as not found)
-			attrs = &blob.Attributes{}
-			alreadyHave = false
+			tracker.Counters["qm_cids_list_index_missing"]++
+		}
+	} else {
+		ss.repairSourceEvidence.recordAttrCall(source)
+		attrs, err := ss.bucket.Attributes(ctx, key)
+		if err != nil {
+			if gcerrors.Code(err) == gcerrors.NotFound || strings.Contains(err.Error(), "notFound") {
+				alreadyHave = false
+			} else {
+				tracker.Counters["read_attrs_fail"]++
+				logger.Error("exist check failed", zap.Error(err))
+				alreadyHave = false
+			}
+		} else {
+			alreadyHave = true
+			blobSize = attrs.Size
+			blobModTime = attrs.ModTime
 		}
 	}
 
 	// Store result for future duplicate checks within this cycle.
-	tracker.SeenKeys[key] = seenKeyResult{alreadyHave: alreadyHave, size: attrs.Size}
+	tracker.SeenKeys[key] = seenKeyResult{alreadyHave: alreadyHave, size: blobSize}
 
 	// in cleanup mode do some extra checks:
 	// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
@@ -477,7 +517,7 @@ func (ss *MediorumServer) repairCidWithCleanupMode(
 
 	if alreadyHave {
 		tracker.Counters["already_have"]++
-		tracker.ContentSize += attrs.Size
+		tracker.ContentSize += blobSize
 	}
 
 	// get blobs that I should have (regardless of health of other nodes)
@@ -517,7 +557,7 @@ func (ss *MediorumServer) repairCidWithCleanupMode(
 	// check all healthy nodes ahead of me in the preferred order to ensure they have it.
 	// if R+1 healthy nodes in front of me have it, I can safely delete.
 	// don't delete if we replicated the blob within the past week
-	wasReplicatedThisWeek := attrs.ModTime.After(time.Now().Add(-24 * 7 * time.Hour))
+	wasReplicatedThisWeek := blobModTime.After(time.Now().Add(-24 * 7 * time.Hour))
 
 	// by default retain blob if our rank < ReplicationFactor+2
 	// but nodes with more free disk space will use a higher threshold
@@ -535,7 +575,7 @@ func (ss *MediorumServer) repairCidWithCleanupMode(
 	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > rankThreshold && !wasReplicatedThisWeek {
 		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
 		tracker.Counters["delete_over_replicated_needed"]++
-		err = ss.dropFromMyBucket(cid)
+		err := ss.dropFromMyBucket(cid)
 		if err != nil {
 			tracker.Counters["delete_over_replicated_fail"]++
 			logger.Error("delete failed", zap.Error(err))
@@ -543,7 +583,7 @@ func (ss *MediorumServer) repairCidWithCleanupMode(
 		} else {
 			tracker.Counters["delete_over_replicated_success"]++
 			logger.Debug("delete OK")
-			tracker.ContentSize -= attrs.Size
+			tracker.ContentSize -= blobSize
 			return nil
 		}
 	}

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"hash/fnv"
 	"io"
+	"math"
 	"time"
 )
 
@@ -52,6 +53,16 @@ func (idx *repairPresenceIndex) ShouldShadowCompare(key string) bool {
 	hasher := fnv.New32a()
 	_, _ = hasher.Write([]byte(key))
 	return int(hasher.Sum32()%uint32(idx.shadowCompareEvery)) == 0
+}
+
+func repairPresenceIndexModTimesEquivalent(listModTime, attrModTime time.Time) bool {
+	if listModTime.Equal(attrModTime) {
+		return true
+	}
+	if listModTime.IsZero() || attrModTime.IsZero() {
+		return false
+	}
+	return math.Abs(listModTime.Sub(attrModTime).Seconds()) < 1
 }
 
 func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repairPresenceIndex, error) {

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"hash/fnv"
 	"io"
 	"time"
 )
@@ -12,7 +13,10 @@ type repairPresenceIndexEntry struct {
 }
 
 type repairPresenceIndex struct {
-	entries map[string]repairPresenceIndexEntry
+	entries                 map[string]repairPresenceIndexEntry
+	shadowCompareEvery      int
+	disableOnShadowMismatch bool
+	fallbackToPerKeyAttrs   bool
 }
 
 func (idx *repairPresenceIndex) Len() int {
@@ -30,10 +34,32 @@ func (idx *repairPresenceIndex) Lookup(key string) (repairPresenceIndexEntry, bo
 	return entry, ok
 }
 
+func (idx *repairPresenceIndex) ShouldUsePerKeyAttrsFallback() bool {
+	return idx != nil && idx.fallbackToPerKeyAttrs
+}
+
+func (idx *repairPresenceIndex) EnablePerKeyAttrsFallback() {
+	if idx == nil {
+		return
+	}
+	idx.fallbackToPerKeyAttrs = true
+}
+
+func (idx *repairPresenceIndex) ShouldShadowCompare(key string) bool {
+	if idx == nil || idx.shadowCompareEvery <= 0 {
+		return false
+	}
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(key))
+	return int(hasher.Sum32()%uint32(idx.shadowCompareEvery)) == 0
+}
+
 func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repairPresenceIndex, error) {
 	iter := ss.bucket.List(nil)
 	index := &repairPresenceIndex{
-		entries: map[string]repairPresenceIndexEntry{},
+		entries:                 map[string]repairPresenceIndexEntry{},
+		shadowCompareEvery:      ss.Config.RepairQmCidsListIndexShadowCompareEvery,
+		disableOnShadowMismatch: ss.Config.RepairQmCidsListIndexDisableOnMismatch,
 	}
 
 	for {

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+type repairPresenceIndexEntry struct {
+	Size    int64
+	ModTime time.Time
+}
+
+type repairPresenceIndex struct {
+	entries map[string]repairPresenceIndexEntry
+}
+
+func (idx *repairPresenceIndex) Len() int {
+	if idx == nil {
+		return 0
+	}
+	return len(idx.entries)
+}
+
+func (idx *repairPresenceIndex) Lookup(key string) (repairPresenceIndexEntry, bool) {
+	if idx == nil {
+		return repairPresenceIndexEntry{}, false
+	}
+	entry, ok := idx.entries[key]
+	return entry, ok
+}
+
+func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repairPresenceIndex, error) {
+	iter := ss.bucket.List(nil)
+	index := &repairPresenceIndex{
+		entries: map[string]repairPresenceIndexEntry{},
+	}
+
+	for {
+		obj, err := iter.Next(ctx)
+		if err != nil {
+			if err == io.EOF {
+				return index, nil
+			}
+			return nil, err
+		}
+		if obj == nil || obj.IsDir {
+			continue
+		}
+		index.entries[obj.Key] = repairPresenceIndexEntry{
+			Size:    obj.Size,
+			ModTime: obj.ModTime,
+		}
+	}
+}

--- a/pkg/mediorum/server/repair_source_evidence.go
+++ b/pkg/mediorum/server/repair_source_evidence.go
@@ -10,13 +10,14 @@ const (
 )
 
 type repairSourceEvidence struct {
-	CallsTotal           uint64 `json:"calls_total"`
-	FastSkipNotMineTotal uint64 `json:"fast_skip_not_mine_total"`
-	CycleTotal           uint64 `json:"cycle_total"`
-	CycleUnique          uint64 `json:"cycle_unique"`
-	CycleDuplicate       uint64 `json:"cycle_duplicate"`
-	AttrCallsTotal       uint64 `json:"attr_calls_total"`
-	PullMineNeededTotal  uint64 `json:"pull_mine_needed_total"`
+	CallsTotal            uint64 `json:"calls_total"`
+	FastSkipNotMineTotal  uint64 `json:"fast_skip_not_mine_total"`
+	CycleTotal            uint64 `json:"cycle_total"`
+	CycleUnique           uint64 `json:"cycle_unique"`
+	CycleDuplicate        uint64 `json:"cycle_duplicate"`
+	KnownPresentHitsTotal uint64 `json:"known_present_hits_total"`
+	AttrCallsTotal        uint64 `json:"attr_calls_total"`
+	PullMineNeededTotal   uint64 `json:"pull_mine_needed_total"`
 }
 
 type repairSourceEvidenceTracker struct {
@@ -66,6 +67,12 @@ func (t *repairSourceEvidenceTracker) recordCycle(source string, duplicate bool)
 		return
 	}
 	state.CycleUnique++
+}
+
+func (t *repairSourceEvidenceTracker) recordKnownPresentHit(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).KnownPresentHitsTotal++
 }
 
 func (t *repairSourceEvidenceTracker) recordAttrCall(source string) {

--- a/pkg/mediorum/server/repair_source_evidence.go
+++ b/pkg/mediorum/server/repair_source_evidence.go
@@ -10,14 +10,17 @@ const (
 )
 
 type repairSourceEvidence struct {
-	CallsTotal            uint64 `json:"calls_total"`
-	FastSkipNotMineTotal  uint64 `json:"fast_skip_not_mine_total"`
-	CycleTotal            uint64 `json:"cycle_total"`
-	CycleUnique           uint64 `json:"cycle_unique"`
-	CycleDuplicate        uint64 `json:"cycle_duplicate"`
-	KnownPresentHitsTotal uint64 `json:"known_present_hits_total"`
-	AttrCallsTotal        uint64 `json:"attr_calls_total"`
-	PullMineNeededTotal   uint64 `json:"pull_mine_needed_total"`
+	CallsTotal                   uint64 `json:"calls_total"`
+	FastSkipNotMineTotal         uint64 `json:"fast_skip_not_mine_total"`
+	CycleTotal                   uint64 `json:"cycle_total"`
+	CycleUnique                  uint64 `json:"cycle_unique"`
+	CycleDuplicate               uint64 `json:"cycle_duplicate"`
+	KnownPresentHitsTotal        uint64 `json:"known_present_hits_total"`
+	AttrCallsTotal               uint64 `json:"attr_calls_total"`
+	ShadowAttrCallsTotal         uint64 `json:"shadow_attr_calls_total"`
+	ListIndexShadowMismatchTotal uint64 `json:"list_index_shadow_mismatch_total"`
+	ListIndexFallbackTotal       uint64 `json:"list_index_fallback_total"`
+	PullMineNeededTotal          uint64 `json:"pull_mine_needed_total"`
 }
 
 type repairSourceEvidenceTracker struct {
@@ -79,6 +82,24 @@ func (t *repairSourceEvidenceTracker) recordAttrCall(source string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.sourceState(source).AttrCallsTotal++
+}
+
+func (t *repairSourceEvidenceTracker) recordShadowAttrCall(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).ShadowAttrCallsTotal++
+}
+
+func (t *repairSourceEvidenceTracker) recordListIndexShadowMismatch(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).ListIndexShadowMismatchTotal++
+}
+
+func (t *repairSourceEvidenceTracker) recordListIndexFallback(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).ListIndexFallbackTotal++
 }
 
 func (t *repairSourceEvidenceTracker) recordPullMineNeeded(source string) {

--- a/pkg/mediorum/server/repair_source_evidence.go
+++ b/pkg/mediorum/server/repair_source_evidence.go
@@ -1,0 +1,91 @@
+package server
+
+import "sync"
+
+const (
+	repairSourceUploadOrig      = "upload_orig"
+	repairSourceUploadTranscode = "upload_transcode"
+	repairSourceAudioPreview    = "audio_preview"
+	repairSourceQmCID           = "qm_cids"
+)
+
+type repairSourceEvidence struct {
+	CallsTotal           uint64 `json:"calls_total"`
+	FastSkipNotMineTotal uint64 `json:"fast_skip_not_mine_total"`
+	CycleTotal           uint64 `json:"cycle_total"`
+	CycleUnique          uint64 `json:"cycle_unique"`
+	CycleDuplicate       uint64 `json:"cycle_duplicate"`
+	AttrCallsTotal       uint64 `json:"attr_calls_total"`
+	PullMineNeededTotal  uint64 `json:"pull_mine_needed_total"`
+}
+
+type repairSourceEvidenceTracker struct {
+	mu      sync.Mutex
+	sources map[string]*repairSourceEvidence
+}
+
+func newRepairSourceEvidenceTracker() *repairSourceEvidenceTracker {
+	return &repairSourceEvidenceTracker{
+		sources: map[string]*repairSourceEvidence{
+			repairSourceUploadOrig:      {},
+			repairSourceUploadTranscode: {},
+			repairSourceAudioPreview:    {},
+			repairSourceQmCID:           {},
+		},
+	}
+}
+
+func (t *repairSourceEvidenceTracker) sourceState(source string) *repairSourceEvidence {
+	state, ok := t.sources[source]
+	if !ok {
+		state = &repairSourceEvidence{}
+		t.sources[source] = state
+	}
+	return state
+}
+
+func (t *repairSourceEvidenceTracker) recordCall(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).CallsTotal++
+}
+
+func (t *repairSourceEvidenceTracker) recordFastSkipNotMine(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).FastSkipNotMineTotal++
+}
+
+func (t *repairSourceEvidenceTracker) recordCycle(source string, duplicate bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state := t.sourceState(source)
+	state.CycleTotal++
+	if duplicate {
+		state.CycleDuplicate++
+		return
+	}
+	state.CycleUnique++
+}
+
+func (t *repairSourceEvidenceTracker) recordAttrCall(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).AttrCallsTotal++
+}
+
+func (t *repairSourceEvidenceTracker) recordPullMineNeeded(source string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sourceState(source).PullMineNeededTotal++
+}
+
+func (t *repairSourceEvidenceTracker) snapshot() map[string]repairSourceEvidence {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	payload := make(map[string]repairSourceEvidence, len(t.sources))
+	for source, state := range t.sources {
+		payload[source] = *state
+	}
+	return payload
+}

--- a/pkg/mediorum/server/repair_source_evidence_test.go
+++ b/pkg/mediorum/server/repair_source_evidence_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepairSourceEvidenceTrackerSnapshot(t *testing.T) {
+	tracker := newRepairSourceEvidenceTracker()
+	tracker.recordCall(repairSourceQmCID)
+	tracker.recordFastSkipNotMine(repairSourceQmCID)
+	tracker.recordCycle(repairSourceQmCID, false)
+	tracker.recordCycle(repairSourceQmCID, true)
+	tracker.recordAttrCall(repairSourceQmCID)
+	tracker.recordPullMineNeeded(repairSourceQmCID)
+
+	snapshot := tracker.snapshot()
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].CallsTotal)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].FastSkipNotMineTotal)
+	assert.Equal(t, uint64(2), snapshot[repairSourceQmCID].CycleTotal)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].CycleUnique)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].CycleDuplicate)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].AttrCallsTotal)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].PullMineNeededTotal)
+}
+
+func TestGetMetricsIncludesRepairSourceEvidence(t *testing.T) {
+	ss := testNetwork[0]
+	ss.repairSourceEvidence.recordCall(repairSourceUploadOrig)
+	ss.repairSourceEvidence.recordAttrCall(repairSourceUploadOrig)
+
+	req := httptest.NewRequest("GET", "/internal/metrics", nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	assert.NoError(t, ss.getMetrics(c))
+	assert.Equal(t, 200, rec.Code)
+
+	var payload map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	assert.Contains(t, payload, "storage_repair_source_evidence")
+}

--- a/pkg/mediorum/server/repair_source_evidence_test.go
+++ b/pkg/mediorum/server/repair_source_evidence_test.go
@@ -16,6 +16,9 @@ func TestRepairSourceEvidenceTrackerSnapshot(t *testing.T) {
 	tracker.recordCycle(repairSourceQmCID, false)
 	tracker.recordCycle(repairSourceQmCID, true)
 	tracker.recordAttrCall(repairSourceQmCID)
+	tracker.recordShadowAttrCall(repairSourceQmCID)
+	tracker.recordListIndexShadowMismatch(repairSourceQmCID)
+	tracker.recordListIndexFallback(repairSourceQmCID)
 	tracker.recordPullMineNeeded(repairSourceQmCID)
 
 	snapshot := tracker.snapshot()
@@ -25,6 +28,9 @@ func TestRepairSourceEvidenceTrackerSnapshot(t *testing.T) {
 	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].CycleUnique)
 	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].CycleDuplicate)
 	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].AttrCallsTotal)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].ShadowAttrCallsTotal)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].ListIndexShadowMismatchTotal)
+	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].ListIndexFallbackTotal)
 	assert.Equal(t, uint64(1), snapshot[repairSourceQmCID].PullMineNeededTotal)
 }
 

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -419,3 +419,43 @@ func TestRepairCidWithPresenceIndexShadowMatchStaysOnFastPath(t *testing.T) {
 	assert.Equal(t, before.ShadowAttrCallsTotal+1, after.ShadowAttrCallsTotal)
 	assert.Equal(t, before.ListIndexShadowMismatchTotal, after.ListIndexShadowMismatchTotal)
 }
+
+func TestRepairCidWithPresenceIndexToleratesSubsecondModTimeDrift(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	data := []byte("presence-index-modtime-tolerance")
+	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
+	assert.NoError(t, err)
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+
+	index, err := ss.buildRepairPresenceIndex(ctx)
+	assert.NoError(t, err)
+	index.shadowCompareEvery = 1
+	index.disableOnShadowMismatch = true
+
+	key := cidutil.ShardCID(cid)
+	entry, ok := index.Lookup(key)
+	assert.True(t, ok)
+	entry.ModTime = entry.ModTime.Add(500 * time.Millisecond)
+	index.entries[key] = entry
+
+	tracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: true,
+		Counters:          map[string]int{},
+	}
+
+	before := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.NoError(t, ss.repairCidWithPresenceIndex(ctx, cid, []string{ss.Config.Self.Host}, tracker, repairSourceQmCID, false, index))
+
+	after := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.False(t, index.ShouldUsePerKeyAttrsFallback())
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_shadow_compare_total"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_shadow_match"])
+	assert.Equal(t, 0, tracker.Counters["qm_cids_list_index_shadow_mismatch"])
+	assert.Equal(t, before.AttrCallsTotal, after.AttrCallsTotal)
+	assert.Equal(t, before.ShadowAttrCallsTotal+1, after.ShadowAttrCallsTotal)
+	assert.Equal(t, before.ListIndexShadowMismatchTotal, after.ListIndexShadowMismatchTotal)
+}

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -162,3 +162,21 @@ func TestRepair(t *testing.T) {
 	}
 
 }
+
+func TestNextRepairCursorRespectsCleanupEvery(t *testing.T) {
+	cursor, cleanup := nextRepairCursor(3, 4)
+	assert.Equal(t, 4, cursor)
+	assert.False(t, cleanup)
+
+	cursor, cleanup = nextRepairCursor(4, 4)
+	assert.Equal(t, 1, cursor)
+	assert.True(t, cleanup)
+
+	cursor, cleanup = nextRepairCursor(11, 12)
+	assert.Equal(t, 12, cursor)
+	assert.False(t, cleanup)
+
+	cursor, cleanup = nextRepairCursor(12, 12)
+	assert.Equal(t, 1, cursor)
+	assert.True(t, cleanup)
+}

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -221,3 +221,51 @@ func TestRepairCidWithCleanupOverrideSkipsNotMineFastPath(t *testing.T) {
 	snapshot := ss.repairSourceEvidence.snapshot()
 	assert.Positive(t, snapshot[repairSourceQmCID].FastSkipNotMineTotal)
 }
+
+func TestBuildRepairPresenceIndexIncludesLocalBlob(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	data := []byte("presence-index-local-blob")
+	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
+	assert.NoError(t, err)
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+
+	index, err := ss.buildRepairPresenceIndex(ctx)
+	assert.NoError(t, err)
+
+	entry, ok := index.Lookup(cidutil.ShardCID(cid))
+	assert.True(t, ok)
+	assert.Equal(t, int64(len(data)), entry.Size)
+}
+
+func TestRepairCidWithPresenceIndexUsesListedState(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	data := []byte("presence-index-repair-path")
+	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
+	assert.NoError(t, err)
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+
+	index, err := ss.buildRepairPresenceIndex(ctx)
+	assert.NoError(t, err)
+
+	assert.NoError(t, ss.dropFromMyBucket(cid))
+
+	before := ss.repairSourceEvidence.snapshot()[repairSourceQmCID].AttrCallsTotal
+	tracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: true,
+		Counters:          map[string]int{},
+	}
+
+	assert.NoError(t, ss.repairCidWithPresenceIndex(ctx, cid, []string{ss.Config.Self.Host}, tracker, repairSourceQmCID, false, index))
+	assert.Equal(t, 1, tracker.Counters["already_have"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_lookup"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_present"])
+
+	after := ss.repairSourceEvidence.snapshot()[repairSourceQmCID].AttrCallsTotal
+	assert.Equal(t, before, after)
+}

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -269,3 +269,153 @@ func TestRepairCidWithPresenceIndexUsesListedState(t *testing.T) {
 	after := ss.repairSourceEvidence.snapshot()[repairSourceQmCID].AttrCallsTotal
 	assert.Equal(t, before, after)
 }
+
+func TestRepairCidWithPresenceIndexShadowMismatchFallsBack(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	var cid string
+	var data []byte
+	for i := 0; i < 128; i++ {
+		candidateData := []byte("presence-index-shadow-mismatch-" + string(rune('a'+i)))
+		candidateCID, err := cidutil.ComputeFileCID(bytes.NewReader(candidateData))
+		assert.NoError(t, err)
+		_, isMine := ss.rendezvousAllHosts(candidateCID)
+		if !isMine {
+			cid = candidateCID
+			data = candidateData
+			break
+		}
+	}
+	if cid == "" {
+		t.Fatal("failed to find cid that is not mine")
+	}
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+
+	index, err := ss.buildRepairPresenceIndex(ctx)
+	assert.NoError(t, err)
+	index.shadowCompareEvery = 1
+	index.disableOnShadowMismatch = true
+
+	assert.NoError(t, ss.dropFromMyBucket(cid))
+
+	tracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: true,
+		Counters:          map[string]int{},
+	}
+
+	before := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.NoError(t, ss.repairCidWithPresenceIndex(ctx, cid, nil, tracker, repairSourceQmCID, true, index))
+
+	after := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.True(t, index.ShouldUsePerKeyAttrsFallback())
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_lookup"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_present"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_shadow_compare_total"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_shadow_mismatch"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_fallback_triggered"])
+	assert.Equal(t, 0, tracker.Counters["pull_mine_needed"])
+	assert.Equal(t, 0, tracker.Counters["already_have"])
+	assert.Equal(t, before.AttrCallsTotal, after.AttrCallsTotal)
+	assert.Equal(t, before.ShadowAttrCallsTotal+1, after.ShadowAttrCallsTotal)
+	assert.Equal(t, before.ListIndexShadowMismatchTotal+1, after.ListIndexShadowMismatchTotal)
+	assert.Equal(t, before.ListIndexFallbackTotal+1, after.ListIndexFallbackTotal)
+}
+
+func TestRepairCidWithPresenceIndexFallbackUsesPerKeyAttrsAfterMismatch(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	var staleCID string
+	var staleData []byte
+	var fallbackCID string
+	for i := 0; i < 256; i++ {
+		candidateData := []byte("presence-index-fallback-" + string(rune('a'+(i%26))) + string(rune('A'+(i/26))))
+		candidateCID, err := cidutil.ComputeFileCID(bytes.NewReader(candidateData))
+		assert.NoError(t, err)
+		_, isMine := ss.rendezvousAllHosts(candidateCID)
+		if isMine {
+			continue
+		}
+		if staleCID == "" {
+			staleCID = candidateCID
+			staleData = candidateData
+			continue
+		}
+		fallbackCID = candidateCID
+		break
+	}
+	if staleCID == "" || fallbackCID == "" {
+		t.Fatal("failed to find non-mine cids for fallback test")
+	}
+
+	assert.NoError(t, ss.replicateToMyBucket(ctx, staleCID, bytes.NewReader(staleData)))
+
+	index, err := ss.buildRepairPresenceIndex(ctx)
+	assert.NoError(t, err)
+	index.shadowCompareEvery = 1
+	index.disableOnShadowMismatch = true
+
+	assert.NoError(t, ss.dropFromMyBucket(staleCID))
+
+	before := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	mismatchTracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: true,
+		Counters:          map[string]int{},
+	}
+	assert.NoError(t, ss.repairCidWithPresenceIndex(ctx, staleCID, nil, mismatchTracker, repairSourceQmCID, true, index))
+	assert.True(t, index.ShouldUsePerKeyAttrsFallback())
+
+	fallbackTracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: true,
+		Counters:          map[string]int{},
+	}
+	assert.NoError(t, ss.repairCidWithPresenceIndex(ctx, fallbackCID, nil, fallbackTracker, repairSourceQmCID, true, index))
+
+	after := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.Equal(t, 1, fallbackTracker.Counters["qm_cids_list_index_fallback_lookup"])
+	assert.Equal(t, 0, fallbackTracker.Counters["qm_cids_list_index_lookup"])
+	assert.Equal(t, before.AttrCallsTotal+1, after.AttrCallsTotal)
+	assert.Equal(t, before.ShadowAttrCallsTotal+1, after.ShadowAttrCallsTotal)
+	assert.Equal(t, before.ListIndexShadowMismatchTotal+1, after.ListIndexShadowMismatchTotal)
+	assert.Equal(t, before.ListIndexFallbackTotal+2, after.ListIndexFallbackTotal)
+}
+
+func TestRepairCidWithPresenceIndexShadowMatchStaysOnFastPath(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	data := []byte("presence-index-shadow-match")
+	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
+	assert.NoError(t, err)
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+
+	index, err := ss.buildRepairPresenceIndex(ctx)
+	assert.NoError(t, err)
+	index.shadowCompareEvery = 1
+	index.disableOnShadowMismatch = true
+
+	tracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: true,
+		Counters:          map[string]int{},
+	}
+
+	before := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.NoError(t, ss.repairCidWithPresenceIndex(ctx, cid, []string{ss.Config.Self.Host}, tracker, repairSourceQmCID, false, index))
+
+	after := ss.repairSourceEvidence.snapshot()[repairSourceQmCID]
+	assert.False(t, index.ShouldUsePerKeyAttrsFallback())
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_shadow_compare_total"])
+	assert.Equal(t, 1, tracker.Counters["qm_cids_list_index_shadow_match"])
+	assert.Equal(t, before.AttrCallsTotal, after.AttrCallsTotal)
+	assert.Equal(t, before.ShadowAttrCallsTotal+1, after.ShadowAttrCallsTotal)
+	assert.Equal(t, before.ListIndexShadowMismatchTotal, after.ListIndexShadowMismatchTotal)
+}

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -180,3 +180,44 @@ func TestNextRepairCursorRespectsCleanupEvery(t *testing.T) {
 	assert.Equal(t, 1, cursor)
 	assert.True(t, cleanup)
 }
+
+func TestShouldRunQmCidsCleanup(t *testing.T) {
+	assert.True(t, shouldRunQmCidsCleanup(1, 1))
+	assert.True(t, shouldRunQmCidsCleanup(1, 12))
+	assert.False(t, shouldRunQmCidsCleanup(2, 12))
+	assert.False(t, shouldRunQmCidsCleanup(12, 12))
+	assert.True(t, shouldRunQmCidsCleanup(13, 12))
+	assert.False(t, shouldRunQmCidsCleanup(1, 0))
+}
+
+func TestRepairCidWithCleanupOverrideSkipsNotMineFastPath(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+
+	var cid string
+	for i := 0; i < 128; i++ {
+		candidate, err := cidutil.ComputeFileCID(bytes.NewReader([]byte("qm-cleanup-fast-skip-" + string(rune('a'+i)))))
+		assert.NoError(t, err)
+		_, isMine := ss.rendezvousAllHosts(candidate)
+		if !isMine {
+			cid = candidate
+			break
+		}
+	}
+	if cid == "" {
+		t.Fatal("failed to find cid that is not mine")
+	}
+
+	tracker := &RepairTracker{
+		StartedAt:         time.Now(),
+		CleanupMode:       true,
+		QmCidsCleanupMode: false,
+		Counters:          map[string]int{},
+	}
+
+	assert.NoError(t, ss.repairCidWithCleanupMode(ctx, cid, nil, tracker, repairSourceQmCID, false))
+	assert.Equal(t, 0, tracker.Counters["total_checked"])
+
+	snapshot := ss.repairSourceEvidence.snapshot()
+	assert.Positive(t, snapshot[repairSourceQmCID].FastSkipNotMineTotal)
+}

--- a/pkg/mediorum/server/serve_metrics.go
+++ b/pkg/mediorum/server/serve_metrics.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Metrics struct {
-	Host              string         `json:"host"`
-	Uploads           int64          `json:"uploads"`
-	OutboxSizes       map[string]int `json:"outbox_sizes"`
-	RedirectCacheSize int            `json:"redirect_cache_size"`
+	Host                        string                          `json:"host"`
+	Uploads                     int64                           `json:"uploads"`
+	OutboxSizes                 map[string]int                  `json:"outbox_sizes"`
+	RedirectCacheSize           int                             `json:"redirect_cache_size"`
+	StorageRepairSourceEvidence map[string]repairSourceEvidence `json:"storage_repair_source_evidence"`
 }
 
 type BlobMetric struct {
@@ -42,6 +43,7 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	m.Uploads = ss.uploadsCount
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
 	m.RedirectCacheSize = ss.redirectCache.Len()
+	m.StorageRepairSourceEvidence = ss.repairSourceEvidence.snapshot()
 
 	return c.JSON(200, m)
 }

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -53,34 +53,36 @@ type trackAccessInfo struct {
 }
 
 type MediorumConfig struct {
-	Env                       string
-	Self                      registrar.Peer
-	Peers                     []registrar.Peer
-	Signers                   []registrar.Peer
-	ReplicationFactor         int
-	Dir                       string `default:"/tmp/mediorum"`
-	BlobStoreDSN              string `json:"-"`
-	MoveFromBlobStoreDSN      string `json:"-"`
-	PostgresDSN               string `json:"-"`
-	PrivateKey                string `json:"-"`
-	ListenPort                string
-	TrustedNotifierID         int
-	SPID                      int
-	SPOwnerWallet             string
-	GitSHA                    string
-	AudiusDockerCompose       string
-	AutoUpgradeEnabled        bool
-	WalletIsRegistered        bool
-	StoreAll                  bool
-	VersionJson               version.VersionJson
-	DiscoveryListensEndpoints []string
-	LogLevel                  string
-	DeadHosts                 []string
-	RepairEnabled             bool          `default:"true"`
-	RepairInterval            time.Duration `default:"1h"`
-	RepairCleanupEvery        int           `default:"4"`
-	RepairQmCidsCleanupEvery  int           `default:"1"`
-	RepairQmCidsUseListIndex  bool
+	Env                                     string
+	Self                                    registrar.Peer
+	Peers                                   []registrar.Peer
+	Signers                                 []registrar.Peer
+	ReplicationFactor                       int
+	Dir                                     string `default:"/tmp/mediorum"`
+	BlobStoreDSN                            string `json:"-"`
+	MoveFromBlobStoreDSN                    string `json:"-"`
+	PostgresDSN                             string `json:"-"`
+	PrivateKey                              string `json:"-"`
+	ListenPort                              string
+	TrustedNotifierID                       int
+	SPID                                    int
+	SPOwnerWallet                           string
+	GitSHA                                  string
+	AudiusDockerCompose                     string
+	AutoUpgradeEnabled                      bool
+	WalletIsRegistered                      bool
+	StoreAll                                bool
+	VersionJson                             version.VersionJson
+	DiscoveryListensEndpoints               []string
+	LogLevel                                string
+	DeadHosts                               []string
+	RepairEnabled                           bool          `default:"true"`
+	RepairInterval                          time.Duration `default:"1h"`
+	RepairCleanupEvery                      int           `default:"4"`
+	RepairQmCidsCleanupEvery                int           `default:"1"`
+	RepairQmCidsUseListIndex                bool
+	RepairQmCidsListIndexShadowCompareEvery int
+	RepairQmCidsListIndexDisableOnMismatch  bool
 
 	ProgrammableDistributionEnabled bool
 	BlobStorageStreaming            bool

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -79,6 +79,7 @@ type MediorumConfig struct {
 	RepairEnabled             bool          `default:"true"`
 	RepairInterval            time.Duration `default:"1h"`
 	RepairCleanupEvery        int           `default:"4"`
+	RepairQmCidsCleanupEvery  int           `default:"1"`
 
 	ProgrammableDistributionEnabled bool
 	BlobStorageStreaming            bool

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -131,6 +131,7 @@ type MediorumServer struct {
 	uploadOrigCidCache    *imcache.Cache[string, string]
 	imageCache            *imcache.Cache[string, []byte]
 	trackAccessInfoCache  *imcache.Cache[string, trackAccessInfo]
+	repairSourceEvidence  *repairSourceEvidenceTracker
 	failsPeerReachability bool
 
 	StartedAt time.Time
@@ -371,6 +372,7 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		uploadOrigCidCache:   imcache.New(imcache.WithMaxEntriesLimitOption[string, string](50_000, imcache.EvictionPolicyLRU)),
 		imageCache:           imcache.New(imcache.WithMaxEntriesLimitOption[string, []byte](10_000, imcache.EvictionPolicyLRU)),
 		trackAccessInfoCache: imcache.New(imcache.WithMaxEntriesLimitOption[string, trackAccessInfo](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, trackAccessInfo](5*time.Minute)),
+		repairSourceEvidence: newRepairSourceEvidenceTracker(),
 
 		StartedAt:    time.Now().UTC(),
 		Config:       config,

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -78,16 +78,16 @@ type MediorumConfig struct {
 	DeadHosts                 []string
 	RepairEnabled             bool          `default:"true"`
 	RepairInterval            time.Duration `default:"1h"`
+	RepairCleanupEvery        int           `default:"4"`
 
 	ProgrammableDistributionEnabled bool
-	BlobStorageStreaming             bool
+	BlobStorageStreaming            bool
 
 	// should have a basedir type of thing
 	// by default will put db + blobs there
 
 	privateKey *ecdsa.PrivateKey
 }
-
 
 type MediorumServer struct {
 	lc               *lifecycle.Lifecycle
@@ -372,8 +372,8 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		imageCache:           imcache.New(imcache.WithMaxEntriesLimitOption[string, []byte](10_000, imcache.EvictionPolicyLRU)),
 		trackAccessInfoCache: imcache.New(imcache.WithMaxEntriesLimitOption[string, trackAccessInfo](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, trackAccessInfo](5*time.Minute)),
 
-		StartedAt: time.Now().UTC(),
-		Config:    config,
+		StartedAt:    time.Now().UTC(),
+		Config:       config,
 		geoIPdbReady: make(chan struct{}),
 
 		core: core,

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -80,6 +80,7 @@ type MediorumConfig struct {
 	RepairInterval            time.Duration `default:"1h"`
 	RepairCleanupEvery        int           `default:"4"`
 	RepairQmCidsCleanupEvery  int           `default:"1"`
+	RepairQmCidsUseListIndex  bool
 
 	ProgrammableDistributionEnabled bool
 	BlobStorageStreaming            bool


### PR DESCRIPTION
## Summary

This PR reduces per-key blob attribute checks during `qm_cids` cleanup by allowing cleanup to use a list-based presence index instead of requiring an object attribute lookup for every candidate CID.

It also separates `qm_cids` cleanup cadence from the broader repair cadence, so operators can control how often that expensive cleanup path runs.

## Reviewer Decision

If this PR is accepted, the intended decision is:

- accept the new `qm_cids` cleanup fast path behind explicit flags
- accept sampled shadow verification and fallback-on-mismatch as the safety boundary
- accept the small repair-source evidence surface as the observability needed to judge rollout safety
- do not treat this PR as a change to normal stream serving or blob streaming

## What Changed

- add `OPENAUDIO_REPAIR_CLEANUP_EVERY`
- add `OPENAUDIO_REPAIR_QM_CIDS_CLEANUP_EVERY`
- add optional `qm_cids` presence-index cleanup path
- add optional sampled shadow comparison against per-key attrs
- add optional disable-on-mismatch fallback
- tolerate sub-second `ModTime` precision drift between list results and attrs
- add repair-source evidence counters so operators can see normal attr calls, shadow attr calls, and fallback behavior by repair source

## Why

On our validator fleet, repair has been the dominant measured object-metadata cost, and `qm_cids` cleanup has been the dominant measured repair sub-path.

The goal here is to replace the highest-volume per-key attr loop with a cheaper cleanup mechanism while keeping correctness bounded and observable.

## Safety

This path is explicitly gated:

- `OPENAUDIO_REPAIR_QM_CIDS_USE_LIST_INDEX`
- `OPENAUDIO_REPAIR_QM_CIDS_LIST_INDEX_SHADOW_COMPARE_EVERY`
- `OPENAUDIO_REPAIR_QM_CIDS_LIST_INDEX_DISABLE_ON_MISMATCH`

If sampled shadow checks disagree with per-key attrs, the fast path can disable itself and fall back to existing attr-based behavior.

The repair-source evidence counters included here are meant to make that decision visible during rollout rather than inferred from indirect storage-provider data.

## Evidence

Focused tests on this branch:

```bash
go test ./pkg/mediorum/server -run 'TestNextRepairCursorRespectsCleanupEvery|TestShouldRunQmCidsCleanup|TestRepairSourceEvidenceTrackerSnapshot|TestRepairCidWithPresenceIndexUsesListedState|TestBuildRepairPresenceIndexIncludesLocalBlob|TestRepairCidWithPresenceIndexShadowMismatchFallsBack|TestRepairCidWithPresenceIndexFallbackUsesPerKeyAttrsAfterMismatch|TestRepairCidWithPresenceIndexShadowMatchStaysOnFastPath|TestRepairCidWithPresenceIndexToleratesSubsecondModTimeDrift' -count=1
go test ./pkg/mediorum/server -run '^$'
```

Live operator canaries on our side showed the normal `qm_cids` attr path collapsing by order-of-magnitude class with shadow comparison still enabled and no clean-window mismatch-triggered regressions.

Representative live cohort sample from the exact candidate lane:

- `1,995,657` total `qm_cids` calls
- `29,937` effective attr-backed lookups
- about `66.66x` reduction vs attr-per-lookup
- about `98.4999%` reduction
- zero normal `qm_cids` attr calls on multiple exact-candidate live nodes during the clean observation windows

## Non-Goals

- this PR is not about direct blob streaming
- this PR does not change normal stream serving semantics
- this PR is specifically about reducing repair-side metadata churn
