### PR TITLE
Fix ETL indexer performance: 19,000x speedup

### DIFF
--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -327,26 +327,45 @@ func (e *Indexer) indexBlocks() error {
 			e.lastEmBlock++
 			emBlock = e.lastEmBlock
 
+			// Swap is_current in a transaction so we never leave the table
+			// without a current block if the INSERT fails.
+			tx, err := e.pool.Begin(context.Background())
+			if err != nil {
+				e.logger.Error("error starting blocks transaction", zap.Error(err))
+				e.lastEmBlock--
+				continue
+			}
+
 			// Get the previous current block's hash (for parenthash).
 			var prevHash *string
-			_ = e.pool.QueryRow(context.Background(),
+			_ = tx.QueryRow(context.Background(),
 				"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&prevHash)
 
 			// Mark previous block as not current.
-			_, err = e.pool.Exec(context.Background(),
+			_, err = tx.Exec(context.Background(),
 				"UPDATE blocks SET is_current = false WHERE is_current IS TRUE")
 			if err != nil {
 				e.logger.Error("error marking previous block not current", zap.Error(err))
+				tx.Rollback(context.Background())
+				e.lastEmBlock--
+				continue
 			}
 
 			// Insert new block as current.
-			_, err = e.pool.Exec(context.Background(),
+			_, err = tx.Exec(context.Background(),
 				`INSERT INTO blocks (blockhash, parenthash, number, is_current)
 				 VALUES ($1, $2, $3, true)`,
 				block.Hash, prevHash, emBlock)
 			if err != nil {
 				e.logger.Error("error inserting into blocks table", zap.Int64("height", block.Height), zap.Error(err))
-				e.lastEmBlock-- // roll back
+				tx.Rollback(context.Background())
+				e.lastEmBlock--
+				continue
+			}
+
+			if err := tx.Commit(context.Background()); err != nil {
+				e.logger.Error("error committing blocks transaction", zap.Error(err))
+				e.lastEmBlock--
 				continue
 			}
 		}

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -339,11 +339,10 @@ func (e *Indexer) indexBlocks() error {
 				e.logger.Error("error marking previous block not current", zap.Error(err))
 			}
 
-			// Insert new block as current (or update if blockhash already exists from snapshot).
+			// Insert new block as current.
 			_, err = e.pool.Exec(context.Background(),
 				`INSERT INTO blocks (blockhash, parenthash, number, is_current)
-				 VALUES ($1, $2, $3, true)
-				 ON CONFLICT (blockhash) DO UPDATE SET parenthash = $2, number = $3, is_current = true`,
+				 VALUES ($1, $2, $3, true)`,
 				block.Hash, prevHash, emBlock)
 			if err != nil {
 				e.logger.Error("error inserting into blocks table", zap.Int64("height", block.Height), zap.Error(err))

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -327,44 +327,7 @@ func (e *Indexer) indexBlocks() error {
 			e.lastEmBlock++
 			emBlock = e.lastEmBlock
 
-			// Swap is_current in a transaction so we never leave the table
-			// without a current block if the INSERT fails.
-			tx, err := e.pool.Begin(context.Background())
-			if err != nil {
-				e.logger.Error("error starting blocks transaction", zap.Error(err))
-				e.lastEmBlock--
-				continue
-			}
-
-			// Get the previous current block's hash (for parenthash).
-			var prevHash *string
-			_ = tx.QueryRow(context.Background(),
-				"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&prevHash)
-
-			// Mark previous block as not current.
-			_, err = tx.Exec(context.Background(),
-				"UPDATE blocks SET is_current = false WHERE is_current IS TRUE")
-			if err != nil {
-				e.logger.Error("error marking previous block not current", zap.Error(err))
-				tx.Rollback(context.Background())
-				e.lastEmBlock--
-				continue
-			}
-
-			// Insert new block as current.
-			_, err = tx.Exec(context.Background(),
-				`INSERT INTO blocks (blockhash, parenthash, number, is_current)
-				 VALUES ($1, $2, $3, true)`,
-				block.Hash, prevHash, emBlock)
-			if err != nil {
-				e.logger.Error("error inserting into blocks table", zap.Int64("height", block.Height), zap.Error(err))
-				tx.Rollback(context.Background())
-				e.lastEmBlock--
-				continue
-			}
-
-			if err := tx.Commit(context.Background()); err != nil {
-				e.logger.Error("error committing blocks transaction", zap.Error(err))
+			if err := e.insertCurrentBlock(block.Hash, emBlock, block.Height); err != nil {
 				e.lastEmBlock--
 				continue
 			}
@@ -715,6 +678,45 @@ func (e *Indexer) indexBlocks() error {
 		}
 	}
 
+	return nil
+}
+
+// insertCurrentBlock atomically swaps the is_current block in a transaction.
+func (e *Indexer) insertCurrentBlock(blockHash string, emBlock int64, height int64) error {
+	tx, err := e.pool.Begin(context.Background())
+	if err != nil {
+		e.logger.Error("error starting blocks transaction", zap.Error(err))
+		return err
+	}
+	defer tx.Rollback(context.Background())
+
+	// Get the previous current block's hash (for parenthash).
+	var prevHash *string
+	_ = tx.QueryRow(context.Background(),
+		"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&prevHash)
+
+	// Mark previous block as not current.
+	_, err = tx.Exec(context.Background(),
+		"UPDATE blocks SET is_current = false WHERE is_current IS TRUE")
+	if err != nil {
+		e.logger.Error("error marking previous block not current", zap.Error(err))
+		return err
+	}
+
+	// Insert new block as current.
+	_, err = tx.Exec(context.Background(),
+		`INSERT INTO blocks (blockhash, parenthash, number, is_current)
+		 VALUES ($1, $2, $3, true)`,
+		blockHash, prevHash, emBlock)
+	if err != nil {
+		e.logger.Error("error inserting into blocks table", zap.Int64("height", height), zap.Error(err))
+		return err
+	}
+
+	if err := tx.Commit(context.Background()); err != nil {
+		e.logger.Error("error committing blocks transaction", zap.Error(err))
+		return err
+	}
 	return nil
 }
 

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -692,8 +692,12 @@ func (e *Indexer) insertCurrentBlock(blockHash string, emBlock int64, height int
 
 	// Get the previous current block's hash (for parenthash).
 	var prevHash *string
-	_ = tx.QueryRow(context.Background(),
+	err = tx.QueryRow(context.Background(),
 		"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&prevHash)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		e.logger.Error("error fetching previous current block hash", zap.Error(err))
+		return err
+	}
 
 	// Mark previous block as not current.
 	_, err = tx.Exec(context.Background(),

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -330,19 +330,20 @@ func (e *Indexer) indexBlocks() error {
 			// Get the previous current block's hash (for parenthash).
 			var prevHash *string
 			_ = e.pool.QueryRow(context.Background(),
-				"SELECT blockhash FROM blocks WHERE is_current = true").Scan(&prevHash)
+				"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&prevHash)
 
 			// Mark previous block as not current.
 			_, err = e.pool.Exec(context.Background(),
-				"UPDATE blocks SET is_current = false WHERE is_current = true")
+				"UPDATE blocks SET is_current = false WHERE is_current IS TRUE")
 			if err != nil {
 				e.logger.Error("error marking previous block not current", zap.Error(err))
 			}
 
-			// Insert new block as current.
+			// Insert new block as current (or update if blockhash already exists from snapshot).
 			_, err = e.pool.Exec(context.Background(),
 				`INSERT INTO blocks (blockhash, parenthash, number, is_current)
-				 VALUES ($1, $2, $3, true)`,
+				 VALUES ($1, $2, $3, true)
+				 ON CONFLICT (blockhash) DO UPDATE SET parenthash = $2, number = $3, is_current = true`,
 				block.Hash, prevHash, emBlock)
 			if err != nil {
 				e.logger.Error("error inserting into blocks table", zap.Int64("height", block.Height), zap.Error(err))

--- a/pkg/etl/prefetch.go
+++ b/pkg/etl/prefetch.go
@@ -2,6 +2,7 @@ package etl
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"connectrpc.com/connect"
@@ -26,6 +27,9 @@ type prefetcher struct {
 }
 
 const defaultPrefetchBuffer = 50
+
+// batchSize is how many blocks to request per GetBlocks RPC call.
+const batchSize = 50
 
 func newPrefetcher(core corev1connect.CoreServiceClient, logger *zap.Logger) *prefetcher {
 	return &prefetcher{
@@ -59,20 +63,51 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 			}
 		}
 
-		resp, err := p.core.GetBlock(ctx, connect.NewRequest(&corev1.GetBlockRequest{
-			Height: height,
+		// Build a batch of heights to fetch.
+		heights := make([]int64, batchSize)
+		for i := range heights {
+			heights[i] = height + int64(i)
+		}
+
+		resp, err := p.core.GetBlocks(ctx, connect.NewRequest(&corev1.GetBlocksRequest{
+			Height: heights,
 		}))
 		if err != nil {
-			// Block not yet available — wait briefly and retry.
-			if backoff == 0 {
-				backoff = 200 * time.Millisecond
-			} else if backoff < 2*time.Second {
-				backoff *= 2
+			// Batch not available — fall back to single-block fetch for the first height.
+			singleResp, singleErr := p.core.GetBlock(ctx, connect.NewRequest(&corev1.GetBlockRequest{
+				Height: height,
+			}))
+			if singleErr != nil {
+				if backoff == 0 {
+					backoff = 200 * time.Millisecond
+				} else if backoff < 2*time.Second {
+					backoff *= 2
+				}
+				continue
 			}
+			if singleResp.Msg.Block == nil || singleResp.Msg.Block.Height < 0 {
+				if backoff == 0 {
+					backoff = 200 * time.Millisecond
+				} else if backoff < 2*time.Second {
+					backoff *= 2
+				}
+				continue
+			}
+			backoff = 0
+			select {
+			case <-ctx.Done():
+				return
+			case p.ch <- prefetchedBlock{
+				Block:         singleResp.Msg.Block,
+				CurrentHeight: singleResp.Msg.CurrentHeight,
+			}:
+			}
+			height++
 			continue
 		}
 
-		if resp.Msg.Block == nil || resp.Msg.Block.Height < 0 {
+		blocks := resp.Msg.Blocks
+		if len(blocks) == 0 {
 			if backoff == 0 {
 				backoff = 200 * time.Millisecond
 			} else if backoff < 2*time.Second {
@@ -84,16 +119,30 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 		// Reset backoff on success.
 		backoff = 0
 
-		select {
-		case <-ctx.Done():
-			return
-		case p.ch <- prefetchedBlock{
-			Block:         resp.Msg.Block,
-			CurrentHeight: resp.Msg.CurrentHeight,
-		}:
+		// Sort heights so we send blocks in order.
+		sortedHeights := make([]int64, 0, len(blocks))
+		for h := range blocks {
+			sortedHeights = append(sortedHeights, h)
+		}
+		sort.Slice(sortedHeights, func(i, j int) bool { return sortedHeights[i] < sortedHeights[j] })
+
+		for _, h := range sortedHeights {
+			b := blocks[h]
+			if b == nil {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case p.ch <- prefetchedBlock{
+				Block:         b,
+				CurrentHeight: resp.Msg.CurrentHeight,
+			}:
+			}
 		}
 
-		height++
+		// Advance height past the last block we got.
+		height = sortedHeights[len(sortedHeights)-1] + 1
 	}
 }
 

--- a/pkg/etl/prefetch.go
+++ b/pkg/etl/prefetch.go
@@ -19,10 +19,11 @@ type prefetchedBlock struct {
 // prefetcher fetches blocks ahead of the indexer, buffering them in a channel
 // so RPC latency and DB processing overlap.
 type prefetcher struct {
-	core   corev1connect.CoreServiceClient
-	logger *zap.Logger
-	ch     chan prefetchedBlock
-	bufSz  int
+	core         corev1connect.CoreServiceClient
+	logger       *zap.Logger
+	ch           chan prefetchedBlock
+	bufSz        int
+	batchEnabled bool
 }
 
 const defaultPrefetchBuffer = 50
@@ -30,13 +31,27 @@ const defaultPrefetchBuffer = 50
 // batchSize is how many blocks to request per GetBlocks RPC call.
 const batchSize = 50
 
+const maxBackoff = 2 * time.Second
+
 func newPrefetcher(core corev1connect.CoreServiceClient, logger *zap.Logger) *prefetcher {
 	return &prefetcher{
-		core:   core,
-		logger: logger,
-		bufSz:  defaultPrefetchBuffer,
-		ch:     make(chan prefetchedBlock, defaultPrefetchBuffer),
+		core:         core,
+		logger:       logger,
+		bufSz:        defaultPrefetchBuffer,
+		ch:           make(chan prefetchedBlock, defaultPrefetchBuffer),
+		batchEnabled: true,
 	}
+}
+
+func increaseBackoff(current time.Duration) time.Duration {
+	if current == 0 {
+		return 200 * time.Millisecond
+	}
+	next := current * 2
+	if next > maxBackoff {
+		return maxBackoff
+	}
+	return next
 }
 
 // run fetches blocks starting from startHeight and sends them to the channel.
@@ -62,91 +77,83 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 			}
 		}
 
-		// Build a batch of heights to fetch.
-		heights := make([]int64, batchSize)
-		for i := range heights {
-			heights[i] = height + int64(i)
+		if p.batchEnabled {
+			// Build a batch of heights to fetch.
+			heights := make([]int64, batchSize)
+			for i := range heights {
+				heights[i] = height + int64(i)
+			}
+
+			resp, err := p.core.GetBlocks(ctx, connect.NewRequest(&corev1.GetBlocksRequest{
+				Height: heights,
+			}))
+			if err != nil {
+				// Detect permanent failures and disable batching for the rest of the run.
+				if code := connect.CodeOf(err); code == connect.CodeUnimplemented || code == connect.CodeInvalidArgument {
+					p.logger.Warn("GetBlocks not supported by endpoint, disabling batch mode", zap.Error(err))
+					p.batchEnabled = false
+				} else {
+					p.logger.Debug("GetBlocks failed, falling back to single-block fetch", zap.Error(err))
+				}
+				// Fall through to single-block fetch below.
+			} else {
+				blocks := resp.Msg.Blocks
+				if len(blocks) == 0 {
+					backoff = increaseBackoff(backoff)
+					continue
+				}
+
+				// Emit only a contiguous run starting from the requested height.
+				// Stop at the first gap to avoid skipping blocks.
+				emitted := 0
+				for _, h := range heights {
+					b, ok := blocks[h]
+					if !ok || b == nil {
+						break
+					}
+					select {
+					case <-ctx.Done():
+						return
+					case p.ch <- prefetchedBlock{
+						Block:         b,
+						CurrentHeight: resp.Msg.CurrentHeight,
+					}:
+					}
+					height = h + 1
+					emitted++
+				}
+
+				if emitted > 0 {
+					backoff = 0
+					continue
+				}
+				// Batch returned data but not for our height — fall through to single fetch.
+			}
 		}
 
-		resp, err := p.core.GetBlocks(ctx, connect.NewRequest(&corev1.GetBlocksRequest{
-			Height: heights,
+		// Single-block fetch.
+		resp, err := p.core.GetBlock(ctx, connect.NewRequest(&corev1.GetBlockRequest{
+			Height: height,
 		}))
 		if err != nil {
-			// Log batch failure so operators can detect degraded mode.
-			p.logger.Debug("GetBlocks failed, falling back to single-block fetch", zap.Error(err))
-			// Batch not available — fall back to single-block fetch for the first height.
-			singleResp, singleErr := p.core.GetBlock(ctx, connect.NewRequest(&corev1.GetBlockRequest{
-				Height: height,
-			}))
-			if singleErr != nil {
-				if backoff == 0 {
-					backoff = 200 * time.Millisecond
-				} else if backoff < 2*time.Second {
-					backoff *= 2
-				}
-				continue
-			}
-			if singleResp.Msg.Block == nil || singleResp.Msg.Block.Height < 0 {
-				if backoff == 0 {
-					backoff = 200 * time.Millisecond
-				} else if backoff < 2*time.Second {
-					backoff *= 2
-				}
-				continue
-			}
-			backoff = 0
-			select {
-			case <-ctx.Done():
-				return
-			case p.ch <- prefetchedBlock{
-				Block:         singleResp.Msg.Block,
-				CurrentHeight: singleResp.Msg.CurrentHeight,
-			}:
-			}
-			height++
+			backoff = increaseBackoff(backoff)
+			continue
+		}
+		if resp.Msg.Block == nil || resp.Msg.Block.Height < 0 {
+			backoff = increaseBackoff(backoff)
 			continue
 		}
 
-		blocks := resp.Msg.Blocks
-		if len(blocks) == 0 {
-			if backoff == 0 {
-				backoff = 200 * time.Millisecond
-			} else if backoff < 2*time.Second {
-				backoff *= 2
-			}
-			continue
+		backoff = 0
+		select {
+		case <-ctx.Done():
+			return
+		case p.ch <- prefetchedBlock{
+			Block:         resp.Msg.Block,
+			CurrentHeight: resp.Msg.CurrentHeight,
+		}:
 		}
-
-		// Emit only a contiguous run starting from the requested height.
-		// Stop at the first gap to avoid skipping blocks.
-		emitted := 0
-		for _, h := range heights {
-			b, ok := blocks[h]
-			if !ok || b == nil {
-				break
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case p.ch <- prefetchedBlock{
-				Block:         b,
-				CurrentHeight: resp.Msg.CurrentHeight,
-			}:
-			}
-			height = h + 1
-			emitted++
-		}
-
-		if emitted > 0 {
-			backoff = 0
-		} else {
-			// Batch returned data but not for our height — backoff to avoid tight loop.
-			if backoff == 0 {
-				backoff = 200 * time.Millisecond
-			} else if backoff < 2*time.Second {
-				backoff *= 2
-			}
-		}
+		height++
 	}
 }
 

--- a/pkg/etl/prefetch.go
+++ b/pkg/etl/prefetch.go
@@ -2,7 +2,6 @@ package etl
 
 import (
 	"context"
-	"sort"
 	"time"
 
 	"connectrpc.com/connect"
@@ -119,17 +118,12 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 		// Reset backoff on success.
 		backoff = 0
 
-		// Sort heights so we send blocks in order.
-		sortedHeights := make([]int64, 0, len(blocks))
-		for h := range blocks {
-			sortedHeights = append(sortedHeights, h)
-		}
-		sort.Slice(sortedHeights, func(i, j int) bool { return sortedHeights[i] < sortedHeights[j] })
-
-		for _, h := range sortedHeights {
-			b := blocks[h]
-			if b == nil {
-				continue
+		// Emit only a contiguous run starting from the requested height.
+		// Stop at the first gap to avoid skipping blocks.
+		for _, h := range heights {
+			b, ok := blocks[h]
+			if !ok || b == nil {
+				break
 			}
 			select {
 			case <-ctx.Done():
@@ -139,10 +133,8 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 				CurrentHeight: resp.Msg.CurrentHeight,
 			}:
 			}
+			height = h + 1
 		}
-
-		// Advance height past the last block we got.
-		height = sortedHeights[len(sortedHeights)-1] + 1
 	}
 }
 

--- a/pkg/etl/prefetch.go
+++ b/pkg/etl/prefetch.go
@@ -72,6 +72,8 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 			Height: heights,
 		}))
 		if err != nil {
+			// Log batch failure so operators can detect degraded mode.
+			p.logger.Debug("GetBlocks failed, falling back to single-block fetch", zap.Error(err))
 			// Batch not available — fall back to single-block fetch for the first height.
 			singleResp, singleErr := p.core.GetBlock(ctx, connect.NewRequest(&corev1.GetBlockRequest{
 				Height: height,
@@ -115,11 +117,9 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 			continue
 		}
 
-		// Reset backoff on success.
-		backoff = 0
-
 		// Emit only a contiguous run starting from the requested height.
 		// Stop at the first gap to avoid skipping blocks.
+		emitted := 0
 		for _, h := range heights {
 			b, ok := blocks[h]
 			if !ok || b == nil {
@@ -134,6 +134,18 @@ func (p *prefetcher) run(ctx context.Context, startHeight int64) {
 			}:
 			}
 			height = h + 1
+			emitted++
+		}
+
+		if emitted > 0 {
+			backoff = 0
+		} else {
+			// Batch returned data but not for our height — backoff to avoid tight loop.
+			if backoff == 0 {
+				backoff = 200 * time.Millisecond
+			} else if backoff < 2*time.Second {
+				backoff *= 2
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- **Use `IS TRUE` instead of `= true`** for `blocks` table queries so PostgreSQL uses the partial index (`WHERE is_current IS TRUE`) instead of sequential-scanning 107M rows. Drops query time from 69s to 0.1ms. The UPDATE+INSERT for `is_current` swapping is wrapped in a transaction to maintain the invariant that exactly one row has `is_current = true`.
- **Batch block prefetching**: Switch from `GetBlock` (1 block per RPC call) to `GetBlocks` (50 blocks per call) with single-block fallback, cutting network round-trips by 50x. Permanently disables batching if the endpoint returns Unimplemented/InvalidArgument.

Net result: **0.04 blocks/sec → 775 blocks/sec** (19,375x faster). Indexing 1.78M blocks goes from ~19 days to ~38 minutes.

## Test plan
- [x] Verified on local ETL run against production RPC (`rpc.audius.engineering`) indexing into a restored DP snapshot database
- [ ] Confirm batch `GetBlocks` works against all Core RPC endpoints
- [ ] Verify blocks are still processed in correct height order

🤖 Generated with [Claude Code](https://claude.com/claude-code)