### PR TITLE
Add --skip-migrations flag to ETL runner

### DIFF
--- a/examples/etl/main.go
+++ b/examples/etl/main.go
@@ -28,6 +28,7 @@ func main() {
 	rpcURL := flag.String("rpc", "", "Core RPC endpoint (e.g. https://core.audius.co)")
 	dbURL := flag.String("db", "", "Postgres connection string (e.g. postgres://localhost:5432/etl_local?sslmode=disable)")
 	startBlock := flag.Int64("start", 0, "Starting block height (0 = resume from last indexed)")
+	skipMigrations := flag.Bool("skip-migrations", false, "Skip running database migrations (use with pre-existing schemas)")
 	verbose := flag.Bool("v", false, "Enable debug logging")
 	flag.Parse()
 
@@ -65,6 +66,9 @@ func main() {
 	})
 	if *startBlock > 0 {
 		indexer.SetStartingBlockHeight(*startBlock)
+	}
+	if *skipMigrations {
+		indexer.SetSkipMigrations(true)
 	}
 
 	logger.Info("starting ETL local runner",

--- a/pkg/etl/etl.go
+++ b/pkg/etl/etl.go
@@ -16,6 +16,7 @@ import (
 type Indexer struct {
 	dbURL               string
 	runDownMigrations   bool
+	skipMigrations      bool
 	startingBlockHeight int64
 	endingBlockHeight   int64
 	checkReadiness      bool
@@ -63,6 +64,10 @@ func (e *Indexer) SetEndingBlockHeight(endingBlockHeight int64) {
 
 func (e *Indexer) SetRunDownMigrations(runDownMigrations bool) {
 	e.runDownMigrations = runDownMigrations
+}
+
+func (e *Indexer) SetSkipMigrations(skip bool) {
+	e.skipMigrations = skip
 }
 
 func (e *Indexer) SetCheckReadiness(checkReadiness bool) {

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -48,9 +48,11 @@ func (e *Indexer) Run() error {
 		return fmt.Errorf("dbUrl environment variable not set")
 	}
 
-	err := db.RunMigrations(e.logger, dbUrl, e.runDownMigrations)
-	if err != nil {
-		return fmt.Errorf("error running migrations: %v", err)
+	if !e.skipMigrations {
+		err := db.RunMigrations(e.logger, dbUrl, e.runDownMigrations)
+		if err != nil {
+			return fmt.Errorf("error running migrations: %v", err)
+		}
 	}
 
 	pgConfig, err := pgxpool.ParseConfig(dbUrl)


### PR DESCRIPTION
## Summary
- Adds `skipMigrations` field and `SetSkipMigrations()` method to the ETL `Indexer`
- Adds `--skip-migrations` CLI flag to `examples/etl`
- When set, skips `db.RunMigrations()` on startup — useful when running against a restored production snapshot that already has all tables, avoiding slow `CREATE INDEX IF NOT EXISTS` on large tables

## Test plan
- [x] Verified locally against a restored DP snapshot (107M-row `blocks` table) — ETL starts immediately without hanging on migration index creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)