### PR TITLE
Version v1.2.9

### DIFF
--- a/pkg/version/.version.json
+++ b/pkg/version/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.2.8",
+  "version": "1.2.9",
   "service": "validator"
 }


### PR DESCRIPTION
## Summary
- Bumps `pkg/version/.version.json` from `1.2.8` → `1.2.9` so the `Create Release` workflow will accept `v1.2.9`.
- Releases #211 (delete sender attestation endpoint).

## Test plan
- [ ] CI green
- [ ] After merge: trigger `Create Release` workflow against `main` with version `v1.2.9`