### PR TITLE
Remove stray .claude/worktrees gitlink breaking main CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.claude/
 
 bin/*
 !bin/.gitkeep


### PR DESCRIPTION
## Summary
- A gitlink at `.claude/worktrees/agent-aad269c9` was accidentally committed in [#200](https://github.com/OpenAudio/go-openaudio/pull/200). Without a corresponding `.gitmodules` entry, the `actions/checkout` submodule cleanup step fails on every push to `main` with `fatal: No url found for submodule path`. That failure skips the `tag-edge` job in [ci.yml](.github/workflows/ci.yml), so `:edge` no longer auto-promotes on merge — both v1.2.11 and v1.2.12 had to be promoted manually via `Update Docker Tags`.
- Drop the gitlink and add `.claude/` to `.gitignore` so local Claude Code worktrees don't get committed again.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, confirm CI on `main` succeeds and `tag-edge` runs (so `:edge` would auto-promote on the next regular merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)