### PR TITLE
feat(openaudio): auto-tune Postgres memory and WAL defaults at container start

### DIFF
--- a/cmd/openaudio/Dockerfile
+++ b/cmd/openaudio/Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir -p /env
 COPY ./cmd/openaudio/env/* /env/
 
 COPY ./cmd/openaudio/entrypoint.sh /bin/entrypoint.sh
-RUN chmod +x /bin/entrypoint.sh
+COPY ./cmd/openaudio/postgres-auto-tune.sh /bin/postgres-auto-tune.sh
+RUN chmod +x /bin/entrypoint.sh /bin/postgres-auto-tune.sh
 
 ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA

--- a/cmd/openaudio/entrypoint.sh
+++ b/cmd/openaudio/entrypoint.sh
@@ -95,6 +95,13 @@ setup_postgres() {
         # Stop PostgreSQL to restart it properly
         su - postgres -c "$PG_BIN/pg_ctl -D $POSTGRES_DATA_DIR stop"
     fi
+
+    # Apply memory/WAL defaults sized to detected host RAM. The shim
+    # exits 0 on every failure path and leaves stock defaults in place.
+    # Operators can disable with AUDIUSD_DISABLE_AUTO_TUNE=1 or override
+    # specific settings via conf.d/99-*.conf or ALTER SYSTEM.
+    /bin/postgres-auto-tune.sh "$POSTGRES_DATA_DIR"
+
     echo "Starting PostgreSQL service..."
     # Ensure locale is set when starting PostgreSQL
     su - postgres -c "LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 $PG_BIN/pg_ctl -D $POSTGRES_DATA_DIR start"

--- a/cmd/openaudio/postgres-auto-tune.sh
+++ b/cmd/openaudio/postgres-auto-tune.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# postgres-auto-tune.sh
+#
+# Renders memory and WAL defaults sized to detected host RAM into
+# $POSTGRES_DATA_DIR/conf.d/00-audiusd-defaults.conf, and ensures
+# postgresql.conf includes that directory.
+#
+# Operators override by:
+#   - setting AUDIUSD_DISABLE_AUTO_TUNE=1 (skip entirely), or
+#   - placing their own conf.d/99-*.conf (later includes win), or
+#   - mounting a custom postgresql.auto.conf (always wins last).
+#
+# The shim runs every container start (so upgrading the image picks up
+# new defaults), but only writes the include line into postgresql.conf
+# once. Any failure path exits 0 and leaves stock defaults in place.
+#
+# Conservative-by-default behavior:
+#   * If postgresql.conf already has any of the tuned parameters set,
+#     skip (operator has hand-tuned values; do not override).
+#   * If postgresql.conf already has any include_dir directive (active,
+#     commented, or pointing at a different directory), skip (operator
+#     intent is unclear; do not append a duplicate).
+#   * If running as non-root and not as postgres, skip (cannot chown
+#     conf files into postgres ownership).
+#   * If postgres rejects the rendered conf via `postgres -C` preflight,
+#     remove the rendered file and skip.
+#
+# Test injection: set POSTGRES_AUTO_TUNE_FORCE_MEM_MB to bypass memory
+# detection. Used by the test suite. Production callers must not set it.
+
+set -u
+
+PG_AUTO_TUNE_LOG_PREFIX="[postgres-auto-tune]"
+
+log() { echo "${PG_AUTO_TUNE_LOG_PREFIX} $*"; }
+
+# 1 PiB in bytes. Some kernels report this (or near it) for an unlimited
+# cgroup memory.max instead of the literal "max" string.
+CGROUP_BOGUS_LIMIT_BYTES=1125899906842624
+
+# Postgres GUCs the shim sets. Used to detect operator tuning conflict.
+TUNED_PARAMS="shared_buffers work_mem maintenance_work_mem effective_cache_size wal_buffers max_wal_size min_wal_size"
+
+if [ "${AUDIUSD_DISABLE_AUTO_TUNE:-0}" = "1" ]; then
+    log "AUDIUSD_DISABLE_AUTO_TUNE set; skipping."
+    exit 0
+fi
+
+# Skip when not running as root or postgres. The shim writes conf files
+# under a chmod-700 postgres-owned data dir; only those uids can chown
+# the rendered file into postgres-readable ownership. Tests bypass via
+# POSTGRES_AUTO_TUNE_SKIP_UID_CHECK=1.
+if [ "${POSTGRES_AUTO_TUNE_SKIP_UID_CHECK:-0}" != "1" ]; then
+    RUN_UID=$(id -u 2>/dev/null || echo "")
+    PG_UID=$(id -u postgres 2>/dev/null || echo "")
+    if [ "$RUN_UID" != "0" ] && [ "$RUN_UID" != "$PG_UID" ]; then
+        log "running as uid $RUN_UID (not root, not postgres); skipping."
+        exit 0
+    fi
+fi
+
+DATA_DIR="${1:-${POSTGRES_DATA_DIR:-/data/postgres}}"
+if [ ! -d "$DATA_DIR" ]; then
+    log "data dir '$DATA_DIR' missing; skipping (postgres init has not run yet)."
+    exit 0
+fi
+
+PG_CONF="${DATA_DIR}/postgresql.conf"
+
+# If postgresql.conf already has any of the tuned parameters set
+# uncommented, the operator has done their own tuning. Do not override.
+if [ -f "$PG_CONF" ]; then
+    for param in $TUNED_PARAMS; do
+        if grep -qE "^[[:space:]]*${param}[[:space:]]*=" "$PG_CONF"; then
+            log "operator-tuned ${param} found in postgresql.conf; skipping (operator wins)."
+            exit 0
+        fi
+    done
+fi
+
+# If postgresql.conf already has any include_dir directive (active,
+# commented, or pointing at a different directory), do not append a
+# duplicate. Last-occurrence-wins on include_dir would silently steal
+# the operator's directory.
+if [ -f "$PG_CONF" ]; then
+    if grep -qE "^[[:space:]]*#?[[:space:]]*include_dir[[:space:]]*=" "$PG_CONF"; then
+        if grep -qE "^[[:space:]]*include_dir[[:space:]]*=[[:space:]]*'conf.d'" "$PG_CONF"; then
+            INCLUDE_DIR_PRESENT=ours
+        else
+            INCLUDE_DIR_PRESENT=foreign
+        fi
+    else
+        INCLUDE_DIR_PRESENT=none
+    fi
+else
+    INCLUDE_DIR_PRESENT=none
+fi
+
+if [ "${INCLUDE_DIR_PRESENT:-none}" = "foreign" ]; then
+    log "non-conf.d include_dir directive already in postgresql.conf; skipping (operator wins)."
+    exit 0
+fi
+
+# Detect available memory in MB. Prefer cgroup limit (containerised env
+# may be constrained below host RAM), fall back to /proc/meminfo, fall
+# back to skip. Trim non-digit characters before numeric checks so a
+# trailing CR or whitespace does not silently fall through to host RAM.
+detect_mem_mb() {
+    local cg_v2="/sys/fs/cgroup/memory.max"
+    local cg_v1="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    local val=""
+    local raw=""
+
+    if [ -r "$cg_v2" ]; then
+        raw=$(cat "$cg_v2" 2>/dev/null)
+        # Trim whitespace/CR for the literal "max" comparison.
+        val="${raw//[[:space:]]/}"
+        if [ "$val" != "max" ] && [ -n "$val" ]; then
+            # Strip non-digits for the numeric compare. If the file held
+            # garbage, this leaves an empty string which fails the check.
+            val="${val//[!0-9]/}"
+            if [ -n "$val" ] && [ "$val" -gt 0 ] 2>/dev/null && [ "$val" -lt "$CGROUP_BOGUS_LIMIT_BYTES" ]; then
+                echo $((val / 1024 / 1024))
+                return 0
+            fi
+        fi
+    fi
+
+    if [ -r "$cg_v1" ]; then
+        raw=$(cat "$cg_v1" 2>/dev/null)
+        val="${raw//[!0-9]/}"
+        if [ -n "$val" ] && [ "$val" -gt 0 ] 2>/dev/null && [ "$val" -lt "$CGROUP_BOGUS_LIMIT_BYTES" ]; then
+            echo $((val / 1024 / 1024))
+            return 0
+        fi
+    fi
+
+    if [ -r /proc/meminfo ]; then
+        val=$(awk '/^MemTotal:/ {print int($2/1024); exit}' /proc/meminfo 2>/dev/null)
+        if [ -n "$val" ] && [ "$val" -gt 0 ] 2>/dev/null; then
+            echo "$val"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+if [ -n "${POSTGRES_AUTO_TUNE_FORCE_MEM_MB:-}" ]; then
+    MEM_MB="$POSTGRES_AUTO_TUNE_FORCE_MEM_MB"
+else
+    MEM_MB=$(detect_mem_mb) || {
+        log "could not detect host memory; leaving stock defaults."
+        exit 0
+    }
+fi
+
+if [ "$MEM_MB" -lt 2048 ] 2>/dev/null; then
+    log "host memory ${MEM_MB} MB below 2 GB tier floor; leaving stock defaults."
+    exit 0
+fi
+
+# Tier selection. shared_buffers near 25% of RAM (capped to leave room
+# for the audiusd Go process and OS cache). effective_cache_size at
+# about 50% (more conservative than pgtune's 75%; postgres is not the
+# only tenant in this container). wal_buffers capped at 16 MB per the
+# Postgres docs (larger values are not useful). work_mem modest because
+# audiusd's observed concurrency is well under max_connections.
+if [ "$MEM_MB" -lt 4096 ]; then
+    TIER="2-4GB"
+    SHARED_BUFFERS="256MB"; WORK_MEM="4MB"; MAINTENANCE_WORK_MEM="128MB"
+    EFFECTIVE_CACHE_SIZE="1GB"; WAL_BUFFERS="8MB"
+    MAX_WAL_SIZE="1GB"; MIN_WAL_SIZE="256MB"
+elif [ "$MEM_MB" -lt 8192 ]; then
+    TIER="4-8GB"
+    SHARED_BUFFERS="1GB"; WORK_MEM="8MB"; MAINTENANCE_WORK_MEM="256MB"
+    EFFECTIVE_CACHE_SIZE="3GB"; WAL_BUFFERS="16MB"
+    MAX_WAL_SIZE="2GB"; MIN_WAL_SIZE="512MB"
+elif [ "$MEM_MB" -lt 16384 ]; then
+    TIER="8-16GB"
+    SHARED_BUFFERS="2GB"; WORK_MEM="16MB"; MAINTENANCE_WORK_MEM="512MB"
+    EFFECTIVE_CACHE_SIZE="6GB"; WAL_BUFFERS="16MB"
+    MAX_WAL_SIZE="2GB"; MIN_WAL_SIZE="1GB"
+elif [ "$MEM_MB" -lt 32768 ]; then
+    TIER="16-32GB"
+    SHARED_BUFFERS="4GB"; WORK_MEM="32MB"; MAINTENANCE_WORK_MEM="1GB"
+    EFFECTIVE_CACHE_SIZE="12GB"; WAL_BUFFERS="16MB"
+    MAX_WAL_SIZE="4GB"; MIN_WAL_SIZE="1GB"
+elif [ "$MEM_MB" -lt 65536 ]; then
+    TIER="32-64GB"
+    SHARED_BUFFERS="8GB"; WORK_MEM="32MB"; MAINTENANCE_WORK_MEM="2GB"
+    EFFECTIVE_CACHE_SIZE="24GB"; WAL_BUFFERS="16MB"
+    MAX_WAL_SIZE="8GB"; MIN_WAL_SIZE="2GB"
+else
+    TIER="64GB+"
+    SHARED_BUFFERS="16GB"; WORK_MEM="32MB"; MAINTENANCE_WORK_MEM="2GB"
+    EFFECTIVE_CACHE_SIZE="48GB"; WAL_BUFFERS="16MB"
+    MAX_WAL_SIZE="16GB"; MIN_WAL_SIZE="2GB"
+fi
+
+CONF_D="${DATA_DIR}/conf.d"
+TUNE_FILE="${CONF_D}/00-audiusd-defaults.conf"
+
+# Use mktemp for the staging file (unique, less symlink-attack surface
+# than $$). Falls back to a $$-suffixed name if mktemp is unavailable.
+TMP_FILE=$(mktemp "${CONF_D}/.00-audiusd-defaults.conf.XXXXXX" 2>/dev/null || echo "${TUNE_FILE}.tmp.$$")
+
+mkdir -p "$CONF_D" || {
+    log "could not create $CONF_D; leaving stock defaults."
+    exit 0
+}
+chown postgres:postgres "$CONF_D" 2>/dev/null || true
+
+# Clean up any orphan temp files left by a prior interrupted run.
+rm -f "${CONF_D}"/.00-audiusd-defaults.conf.* "${TUNE_FILE}".tmp.* 2>/dev/null || true
+
+# Re-create TMP_FILE after cleanup (in case our mktemp output was
+# matched by the cleanup glob).
+TMP_FILE=$(mktemp "${CONF_D}/.00-audiusd-defaults.conf.XXXXXX" 2>/dev/null || echo "${TUNE_FILE}.tmp.$$")
+
+# Render to a temp file then atomically rename. Avoids partial-write
+# states if the container is killed mid-write.
+{
+    cat <<EOF
+# Auto-generated by postgres-auto-tune.sh on container start.
+# Do not edit; values are re-rendered every start.
+# Detected host memory: ${MEM_MB} MB (tier ${TIER}).
+#
+# Precedence (later wins):
+#   1. postgresql.conf top-of-file values
+#   2. THIS FILE (conf.d/00-audiusd-defaults.conf)
+#   3. conf.d/99-*.conf (operator override slot)
+#   4. postgresql.auto.conf (ALTER SYSTEM, processed last by Postgres)
+#
+# To disable entirely: set AUDIUSD_DISABLE_AUTO_TUNE=1 in the container env.
+# To override per setting: drop conf.d/99-yours.conf or use ALTER SYSTEM.
+
+shared_buffers = ${SHARED_BUFFERS}
+work_mem = ${WORK_MEM}
+maintenance_work_mem = ${MAINTENANCE_WORK_MEM}
+effective_cache_size = ${EFFECTIVE_CACHE_SIZE}
+wal_buffers = ${WAL_BUFFERS}
+max_wal_size = ${MAX_WAL_SIZE}
+min_wal_size = ${MIN_WAL_SIZE}
+EOF
+} > "$TMP_FILE" || {
+    log "could not write tune file; leaving stock defaults."
+    rm -f "$TMP_FILE"
+    exit 0
+}
+
+mv "$TMP_FILE" "$TUNE_FILE" || {
+    log "could not move tune file into place; leaving stock defaults."
+    rm -f "$TMP_FILE"
+    exit 0
+}
+chown postgres:postgres "$TUNE_FILE" 2>/dev/null || true
+
+# Ensure postgresql.conf includes conf.d. We only reach this branch
+# when INCLUDE_DIR_PRESENT was 'none' (foreign was rejected above).
+# Atomic write: build new postgresql.conf in a temp file and rename.
+if [ "${INCLUDE_DIR_PRESENT}" = "none" ] && [ -f "$PG_CONF" ]; then
+    PG_CONF_TMP=$(mktemp "${DATA_DIR}/.postgresql.conf.XXXXXX" 2>/dev/null || echo "${PG_CONF}.tmp.$$")
+    {
+        cat "$PG_CONF"
+        echo ""
+        echo "# Added by audiusd postgres-auto-tune; reads conf.d/*.conf in name order."
+        echo "include_dir = 'conf.d'"
+    } > "$PG_CONF_TMP" || {
+        log "could not stage postgresql.conf update; tune file ready, include_dir not wired."
+        rm -f "$PG_CONF_TMP" "$TUNE_FILE"
+        exit 0
+    }
+    chown postgres:postgres "$PG_CONF_TMP" 2>/dev/null || true
+    if ! mv "$PG_CONF_TMP" "$PG_CONF"; then
+        log "could not install updated postgresql.conf; tune file ready, include_dir not wired."
+        rm -f "$PG_CONF_TMP" "$TUNE_FILE"
+        exit 0
+    fi
+fi
+
+# Preflight: ask postgres to parse the conf and read back a tuned value.
+# If postgres rejects the conf, remove the tune file rather than letting
+# the next pg_ctl start fail.
+if command -v su >/dev/null 2>&1 && [ -x /usr/lib/postgresql/15/bin/postgres ]; then
+    if ! su - postgres -c "/usr/lib/postgresql/15/bin/postgres -D '${DATA_DIR}' -C shared_buffers" >/dev/null 2>&1; then
+        log "postgres rejected the rendered conf; removing tune file and leaving stock defaults."
+        rm -f "$TUNE_FILE"
+        exit 0
+    fi
+fi
+
+log "applied tier ${TIER} (host ${MEM_MB} MB): shared_buffers=${SHARED_BUFFERS} work_mem=${WORK_MEM} effective_cache_size=${EFFECTIVE_CACHE_SIZE} max_wal_size=${MAX_WAL_SIZE}"
+exit 0

--- a/cmd/openaudio/postgres-auto-tune_test.sh
+++ b/cmd/openaudio/postgres-auto-tune_test.sh
@@ -1,0 +1,358 @@
+#!/bin/bash
+# Tests for postgres-auto-tune.sh.
+#
+# Run from the repo root:
+#   bash cmd/openaudio/postgres-auto-tune_test.sh
+#
+# Memory injection: the shim reads POSTGRES_AUTO_TUNE_FORCE_MEM_MB to
+# bypass detect_mem_mb. Tests set this directly. detect_mem_mb's
+# cgroup-v2 / cgroup-v1 / /proc/meminfo branches are exercised at
+# runtime (they read absolute paths under /sys and /proc that cannot
+# be mocked from a userspace shell test without privileged tooling).
+# Production verification of detect_mem_mb is covered by running the
+# shim inside a real container against real cgroup files.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SHIM="${REPO_ROOT}/cmd/openaudio/postgres-auto-tune.sh"
+PASS=0
+FAIL=0
+
+if [ ! -x "$SHIM" ]; then
+    chmod +x "$SHIM" 2>/dev/null || true
+fi
+
+assert_value() {
+    local conf="$1" key="$2" want="$3" testname="$4"
+    local got
+    got=$(grep "^${key}[[:space:]]*=" "$conf" 2>/dev/null | sed 's/^[^=]*=[[:space:]]*//' | tr -d '[:space:]')
+    if [ "$got" = "$want" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: ${testname}: ${key}=${got}"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: ${testname}: ${key}: want=${want} got=${got}"
+    fi
+}
+
+assert_file_present() {
+    local f="$1" testname="$2"
+    if [ -f "$f" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: ${testname}: file present"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: ${testname}: file missing: ${f}"
+    fi
+}
+
+assert_file_absent() {
+    local f="$1" testname="$2"
+    if [ ! -f "$f" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: ${testname}: file absent"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: ${testname}: file unexpectedly present: ${f}"
+    fi
+}
+
+assert_log_contains() {
+    local logfile="$1" pattern="$2" testname="$3"
+    if grep -qF "$pattern" "$logfile" 2>/dev/null; then
+        PASS=$((PASS + 1))
+        echo "  PASS: ${testname}: log contains '${pattern}'"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: ${testname}: log does not contain '${pattern}'"
+        echo "    log was:"
+        sed 's/^/      /' "$logfile"
+    fi
+}
+
+count_lines() {
+    grep -cE "$2" "$1" 2>/dev/null || echo 0
+}
+
+SBX_BASE="$(mktemp -d -t pgtune-test.XXXXXX)"
+trap 'rm -rf "$SBX_BASE"' EXIT
+
+# Tests run as the developer's uid, not root or postgres. The shim's
+# production uid check (root or postgres only) is bypassed for tests.
+export POSTGRES_AUTO_TUNE_SKIP_UID_CHECK=1
+
+# Run the shim with a forced memory value into a fresh sandbox dir.
+# The shim's preflight (postgres -C) is skipped here because the test
+# sandbox does not have a postgres binary. We test that path separately.
+run_shim_with_mem_mb() {
+    local mem_mb="$1"
+    local sandbox="$2"
+    local clean_sandbox="${3:-true}"
+
+    if [ "$clean_sandbox" = "true" ]; then
+        rm -rf "$sandbox"
+    fi
+    mkdir -p "$sandbox"
+    if [ ! -f "$sandbox/postgresql.conf" ]; then
+        echo "# stub postgresql.conf for tests" > "$sandbox/postgresql.conf"
+    fi
+
+    POSTGRES_AUTO_TUNE_FORCE_MEM_MB="$mem_mb" \
+        bash "$SHIM" "$sandbox" >"$sandbox/.run.log" 2>&1
+    return $?
+}
+
+run_test_tier() {
+    local mem_mb="$1" tier_name="$2"
+    local sb_want="$3" wm_want="$4" mwm_want="$5" ecs_want="$6" wb_want="$7" maxwal_want="$8" minwal_want="$9"
+
+    local sbx="${SBX_BASE}/${tier_name}-${mem_mb}"
+    echo "Test tier ${tier_name} at ${mem_mb} MB"
+    run_shim_with_mem_mb "$mem_mb" "$sbx"
+
+    local conf="${sbx}/conf.d/00-audiusd-defaults.conf"
+    assert_file_present "$conf" "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "shared_buffers"        "$sb_want"      "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "work_mem"              "$wm_want"      "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "maintenance_work_mem"  "$mwm_want"     "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "effective_cache_size"  "$ecs_want"     "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "wal_buffers"           "$wb_want"      "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "max_wal_size"          "$maxwal_want"  "tier-${tier_name}-${mem_mb}"
+    assert_value "$conf" "min_wal_size"          "$minwal_want"  "tier-${tier_name}-${mem_mb}"
+}
+
+# Mid-range tier checks
+#                  mem_mb  tier_name      sb     wm   mwm    ecs   wb   maxwal minwal
+run_test_tier      3000    "mid-2-4GB"   256MB   4MB  128MB  1GB   8MB  1GB    256MB
+run_test_tier      6144    "mid-4-8GB"   1GB     8MB  256MB  3GB   16MB 2GB    512MB
+run_test_tier      12288   "mid-8-16GB"  2GB    16MB  512MB  6GB   16MB 2GB    1GB
+run_test_tier      24576   "mid-16-32GB" 4GB    32MB  1GB    12GB  16MB 4GB    1GB
+run_test_tier      49152   "mid-32-64GB" 8GB    32MB  2GB    24GB  16MB 8GB    2GB
+run_test_tier      131072  "mid-64GB+"   16GB   32MB  2GB    48GB  16MB 16GB   2GB
+
+# Boundary checks: each tier's lower bound, and the value just below it.
+# A fencepost regression (-le instead of -lt) would flip these.
+run_test_tier      2048    "boundary-2-4GB-lo"   256MB   4MB  128MB  1GB   8MB  1GB    256MB
+run_test_tier      4095    "boundary-2-4GB-hi"   256MB   4MB  128MB  1GB   8MB  1GB    256MB
+run_test_tier      4096    "boundary-4-8GB-lo"   1GB     8MB  256MB  3GB   16MB 2GB    512MB
+run_test_tier      8191    "boundary-4-8GB-hi"   1GB     8MB  256MB  3GB   16MB 2GB    512MB
+run_test_tier      8192    "boundary-8-16GB-lo"  2GB    16MB  512MB  6GB   16MB 2GB    1GB
+run_test_tier      16383   "boundary-8-16GB-hi"  2GB    16MB  512MB  6GB   16MB 2GB    1GB
+run_test_tier      16384   "boundary-16-32GB-lo" 4GB    32MB  1GB    12GB  16MB 4GB    1GB
+run_test_tier      32767   "boundary-16-32GB-hi" 4GB    32MB  1GB    12GB  16MB 4GB    1GB
+run_test_tier      32768   "boundary-32-64GB-lo" 8GB    32MB  2GB    24GB  16MB 8GB    2GB
+run_test_tier      65535   "boundary-32-64GB-hi" 8GB    32MB  2GB    24GB  16MB 8GB    2GB
+run_test_tier      65536   "boundary-64GB+-lo"   16GB   32MB  2GB    48GB  16MB 16GB   2GB
+
+# Below floor: under 2 GB should leave NO conf file.
+echo "Test sub-tier-floor"
+sbx="${SBX_BASE}/below-floor-2047"
+run_shim_with_mem_mb 2047 "$sbx"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "below-floor-2047"
+assert_log_contains "${sbx}/.run.log" "below 2 GB tier floor" "below-floor-log"
+
+echo "Test sub-tier-floor at exactly 1024"
+sbx="${SBX_BASE}/below-floor-1024"
+run_shim_with_mem_mb 1024 "$sbx"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "below-floor-1024"
+
+# Idempotency: include_dir line appears exactly once across re-runs.
+echo "Test include_dir append idempotency"
+sbx="${SBX_BASE}/idempotent"
+run_shim_with_mem_mb 24576 "$sbx"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+n=$(count_lines "${sbx}/postgresql.conf" "^include_dir = 'conf.d'")
+if [ "$n" = "1" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: idempotent: include_dir count = 1"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: idempotent: include_dir count = ${n} (want 1)"
+fi
+
+# Disable: AUDIUSD_DISABLE_AUTO_TUNE=1 short-circuits before any write.
+echo "Test AUDIUSD_DISABLE_AUTO_TUNE=1"
+sbx="${SBX_BASE}/disabled-1"
+mkdir -p "$sbx"
+echo "# stub" > "$sbx/postgresql.conf"
+AUDIUSD_DISABLE_AUTO_TUNE=1 POSTGRES_AUTO_TUNE_FORCE_MEM_MB=24576 \
+    bash "$SHIM" "$sbx" >"$sbx/.run.log" 2>&1
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "disabled-1"
+assert_log_contains "${sbx}/.run.log" "AUDIUSD_DISABLE_AUTO_TUNE set" "disabled-1-log"
+
+# Disable: any value other than "1" must NOT disable. The shim's
+# canonical disable value is "1". An older draft accepted "true" too;
+# we tightened that. This test pins the canonical form.
+echo "Test AUDIUSD_DISABLE_AUTO_TUNE=true is NOT honored (=1 only)"
+sbx="${SBX_BASE}/disabled-true"
+mkdir -p "$sbx"
+echo "# stub" > "$sbx/postgresql.conf"
+AUDIUSD_DISABLE_AUTO_TUNE=true POSTGRES_AUTO_TUNE_FORCE_MEM_MB=24576 \
+    bash "$SHIM" "$sbx" >"$sbx/.run.log" 2>&1
+assert_file_present "${sbx}/conf.d/00-audiusd-defaults.conf" "disabled-true-rejected"
+
+echo "Test AUDIUSD_DISABLE_AUTO_TUNE=0 does not disable"
+sbx="${SBX_BASE}/disabled-0"
+mkdir -p "$sbx"
+echo "# stub" > "$sbx/postgresql.conf"
+AUDIUSD_DISABLE_AUTO_TUNE=0 POSTGRES_AUTO_TUNE_FORCE_MEM_MB=24576 \
+    bash "$SHIM" "$sbx" >"$sbx/.run.log" 2>&1
+assert_file_present "${sbx}/conf.d/00-audiusd-defaults.conf" "disabled-0-rejected"
+
+# Missing data dir: shim exits 0 cleanly.
+echo "Test missing data dir"
+if POSTGRES_AUTO_TUNE_FORCE_MEM_MB=24576 bash "$SHIM" "${SBX_BASE}/does-not-exist" >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  PASS: missing-data-dir: exit 0"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: missing-data-dir: non-zero exit"
+fi
+
+# Operator override: 99-*.conf is preserved across re-runs.
+echo "Test operator 99-*.conf preserved across re-runs"
+sbx="${SBX_BASE}/operator-99-conf"
+run_shim_with_mem_mb 24576 "$sbx"
+echo "shared_buffers = 8GB # operator override" > "$sbx/conf.d/99-operator.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+if grep -q "8GB # operator override" "$sbx/conf.d/99-operator.conf" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: operator-99-conf: preserved"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: operator-99-conf: modified or missing"
+fi
+
+# Operator-tuning detection: if postgresql.conf has any of the tuned
+# params set, the shim must skip without writing conf.d.
+echo "Test operator-tuned shared_buffers in postgresql.conf -> skip"
+sbx="${SBX_BASE}/operator-tuned-sb"
+mkdir -p "$sbx"
+{
+    echo "# operator postgresql.conf"
+    echo "shared_buffers = 8GB"
+} > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "operator-tuned-sb"
+assert_log_contains "${sbx}/.run.log" "operator-tuned shared_buffers" "operator-tuned-sb-log"
+
+echo "Test operator-tuned work_mem in postgresql.conf -> skip"
+sbx="${SBX_BASE}/operator-tuned-wm"
+mkdir -p "$sbx"
+{
+    echo "work_mem = 64MB"
+} > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "operator-tuned-wm"
+
+echo "Test commented-out tuning in postgresql.conf does NOT trigger skip"
+sbx="${SBX_BASE}/commented-tuning"
+mkdir -p "$sbx"
+{
+    echo "# shared_buffers = 8GB"
+    echo "#work_mem = 64MB"
+} > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_present "${sbx}/conf.d/00-audiusd-defaults.conf" "commented-tuning-not-skipped"
+
+# Foreign include_dir detection: any include_dir that is not 'conf.d'
+# (active or commented) makes the shim skip without appending.
+echo "Test foreign include_dir (different directory) -> skip"
+sbx="${SBX_BASE}/foreign-include"
+mkdir -p "$sbx"
+{
+    echo "# operator postgresql.conf"
+    echo "include_dir = 'my-conf.d'"
+} > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "foreign-include-skip"
+assert_log_contains "${sbx}/.run.log" "non-conf.d include_dir" "foreign-include-log"
+
+echo "Test double-quoted include_dir = \"conf.d\" -> skip (different syntax, treat as foreign)"
+sbx="${SBX_BASE}/dquoted-include"
+mkdir -p "$sbx"
+echo 'include_dir = "conf.d"' > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "dquoted-include-skip"
+
+echo "Test commented include_dir -> skip (operator deliberately disabled)"
+sbx="${SBX_BASE}/commented-include"
+mkdir -p "$sbx"
+echo "# include_dir = 'conf.d'" > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_absent "${sbx}/conf.d/00-audiusd-defaults.conf" "commented-include-skip"
+
+echo "Test our own include_dir = 'conf.d' is recognized -> append skipped, conf still rendered on next run"
+sbx="${SBX_BASE}/our-include-already-present"
+mkdir -p "$sbx"
+{
+    echo "# stub"
+    echo "include_dir = 'conf.d'"
+} > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+assert_file_present "${sbx}/conf.d/00-audiusd-defaults.conf" "our-include-already-present"
+n=$(count_lines "${sbx}/postgresql.conf" "^include_dir = 'conf.d'")
+if [ "$n" = "1" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: our-include-no-duplicate: include_dir count = 1"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: our-include-no-duplicate: include_dir count = ${n} (want 1)"
+fi
+
+# Atomic include_dir append: postgresql.conf must be well-formed after
+# the shim runs (no torn writes, no partial directives). We verify by
+# reading the file and confirming it ends with a complete include_dir
+# directive (or has one somewhere, with no truncated lines).
+echo "Test postgresql.conf is well-formed after include_dir append"
+sbx="${SBX_BASE}/well-formed"
+mkdir -p "$sbx"
+{
+    echo "# original conf line 1"
+    echo "# original conf line 2"
+} > "$sbx/postgresql.conf"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+if grep -q "^include_dir = 'conf.d'$" "$sbx/postgresql.conf"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: well-formed: include_dir line is complete"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: well-formed: include_dir line missing or malformed"
+fi
+if grep -q "^# original conf line 1$" "$sbx/postgresql.conf"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: well-formed: original content preserved"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: well-formed: original content lost"
+fi
+
+# Orphan tmp cleanup: a stale temp file from a prior interrupted run
+# must be cleaned up on next start.
+echo "Test orphan tmp file cleanup"
+sbx="${SBX_BASE}/orphan-cleanup"
+mkdir -p "$sbx/conf.d"
+echo "# stub" > "$sbx/postgresql.conf"
+echo "stale" > "$sbx/conf.d/.00-audiusd-defaults.conf.STALE1"
+echo "stale" > "$sbx/conf.d/00-audiusd-defaults.conf.tmp.99999"
+run_shim_with_mem_mb 24576 "$sbx" "false"
+if [ ! -f "$sbx/conf.d/.00-audiusd-defaults.conf.STALE1" ] && [ ! -f "$sbx/conf.d/00-audiusd-defaults.conf.tmp.99999" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: orphan-cleanup: stale temp files removed"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: orphan-cleanup: stale temp files still present"
+fi
+
+# Confirm the shim's logged tier matches expectation for a known input.
+echo "Test logged tier line"
+sbx="${SBX_BASE}/log-line"
+run_shim_with_mem_mb 24576 "$sbx"
+assert_log_contains "${sbx}/.run.log" "applied tier 16-32GB" "log-line-tier"
+assert_log_contains "${sbx}/.run.log" "shared_buffers=4GB" "log-line-sb"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" = "0" ] || exit 1


### PR DESCRIPTION
## Summary

The audiusd container ships stock Debian Postgres 15 defaults (`shared_buffers = 128MB`, `work_mem = 4MB`, `effective_cache_size = 4GB`), sized for a tiny dev VM rather than a validator host. This adds an entrypoint shim that picks a memory and WAL tier from detected host RAM and writes one drop-in conf file at container start.

Suggesting, not requiring. Happy to scope down or close. We're running an equivalent tuning on our 20-node fleet and it's helped meaningfully, so wanted to put it in front of the team.

## Tier table

| Host RAM | shared_buffers | work_mem | maint_work_mem | effective_cache_size | wal_buffers | max_wal_size | min_wal_size |
|---|---|---|---|---|---|---|---|
| < 2 GB | (skip, stock defaults) | | | | | | |
| 2 to 4 GB | 256 MB | 4 MB | 128 MB | 1 GB | 8 MB | 1 GB | 256 MB |
| 4 to 8 GB | 1 GB | 8 MB | 256 MB | 3 GB | 16 MB | 2 GB | 512 MB |
| 8 to 16 GB | 2 GB | 16 MB | 512 MB | 6 GB | 16 MB | 2 GB | 1 GB |
| 16 to 32 GB | 4 GB | 32 MB | 1 GB | 12 GB | 16 MB | 4 GB | 1 GB |
| 32 to 64 GB | 8 GB | 32 MB | 2 GB | 24 GB | 16 MB | 8 GB | 2 GB |
| 64 GB and up | 16 GB | 32 MB | 2 GB | 48 GB | 16 MB | 16 GB | 2 GB |

Sizing rules: `shared_buffers` near 25% of RAM (capped to leave headroom for the audiusd Go process, observed at roughly 7 GB RSS on a busy validator). `effective_cache_size` near 50% (more conservative than pgtune's 75% since Postgres is not the only tenant in this container). `wal_buffers` capped at 16 MB per the [Postgres docs](https://www.postgresql.org/docs/15/runtime-config-wal.html). `work_mem` modest because audiusd's observed concurrency is roughly 8 connections, not 100.

## Conservative-by-default behavior

The shim skips with stock defaults whenever it cannot prove safety:

1. **Operator already tuned `postgresql.conf`.** If `shared_buffers`, `work_mem`, `maintenance_work_mem`, `effective_cache_size`, `wal_buffers`, `max_wal_size`, or `min_wal_size` is set uncommented in `postgresql.conf`, the shim skips with a log line. Operator wins.
2. **Operator already has an `include_dir` directive.** Any `include_dir` line (active, commented out, or pointing at a different directory or using different quoting) makes the shim skip rather than risk last-occurrence-wins overriding the operator's directory.
3. **Non-root execution context.** If the shim runs as a uid that is not root and not the postgres user, it skips. The chown step would otherwise silently fail and leave a conf file postgres cannot read.
4. **Postgres rejects the rendered conf.** A `postgres -C shared_buffers --config-file=...` preflight runs after rendering. If Postgres refuses to parse the conf, the shim removes the rendered file and exits.
5. **Any I/O failure.** Every error path exits 0 and leaves stock defaults in place.

## Override knobs

```bash
# Disable entirely
docker run -e AUDIUSD_DISABLE_AUTO_TUNE=1 ...

# Per-setting override (later wins by include order within conf.d)
echo "shared_buffers = 8GB" > $DATA/conf.d/99-operator.conf

# Or via SQL after connect (postgresql.auto.conf is processed last)
ALTER SYSTEM SET shared_buffers = '8GB';
```

Precedence (later wins):

1. `postgresql.conf` top-of-file
2. `conf.d/00-audiusd-defaults.conf` (this shim, written conditional on the conservative checks above)
3. `conf.d/99-*.conf` (operator override slot)
4. `postgresql.auto.conf` (`ALTER SYSTEM`, processed last by Postgres regardless of position)

## Evidence: controlled before/after on one of our nodes

Same node (24 GB host, 144 GB DB, 38 GB indexes), 20-min steady-state windows on each side, reset stats between. Only `shared_buffers`, `wal_buffers`, `max_wal_size`, and `min_wal_size` were changed (the restart-required group). The other tier values were already in place via `ALTER SYSTEM` on that node.

| Metric | Before: stock 128 MB `shared_buffers` | After: 4 GB `shared_buffers` (16-32 GB tier) |
|---|---:|---:|
| `pg_stat_bgwriter.buffers_alloc` rate | **23,068 / sec** | **65 / sec** (-99.7%) |
| `pg_stat_bgwriter.buffers_backend` (window) | 1,247,356 | 11,591 (-99.1%) |
| `pg_stat_bgwriter.buffers_checkpoint` (window) | 91 | 35,169 (planned writes replace emergency backend writes) |
| Buffer hit ratio | 10.97% (depressed by cold EXPLAINs in the window) | 83.05% |

The shape of buffer accounting changed. Before: backends doing emergency dirty-page writes (1.25M of them) because `shared_buffers` was exhausted. After: the checkpointer does planned batched writes on schedule (35k). The 99% drop in `buffers_backend` is the strongest signal that `shared_buffers` was undersized.

Representative heavy query, `SELECT count(*) FROM ops WHERE "table" = 'uploads'` (full table scan over a 50 GB table):

| Metric | Before | After |
|---:|---:|---:|
| Execution time | 52,481 ms | 41,034 ms (-22%) |
| Buffers dirtied during the query | 1,180,495 | 5,623 (-99.5%) |
| Buffers written during the query | 1,180,370 | 5,474 (-99.5%) |
| Buffers read from disk | 6,300,680 | 6,304,652 (unchanged; table doesn't fit in 4 GB either) |

Light queries (e.g. `SELECT * FROM core_blocks ORDER BY created_at DESC LIMIT 100`) went from 9 to 14 disk reads down to **0**. Index pages stay resident in the bigger pool. Sub-ms either way, but the disk-read count delta is the durable signal.

Restart cost: roughly 3 seconds Postgres unavailability. The audiusd Go process kept running and reconnected; no application errors observed.

Reproduce on any node:
```sql
SELECT pg_stat_reset_shared('bgwriter'); SELECT pg_stat_reset();
-- wait 20 min steady-state, capture:
SELECT round(100.0 * blks_hit / (blks_hit + blks_read), 2) AS hit_ratio_pct
  FROM pg_stat_database WHERE datname = 'openaudio';
SELECT buffers_alloc, buffers_backend, checkpoints_req
  FROM pg_stat_bgwriter;
```

## Determinism and consensus safety

A tuning that changes plan choice (`work_mem`, `effective_cache_size`) could in principle affect consensus state if any state-applied query relied on default plan ordering. We audited the currently visible ORDER-sensitive paths:

- All `:many ... LIMIT` queries in `pkg/core/db/sql/reads.sql` have explicit `ORDER BY`.
- `:one ... LIMIT 1` queries WHERE on a unique column.
- Unordered queries (`GetAllRegisteredNodes`, `GetAllEthAddressesOfRegisteredNodes`, `GetActiveStorageNodeEndpoints`) feed only `common.GetAttestorRendezvous`, which sorts internally by hash. The output is order-independent.
- The CRDT `ops` sweep is `Order("ulid asc")` server-side (`pkg/mediorum/server/serve_crud.go:33`).

We did not find a path where a plan flip could change consensus state. This is an audit, not an executable guard. Adding a deterministic-order assertion test would harden this further; happy to do that if it would help review.

## Caveats for operators

1. **`shared_buffers` is restart-required.** On image upgrade, `docker compose up -d` recreates the container and Postgres starts with the new value. On hosts with very tight free RAM at upgrade time, the larger allocation may cause Postgres start to fail. Workaround: set `AUDIUSD_DISABLE_AUTO_TUNE=1` before upgrading, or override via `conf.d/99-*.conf`.
2. **`/dev/shm` size on big tiers.** Postgres 15's parallel workers use `/dev/shm` for dynamic shared memory. Docker defaults `/dev/shm` to 64 MB. On the 64 GB and up tier (16 GB `shared_buffers`), parallel queries with many workers can hit `could not resize shared memory segment`. Operators on big hosts should pass `--shm-size=2g` or larger.
3. **Non-root container runtimes.** k8s `securityContext.runAsUser`, rootless docker, or podman with `--user` make the in-container `chown postgres:postgres` no-op. The shim detects this and skips. Operators in those modes will see stock defaults, which is the existing behavior.

## Out of scope

`random_page_cost`, `effective_io_concurrency` (assume SSD), `synchronous_commit`, `wal_compression`, `checkpoint_*`, `max_connections`. Memory and WAL sizing only.

## Test plan

- [x] `bash cmd/openaudio/postgres-auto-tune_test.sh`, 161 assertions covering: every tier at midpoint and at both boundary edges (one inside the tier, one just below it); sub-floor; idempotency across re-runs; `AUDIUSD_DISABLE_AUTO_TUNE=1` short-circuit; `=true` and `=0` correctly NOT honored (canonical form is `=1`); operator-tuned `postgresql.conf` skip; commented-tuning does NOT trigger skip; foreign `include_dir` skip (alternate dir, double-quoted, commented); existing `include_dir = 'conf.d'` recognized as ours; well-formed `postgresql.conf` after atomic append; orphan tmp file cleanup; tier log line. Lint-clean (shellcheck).
- [ ] CI builds the image
- [ ] Fresh-init container, Postgres starts with shim-applied defaults
- [ ] Existing-data-dir, `include_dir = 'conf.d'` appended once via atomic temp+rename, drop-in renders, restart picks up new `shared_buffers`
- [ ] `AUDIUSD_DISABLE_AUTO_TUNE=1`, no `conf.d` directory, stock defaults
- [ ] `docker run -m 1G` (cgroup-limited container), shim detects via cgroup, sub-2GB skip, stock defaults
- [ ] Pre-existing `postgresql.conf` with hand-tuned `shared_buffers`, shim detects and skips with log line