### PR TITLE
fix(.gitignore): anchor openaudio to repo root, not any path segment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ node_modules/
 package-lock.json
 **/package-lock.json
 
-openaudio
+/openaudio
 programmable-distribution
 /etl


### PR DESCRIPTION
## Summary

The bare pattern `openaudio` on line 20 of `.gitignore` matches any path component named `openaudio`, which includes the source directory `cmd/openaudio/`. New files added under `cmd/openaudio/` are silently ignored, requiring `git add -f` to stage; on git 2.50+, even already-tracked files in that directory cannot be re-staged without `-f` because git refuses to recurse into an ignored directory by default.

The line's intent is to ignore the local `go build .` output at the repository root (a ~224 MB binary on disk). Anchoring with a leading slash matches only the root file and lets new files inside `cmd/openaudio/` be staged normally.

## Verification

```bash
# After the fix:
$ git check-ignore -v openaudio
.gitignore:20:/openaudio  openaudio          # root binary still ignored

$ git check-ignore -v cmd/openaudio/anything
# (no match -- previously: .gitignore:20:openaudio  cmd/openaudio/anything)
```

`bin/openaudio-*-linux` build outputs are already ignored by the earlier `bin/*` rule on line 4, so this change does not affect them.

## Scope

One-line, defensive. The sibling pattern `programmable-distribution` on line 21 has the same shape (matches `examples/programmable-distribution/` source dir as well as any root binary), but no current root binary exists with that name and bundling it would broaden the diff. Happy to anchor it in a follow-up if useful.

## Test plan

- [x] `git check-ignore -v` confirms the root binary is still ignored and `cmd/openaudio/` paths are no longer matched
- [x] `git status` from a clean checkout still ignores the local `./openaudio` build artifact