### PR TITLE
Add reward_pools schema and migrate core_rewards

### DIFF
--- a/pkg/core/db/models.go
+++ b/pkg/core/db/models.go
@@ -247,19 +247,26 @@ type CoreResource struct {
 }
 
 type CoreReward struct {
-	ID               int64
-	Address          string
-	Index            int64
-	TxHash           string
-	Sender           string
-	RewardID         string
-	Name             string
-	Amount           int64
-	ClaimAuthorities []string
-	RawMessage       []byte
-	BlockHeight      int64
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	RawMessage           []byte
+	BlockHeight          int64
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	RewardsManagerPubkey pgtype.Text
+}
+
+type CoreRewardPool struct {
+	RewardsManagerPubkey string
+	Authorities          []string
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 type CoreTransaction struct {
@@ -303,6 +310,12 @@ type CoreValidator struct {
 	SpID         string
 	CometPubKey  string
 	Jailed       bool
+}
+
+type LaunchpadAuthorityRm struct {
+	Authority            string
+	RewardsManagerPubkey string
+	CreatedAt            pgtype.Timestamptz
 }
 
 type ManagementKey struct {

--- a/pkg/core/db/reads.sql.go
+++ b/pkg/core/db/reads.sql.go
@@ -1487,6 +1487,7 @@ const getLaunchpadRMByAuthority = `-- name: GetLaunchpadRMByAuthority :one
 select rewards_manager_pubkey
 from launchpad_authority_rm
 where authority = any($1::text[])
+order by rewards_manager_pubkey, authority
 limit 1
 `
 

--- a/pkg/core/db/reads.sql.go
+++ b/pkg/core/db/reads.sql.go
@@ -12,20 +12,41 @@ import (
 )
 
 const getActiveRewards = `-- name: GetActiveRewards :many
-select id, address, index, tx_hash, sender, reward_id, name, amount, claim_authorities, raw_message, block_height, created_at, updated_at
-from core_rewards
-order by address
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+order by r.address
 `
 
-func (q *Queries) GetActiveRewards(ctx context.Context) ([]CoreReward, error) {
+type GetActiveRewardsRow struct {
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	ClaimAuthorities     []string
+	RawMessage           []byte
+	BlockHeight          int64
+	RewardsManagerPubkey pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+func (q *Queries) GetActiveRewards(ctx context.Context) ([]GetActiveRewardsRow, error) {
 	rows, err := q.db.Query(ctx, getActiveRewards)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []CoreReward
+	var items []GetActiveRewardsRow
 	for rows.Next() {
-		var i CoreReward
+		var i GetActiveRewardsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Address,
@@ -38,6 +59,7 @@ func (q *Queries) GetActiveRewards(ctx context.Context) ([]CoreReward, error) {
 			&i.ClaimAuthorities,
 			&i.RawMessage,
 			&i.BlockHeight,
+			&i.RewardsManagerPubkey,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -215,23 +237,41 @@ func (q *Queries) GetAllRegisteredNodesSorted(ctx context.Context) ([]CoreValida
 }
 
 const getAllRewards = `-- name: GetAllRewards :many
-select id, address, index, tx_hash, sender, reward_id, name, amount, claim_authorities, raw_message, block_height, created_at, updated_at from core_rewards
-where address in (
-    select distinct address
-    from core_rewards
-)
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+order by r.block_height desc
 `
 
-func (q *Queries) GetAllRewards(ctx context.Context) ([]CoreReward, error) {
+type GetAllRewardsRow struct {
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	ClaimAuthorities     []string
+	RawMessage           []byte
+	BlockHeight          int64
+	RewardsManagerPubkey pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+func (q *Queries) GetAllRewards(ctx context.Context) ([]GetAllRewardsRow, error) {
 	rows, err := q.db.Query(ctx, getAllRewards)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []CoreReward
+	var items []GetAllRewardsRow
 	for rows.Next() {
-		var i CoreReward
+		var i GetAllRewardsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Address,
@@ -244,6 +284,7 @@ func (q *Queries) GetAllRewards(ctx context.Context) ([]CoreReward, error) {
 			&i.ClaimAuthorities,
 			&i.RawMessage,
 			&i.BlockHeight,
+			&i.RewardsManagerPubkey,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -1442,6 +1483,29 @@ func (q *Queries) GetLatestSlaRollup(ctx context.Context) (SlaRollup, error) {
 	return i, err
 }
 
+const getLaunchpadRMByAuthority = `-- name: GetLaunchpadRMByAuthority :one
+select rewards_manager_pubkey
+from launchpad_authority_rm
+where authority = any($1::text[])
+limit 1
+`
+
+// Resolves a launchpad-derived per-mint claim authority (lowercased eth
+// hex) to the Solana reward manager state account that mint's rewards
+// live under. Used by PR2's wire-compat layer at block-sync replay time:
+// when finalizeLegacyCreateReward sees an inline claim_authorities array,
+// it looks up the RM from any one of its lowercased entries and routes
+// the reward into a pool keyed by that RM — matching exactly what PR1's
+// backfill produced for pre-migration rows. Returns ErrNoRows if none of
+// the requested authorities is in the launchpad mapping (e.g., AUDIO
+// rewards or test fixtures).
+func (q *Queries) GetLaunchpadRMByAuthority(ctx context.Context, dollar_1 []string) (string, error) {
+	row := q.db.QueryRow(ctx, getLaunchpadRMByAuthority, dollar_1)
+	var rewards_manager_pubkey string
+	err := row.Scan(&rewards_manager_pubkey)
+	return rewards_manager_pubkey, err
+}
+
 const getMEAD = `-- name: GetMEAD :one
 select id, address, tx_hash, index, sender, resource_addresses, release_addresses, raw_message, raw_acknowledgment, block_height from core_mead where address = $1 order by block_height desc limit 1
 `
@@ -2017,15 +2081,37 @@ func (q *Queries) GetRegisteredNodesByType(ctx context.Context, nodeType string)
 }
 
 const getReward = `-- name: GetReward :one
-select id, address, index, tx_hash, sender, reward_id, name, amount, claim_authorities, raw_message, block_height, created_at, updated_at from core_rewards
-where address = $1
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where r.address = $1
+order by r.block_height desc
 limit 1
 `
 
-func (q *Queries) GetReward(ctx context.Context, address string) (CoreReward, error) {
+type GetRewardRow struct {
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	ClaimAuthorities     []string
+	RawMessage           []byte
+	BlockHeight          int64
+	RewardsManagerPubkey pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+func (q *Queries) GetReward(ctx context.Context, address string) (GetRewardRow, error) {
 	row := q.db.QueryRow(ctx, getReward, address)
-	var i CoreReward
+	var i GetRewardRow
 	err := row.Scan(
 		&i.ID,
 		&i.Address,
@@ -2038,6 +2124,7 @@ func (q *Queries) GetReward(ctx context.Context, address string) (CoreReward, er
 		&i.ClaimAuthorities,
 		&i.RawMessage,
 		&i.BlockHeight,
+		&i.RewardsManagerPubkey,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -2045,15 +2132,37 @@ func (q *Queries) GetReward(ctx context.Context, address string) (CoreReward, er
 }
 
 const getRewardByID = `-- name: GetRewardByID :one
-select id, address, index, tx_hash, sender, reward_id, name, amount, claim_authorities, raw_message, block_height, created_at, updated_at from core_rewards
-where reward_id = $1
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where r.reward_id = $1
+order by r.block_height desc
 limit 1
 `
 
-func (q *Queries) GetRewardByID(ctx context.Context, rewardID string) (CoreReward, error) {
+type GetRewardByIDRow struct {
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	ClaimAuthorities     []string
+	RawMessage           []byte
+	BlockHeight          int64
+	RewardsManagerPubkey pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+func (q *Queries) GetRewardByID(ctx context.Context, rewardID string) (GetRewardByIDRow, error) {
 	row := q.db.QueryRow(ctx, getRewardByID, rewardID)
-	var i CoreReward
+	var i GetRewardByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.Address,
@@ -2066,6 +2175,7 @@ func (q *Queries) GetRewardByID(ctx context.Context, rewardID string) (CoreRewar
 		&i.ClaimAuthorities,
 		&i.RawMessage,
 		&i.BlockHeight,
+		&i.RewardsManagerPubkey,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -2073,15 +2183,37 @@ func (q *Queries) GetRewardByID(ctx context.Context, rewardID string) (CoreRewar
 }
 
 const getRewardByTxHash = `-- name: GetRewardByTxHash :one
-select id, address, index, tx_hash, sender, reward_id, name, amount, claim_authorities, raw_message, block_height, created_at, updated_at from core_rewards
-where tx_hash = $1
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where r.tx_hash = $1
+order by r.block_height desc
 limit 1
 `
 
-func (q *Queries) GetRewardByTxHash(ctx context.Context, txHash string) (CoreReward, error) {
+type GetRewardByTxHashRow struct {
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	ClaimAuthorities     []string
+	RawMessage           []byte
+	BlockHeight          int64
+	RewardsManagerPubkey pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+func (q *Queries) GetRewardByTxHash(ctx context.Context, txHash string) (GetRewardByTxHashRow, error) {
 	row := q.db.QueryRow(ctx, getRewardByTxHash, txHash)
-	var i CoreReward
+	var i GetRewardByTxHashRow
 	err := row.Scan(
 		&i.ID,
 		&i.Address,
@@ -2094,28 +2226,103 @@ func (q *Queries) GetRewardByTxHash(ctx context.Context, txHash string) (CoreRew
 		&i.ClaimAuthorities,
 		&i.RawMessage,
 		&i.BlockHeight,
+		&i.RewardsManagerPubkey,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
 	return i, err
 }
 
-const getRewardsByClaimAuthority = `-- name: GetRewardsByClaimAuthority :many
-select id, address, index, tx_hash, sender, reward_id, name, amount, claim_authorities, raw_message, block_height, created_at, updated_at
-from core_rewards
-where $1::text = any(claim_authorities)
-order by address
+const getRewardPool = `-- name: GetRewardPool :one
+select rewards_manager_pubkey, authorities, created_at, updated_at
+from core_reward_pools
+where rewards_manager_pubkey = $1
 `
 
-func (q *Queries) GetRewardsByClaimAuthority(ctx context.Context, dollar_1 string) ([]CoreReward, error) {
+func (q *Queries) GetRewardPool(ctx context.Context, rewardsManagerPubkey string) (CoreRewardPool, error) {
+	row := q.db.QueryRow(ctx, getRewardPool, rewardsManagerPubkey)
+	var i CoreRewardPool
+	err := row.Scan(
+		&i.RewardsManagerPubkey,
+		&i.Authorities,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getRewardPoolsByAuthority = `-- name: GetRewardPoolsByAuthority :many
+select rewards_manager_pubkey, authorities, created_at, updated_at
+from core_reward_pools
+where authorities @> array[$1::text]
+order by rewards_manager_pubkey
+`
+
+// Uses array containment (@>) so the gin index on authorities is used.
+func (q *Queries) GetRewardPoolsByAuthority(ctx context.Context, dollar_1 string) ([]CoreRewardPool, error) {
+	rows, err := q.db.Query(ctx, getRewardPoolsByAuthority, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CoreRewardPool
+	for rows.Next() {
+		var i CoreRewardPool
+		if err := rows.Scan(
+			&i.RewardsManagerPubkey,
+			&i.Authorities,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getRewardsByClaimAuthority = `-- name: GetRewardsByClaimAuthority :many
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where p.authorities @> array[$1::text]
+order by r.address
+`
+
+type GetRewardsByClaimAuthorityRow struct {
+	ID                   int64
+	Address              string
+	Index                int64
+	TxHash               string
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	ClaimAuthorities     []string
+	RawMessage           []byte
+	BlockHeight          int64
+	RewardsManagerPubkey pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+// Uses array containment (@>) so the gin index on core_reward_pools.authorities
+// can be used. = ANY(...) cannot leverage the gin opclass.
+func (q *Queries) GetRewardsByClaimAuthority(ctx context.Context, dollar_1 string) ([]GetRewardsByClaimAuthorityRow, error) {
 	rows, err := q.db.Query(ctx, getRewardsByClaimAuthority, dollar_1)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []CoreReward
+	var items []GetRewardsByClaimAuthorityRow
 	for rows.Next() {
-		var i CoreReward
+		var i GetRewardsByClaimAuthorityRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Address,
@@ -2128,6 +2335,7 @@ func (q *Queries) GetRewardsByClaimAuthority(ctx context.Context, dollar_1 strin
 			&i.ClaimAuthorities,
 			&i.RawMessage,
 			&i.BlockHeight,
+			&i.RewardsManagerPubkey,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/pkg/core/db/sql/migrations/00033_reward_pools.sql
+++ b/pkg/core/db/sql/migrations/00033_reward_pools.sql
@@ -197,54 +197,13 @@ from (
 ) mapped
 where r.address = mapped.reward_address;
 
--- Backfill step 3: for rewards whose claim_authorities don't include any
--- launchpad-mapped per-mint key, create a synthetic mig_<md5> pool keyed
--- deterministically by the canonical (trim/lower/dedup/sort) authority
--- set. mig_<md5> identifiers fail base58 decoding, so PR3's per-RM
--- sender-attestation gate naturally ignores them; they exist so legacy
--- claim/delete authorization (which iterates the row's claim_authorities
--- via the LEFT JOIN coalesce(p.authorities, '{}') on reads) keeps
--- working for unmapped rewards. Live finalizeCreateReward uses the
--- identical mig_<md5> scheme, so the migration and live paths agree on
--- synthetic pool keys.
-insert into core_reward_pools (rewards_manager_pubkey, authorities)
-select distinct
-    'mig_' || md5(array_to_string(canon, ',')) as rewards_manager_pubkey,
-    canon as authorities
-from (
-    select
-        array(
-            select distinct lower(trim(a))
-            from unnest(r.claim_authorities) as a
-            where a is not null and trim(a) <> ''
-            order by 1
-        ) as canon
-    from core_rewards r
-    where r.claim_authorities is not null
-      and array_length(r.claim_authorities, 1) > 0
-      and r.rewards_manager_pubkey is null
-) sets
-where array_length(sets.canon, 1) > 0
-on conflict (rewards_manager_pubkey) do update set
-    authorities = excluded.authorities,
-    updated_at = now();
-
--- Backfill step 4: point each unmapped core_rewards row at its synthetic
--- pool. After this, every core_rewards row with non-empty
--- claim_authorities has a non-NULL rewards_manager_pubkey.
-update core_rewards r
-set rewards_manager_pubkey = 'mig_' || md5(array_to_string(
-    array(
-        select distinct lower(trim(a))
-        from unnest(r.claim_authorities) as a
-        where a is not null and trim(a) <> ''
-        order by 1
-    ),
-    ','
-))
-where r.claim_authorities is not null
-  and array_length(r.claim_authorities, 1) > 0
-  and r.rewards_manager_pubkey is null;
+-- Rows whose claim_authorities don't include any launchpad-mapped per-mint
+-- key are intentionally left with NULL rewards_manager_pubkey and have no
+-- pool. The launchpad_authority_rm seed above is the complete set of RM
+-- init events; rows that don't match are stale fixture data, never live
+-- production rewards. Such rewards are unclaimable post-migration; their
+-- claim authority recovers by submitting CreateRewardPool + a fresh
+-- CreateReward via PR2's transactions.
 
 alter table core_rewards
     add constraint fk_core_rewards_rewards_manager_pubkey

--- a/pkg/core/db/sql/migrations/00033_reward_pools.sql
+++ b/pkg/core/db/sql/migrations/00033_reward_pools.sql
@@ -189,6 +189,7 @@ from (
             select lower(trim(a)) from unnest(r2.claim_authorities) a
             where a is not null and trim(a) <> ''
         )
+        order by rm.rewards_manager_pubkey, rm.authority
         limit 1
     ) rm
     where r2.claim_authorities is not null

--- a/pkg/core/db/sql/migrations/00033_reward_pools.sql
+++ b/pkg/core/db/sql/migrations/00033_reward_pools.sql
@@ -197,6 +197,55 @@ from (
 ) mapped
 where r.address = mapped.reward_address;
 
+-- Backfill step 3: for rewards whose claim_authorities don't include any
+-- launchpad-mapped per-mint key, create a synthetic mig_<md5> pool keyed
+-- deterministically by the canonical (trim/lower/dedup/sort) authority
+-- set. mig_<md5> identifiers fail base58 decoding, so PR3's per-RM
+-- sender-attestation gate naturally ignores them; they exist so legacy
+-- claim/delete authorization (which iterates the row's claim_authorities
+-- via the LEFT JOIN coalesce(p.authorities, '{}') on reads) keeps
+-- working for unmapped rewards. Live finalizeCreateReward uses the
+-- identical mig_<md5> scheme, so the migration and live paths agree on
+-- synthetic pool keys.
+insert into core_reward_pools (rewards_manager_pubkey, authorities)
+select distinct
+    'mig_' || md5(array_to_string(canon, ',')) as rewards_manager_pubkey,
+    canon as authorities
+from (
+    select
+        array(
+            select distinct lower(trim(a))
+            from unnest(r.claim_authorities) as a
+            where a is not null and trim(a) <> ''
+            order by 1
+        ) as canon
+    from core_rewards r
+    where r.claim_authorities is not null
+      and array_length(r.claim_authorities, 1) > 0
+      and r.rewards_manager_pubkey is null
+) sets
+where array_length(sets.canon, 1) > 0
+on conflict (rewards_manager_pubkey) do update set
+    authorities = excluded.authorities,
+    updated_at = now();
+
+-- Backfill step 4: point each unmapped core_rewards row at its synthetic
+-- pool. After this, every core_rewards row with non-empty
+-- claim_authorities has a non-NULL rewards_manager_pubkey.
+update core_rewards r
+set rewards_manager_pubkey = 'mig_' || md5(array_to_string(
+    array(
+        select distinct lower(trim(a))
+        from unnest(r.claim_authorities) as a
+        where a is not null and trim(a) <> ''
+        order by 1
+    ),
+    ','
+))
+where r.claim_authorities is not null
+  and array_length(r.claim_authorities, 1) > 0
+  and r.rewards_manager_pubkey is null;
+
 alter table core_rewards
     add constraint fk_core_rewards_rewards_manager_pubkey
     foreign key (rewards_manager_pubkey) references core_reward_pools(rewards_manager_pubkey)

--- a/pkg/core/db/sql/migrations/00033_reward_pools.sql
+++ b/pkg/core/db/sql/migrations/00033_reward_pools.sql
@@ -1,0 +1,235 @@
+-- +migrate Up
+
+-- Reward pools group the eth addresses authorized to attest for rewards
+-- under a specific Solana reward manager. The pool is identified BY the
+-- reward manager pubkey (32-byte base58) — there is no separate "pool
+-- address" concept. PR2's CreateRewardPool / SetRewardPoolAuthorities txs
+-- mutate this table; PR3's sender-attestation gate consults it to decide
+-- whether to sign add/delete attestations for a given (RM, eth address)
+-- pair.
+create table if not exists core_reward_pools (
+    rewards_manager_pubkey text primary key,
+    authorities            text[] not null default '{}',
+    created_at             timestamp with time zone default now(),
+    updated_at             timestamp with time zone default now()
+);
+
+create index if not exists idx_core_reward_pools_authorities on core_reward_pools using gin (authorities);
+
+-- launchpad_authority_rm maps a launchpad-derived per-mint claim authority
+-- (lowercased eth hex address) to the Solana reward manager state account
+-- that mint's rewards live under. The values are produced by running
+-- DeriveEthAddressForMint(domain="claimAuthority", secret, mint) for each
+-- known launchpad mint and recording its RM. This table serves two
+-- purposes:
+--
+--   1. The backfill block below uses it to find each existing reward row's
+--      RM (by looking for any one of its claim_authorities that matches a
+--      known launchpad authority).
+--   2. PR2's wire-compat layer (finalizeLegacyCreateReward) queries it at
+--      block-sync replay time to produce the same RM-bound state the
+--      migration produces, so historical replay and the migration agree
+--      on the resulting apphash.
+--
+-- The table must remain populated and queryable as long as any legacy-
+-- format CreateReward txs may still be replayed during block sync. Future
+-- launchpad mints can be added via additional migrations as they're
+-- registered.
+create table if not exists launchpad_authority_rm (
+    authority              text primary key,
+    rewards_manager_pubkey text not null,
+    created_at             timestamp with time zone default now()
+);
+
+insert into launchpad_authority_rm (authority, rewards_manager_pubkey) values
+    ('0x0c5b590a071a377c49a154639fd4343d147bcafe', 'urGNtpg4ppvLKH5Yvkmi1dixbTsokJdAdbzGs9iSSPy'),
+    ('0x103cf68f8d352ba3dbee8b56236befaa1e1429aa', 'BWC8rj4am5izbJXCpwyEfTxAo2StWGiwjBfSzAzKt4Gi'),
+    ('0x111d7c8cb8c46f743a7796a7f9c0f2fb08076f6f', '7hXopQnXfv8tRf8aVXvGauAHyUPcNKAT4gp49ufhxk36'),
+    ('0x1165e5f035ce5eeaed37c6ad190b58903bac6175', 'Di77DoUUbe8QDq6XU3jptxMLnT8S5kj8JZ3qGYRTHNKh'),
+    ('0x14035c457a724b83da6c88b7dca0d283d2789808', 'dWwazU2QUih1pDnuGWXfJnVG6uLfvogqnFknvrxju92'),
+    ('0x14637fad403350a1fdbd6d21cc7658ae46d7bbb0', '5z5TV5WhbUyhJDkhmeKsJLNgreVcNq3kNh3Kwd2mGHEE'),
+    ('0x16ac1f19e207794ff1462b2ffdad742b3b3c0ce7', 'Bvr2HYVpKThU4nCFhpDy7Y6XLBMZUuQHK1KRbAGnCiQt'),
+    ('0x1a17cf24fa74847c4c2e4e14d9fa5d55347ea829', 'FGrk4MQGFyjsgnCBCoCpRgMubo6SqSwvHYiEHuDnXrcE'),
+    ('0x1be07e9b5af6cad186f8e3771d97e11b3af27dbe', 'FDeFBV6XntX2LkkYFmBSyqhwf8w7MzvND3kcJWYD4gVa'),
+    ('0x1edf70aaf55952a8d9d75a550e0f7eef6593c0b9', 'GBDpJArbu7Mes5FnXYgMNAaUdayCAGRzpJrThaKr9dsS'),
+    ('0x212fbc84a052d73b9dbceae3c8de29597db64d0f', 'E7fZSM55CzM7gD9LcnN5jEakKJLcHUwyNQZc9RL2RgTT'),
+    ('0x21adafbd269728c08f2ee6d3a3a43455b7e09ad7', '7Lra25qHo7yJWTQjwAGcyK3PvHXLfKpqNZkpGX76dzkK'),
+    ('0x27ca8265e6d9f0a95657fa7d36964b10d826fa6d', 'BtU6seJeyf5b68mSA2iFH1wdipxNHWSuU9JGKhAYVtry'),
+    ('0x29063c045b421d064993bde6e98646b47998c4f7', 'CDZ6nAr8md5xz2Wvb3LdnLya6yjxpqcLTMZrb8zYMdcM'),
+    ('0x36d1b69132f70558dc4838d5ae87cca21c562f1f', '2QJhBYiEznpjgSSsezcccpfkYdngPik4fvQzxHMucm9L'),
+    ('0x3b3c30eb5dd9bb6f9b92a14448474242513299b2', 'GXX15br7UgnkhUskBtfTn26SsWbtjijofxGH5Be1LKqP'),
+    ('0x3e472953a85573bf25c657772a5f05624de5d9f1', 'FhHiVewd3dM63nJ6h3cZFdvMcyFdVJURhHUfYvvXDpQm'),
+    ('0x48f31a62c79ead300514cb890e68da88acc018e8', '3zaWKMBCR2mDoKCGjtyB4Y24xHQa1XdT2tGXuRThKg8U'),
+    ('0x4b797d0822d595de3e3ac3f2747bd5fdc2dfe96d', 'AvGcJBQpiWTvFFXW7GHYZXHpuNxjvGpZ8ezpjQXf2KN9'),
+    ('0x4e870de81a26d7e84dee34e8678b5958fe8730d1', '8CtDHsjPUpnGyNSAQpwGqPm46Np6jJWxRpzXH2277RX3'),
+    ('0x4fff490d410d5f412392bbad9e5b2b18742eea6c', '8DY6uaCyzmSXNneycc45tS1TxUTPjuYiFQYtsjWsASSN'),
+    ('0x503d34f7615b2a12651a54286f0d27d732647993', 'pRS2Gkt9YNoU1G9HAXeRruKGN5qRUQsg5pVxbtAuPmV'),
+    ('0x50dec0d97ee06a32c81651b8430ff424d6c58dc6', '4Aa5UrKqeUPrUVHRjiGAF6o1V3u17v2rQmERNEXLNkZ9'),
+    ('0x550d7cb8e314828c29bd48ce8e732e5799efe08d', 'GGrpfPa8gXPQ3FEusXhsPQBnWeNqb7Z1cfSD6gY3zunQ'),
+    ('0x5ad1a050b693f59eb64e4ac6d34bf30c3880cd24', 'BNJMsdNJN4NRJcisFtPbWF799eKa19YafLs6oDZAYDGm'),
+    ('0x5c78fe2d276450237d569bc4afa763bf9ccaf74f', 'GCrhftvMubAEQrnCcTUxLHxsCbnGr7wVdLtwjj1SkWQN'),
+    ('0x5f7f7dacbc1f64e28d465cb2644592963771d618', 'CBaP4ncJYxv2wmjT8bxtpuJ41wJU8SkbMKuaP4PP9S8C'),
+    ('0x66a9d306336e227a47a3486669bba023b141192d', '65EKqnYE8Rom3DnLGP7XbXjyNY8xXMfCnpjMZW14tsvV'),
+    ('0x6702d3bff4b3736cf72f9f64db4169a5853dbc9c', '83ENNoux1oKhMndc2Uw6BqwWTPHPavHWQhG292bZun3N'),
+    ('0x6b13053a2b4c7fc71d60d58dd55a97b34b245a80', '2WdvdUbEEY1XRYVQmrHFipTWg8Jy42nE4e7xFK3Q6gjo'),
+    ('0x6c6da83a8237ee4dc4ecfea880c17c4ed6d7a2c8', 'F3xcZ7jQFWBgp2kMjp9fHSkCehRWzuVND6n1mCu1oyjH'),
+    ('0x832d886079387f3ab825e978bfc682f6c158a3e8', '8FkZU5VooBFXqb8GA36kgTyHZ5J1ABqi13bBKzkExvBz'),
+    ('0x85f54509c6075ed7efe6889a85b713cb68ce56cf', '6UuCBYGutteDTYAhd1W5PpvvSAg4LEWiJYQnWVU79bER'),
+    ('0x868d17a61edafd0b9d96032cd44570a95ff6a04f', '86jE4ubrbFGwdwTv6iN2FZpQm2EiHXru4teowrYpu8Tn'),
+    ('0x86a60f5b2b3f29a42c80fec03818bd329655187f', '4kmzFHSSrUxeTkfRrYmKv96o7guqi7LPBaZrzqvKQYL5'),
+    ('0x8719de0df16a3e0889d8509b351dafabee4ea294', 'GaDBQ27F7EmNHumchE6Pjr43frckBuxsUUJjN45uAajQ'),
+    ('0x8ad3ca46321b18e06b35d4c8e76d18d976de7727', 'GQxHiQFfeby9wfyUw5Bw1Q1xPB7ZqwgKjB36PtHhKstV'),
+    ('0x8f4458d8f0ae1b3f83e84be178fd1c4f3fc36bd4', 'CAQm1eMbUn3j5qhFWT4FmnDzwuNddy1supzR5A85VVfW'),
+    ('0x90aaffd8c2bbb0b68e99b90319c3c7bb43d33eb2', 'mY3V2Y2Trjsaa3qHrrL7s3aNWEG6getJUdpXvf71uqe'),
+    ('0x9293d36202216e47afb9d7762f05ad52c59403e4', 'AdDEp4rJe7RAFRg14uaFMUmPfLHJ6oJeSe49aXSwPVgZ'),
+    ('0x9d7ba5f04c7dc2993ff2ccdf19e29ad741036e90', '78XW1jt6T5mXTBocoDuTqB4RAM3mAKnYGSYWDeXY135s'),
+    ('0x9f3ebdf813c04ef8096326dd134270b376525e1a', 'fWcM3QvikFoZGKQ9eJ8yZ4Q7SVcHydnGMoR7fdrtza9'),
+    ('0xa1ef8ef283501d456b76757b32ea345cdcb4224f', '8u3ejuKz7uywPqdz5fS8cB4ppXvAZ3WiLeVKdiFWoK2r'),
+    ('0xa29dff72f7aecb95d1414f7206eb69820ec86cc7', '2hcSdCmtCfgNhjBELh6a9GJ2WSbbU8LMMonqFLZTAp67'),
+    ('0xa85281a327c0848a619659391eb88dd3702fcf41', '781STZvPpSTaDNcB35tbAWk2fwbTpqaRNRpSQpun7C3X'),
+    ('0xaa49c2afad744ac3595baed0d1f9c7876720c9df', 'EUqRiCAgj7QnP176ThaGfrGz3r2VxxNyXuAPU5SPhMJS'),
+    ('0xad6b9555369a438fb4698c46dfad245ef97b270e', '8jrWskYgwYPEZHSUCKnQmdq4hGKgAt9gcZeXtQCsRnJs'),
+    ('0xb3f3f879c7c0cb0a4af1fcddb6557fc2b3963bc9', '3Z4GXG84TjmvnV8h16qraFmWeEBv2eQd9quc39UhwiAe'),
+    ('0xb61525df350dbfc6a2ac82412f6ece0cc4dbd7ff', 'CFawCKFwxqLejDdoyUMjyBQokX2n37E37oS8HAUogmAM'),
+    ('0xbbecbfecf49bb3159c67fa5d254c40307c6fce2b', '86Wqf14Hj3DQMwgpuqQtAApJT3Wyf4wR7wWmdYzfkLWZ'),
+    ('0xbc731ab6905ef383b519702dffbe8bb3f9ccf547', 'EgTvyvn9QDsAyXVamM8pzV2YHoVRuWBVmRFD56BaGgkS'),
+    ('0xbd00af91f78a651bdb74892f7c7207ffed7ef3dd', 'A3ZhYjqJfBZtJxUGXXruYHSWR5Zf7NaBgteTwEhrKwow'),
+    ('0xc402938db359d2644df952697dc3925c62fef99e', 'B4ijMf1byKLmRUV9RZaDCZqs4TTPGEfbEYD67B5M22Z2'),
+    ('0xc82c810ae45ba45d5ccdc02273f48e453d51e2f9', '6YAc7rLW8uom3DRnj6wkwvq6qpW9PkAfxBxXpU2wyyph'),
+    ('0xc8acdb3049903f6758c434d21b77af2b8af48d9e', 'ELs98dgSh3Kd6ViMM9LFT1rfEbPvm4e6xpQzjK2wVjH6'),
+    ('0xce61db54629ef47d0dfb2923660c787ac92fcec1', 'P76iaELTfBg1hKo6hr22scupEMhDsAcayg5AMGpQiCM'),
+    ('0xcece39acb112bfbc59fe41606d4475435f1b3676', '4E7B4BGd2bfjutdjkWsMcjgubGkxgf5niNNuKQKhbfpQ'),
+    ('0xda1a09589098954b05648419cc4bbea20c6e39ea', '46w1RsTcygL5C6ijfaAztUstPqHuzZXPEB2KCr52cYHf'),
+    ('0xdaef8d116025a7053577c95cf793827cbf6d7767', '7ij5BsYE2aL3QG2Mt1ifB3mNZx9ELXBEZbCMX6nLM977'),
+    ('0xe325971fe787077e8b6d42e9f353eea06a801680', '31Dq71KBhKEs2nEwytX8RwEC1wBS2pUaQdPVk3zTHsWP'),
+    ('0xe9448fb249fb675f6d51483edef063bf64487a3f', 'GqHmpeQkqNW7h8mPUQPsXqy3E5CVy1siMbeHuU9uhNVi'),
+    ('0xee878a78a703a67c73d1e794e61bb36fc715eef2', '6TW5NzdMF7ps4zaDo6ogCV1iUHde4VdA2ZyNtJKLwSLp'),
+    ('0xf0ed91252a509ff2d24f0dd6e22c0e985f636334', 'BrY2VSnagcjsr6DND1FpcfpYiJ8PrBdheuPRggKVfZUN'),
+    ('0xf174de7442c805c3900ce4140a81f329c5a7f5bc', '3G9yANcxNcFobZgZbP3TyQuF4zqC3hqeqEi1LDcJjJgo'),
+    ('0xf3baf2379bb060fa63f620576fbb977ef5fa4e51', '8dZLVViKogvR8nPFVLcK64r32WG5GKZojn2BTvJ2LHHL'),
+    ('0xfa29072ea2933a8ece9842d19480184ef9583ba8', '8ThSmVGV6NW36JDuVgNCgYuh6b9QycaQCmRT18boS4aR'),
+    ('0xfe3d5e7b8bab7599d63f43dcd673f7c27424296e', 'G1YQE4itykWEWSheCzKMKVma7D7AYxrQ7UY92DvZLUeV'),
+    ('0xffbb95b5631c39e860016d23918592489031248c', '454bPX92ayZf6XmuGRjFGKGAr43hYX2T8U3avcd6KNGi')
+on conflict (authority) do nothing;
+
+-- Add rewards_manager_pubkey FK to core_rewards. Nullable: rows whose
+-- claim_authorities don't include any known launchpad-derived authority
+-- (e.g., test fixtures, abandoned rewards) stay NULL after the backfill
+-- and have no pool. PR3's sender-attestation gate refuses to operate on
+-- NULL-RM rewards (no pool, no authority data).
+alter table core_rewards add column if not exists rewards_manager_pubkey text;
+create index if not exists idx_core_rewards_rewards_manager_pubkey on core_rewards (rewards_manager_pubkey);
+
+-- Backfill step 1: insert one core_reward_pools row per (RM, canonical
+-- authorities) pair seen in core_rewards. The pool's RM is determined by
+-- finding any one of the row's claim_authorities that matches a launchpad
+-- authority — so each unique authority set becomes a real RM-bound pool,
+-- not a synthetic mig_<md5> identifier. The pool's authorities array is
+-- the canonical (trim, lower, dedup, sort) form of the row's full
+-- claim_authorities, preserving the partner-signer / leaked-key entries
+-- as the pool's *initial* authorities. PR2's SetRewardPoolAuthorities is
+-- the rotation surface that drains them out.
+-- Per-RM authority union: for each RM, take the UNION of authorities
+-- across every reward whose claim_authorities contain ANY of that RM's
+-- launchpad-derived keys. This guards against the case where two
+-- rewards under the same mint were created with slightly different
+-- authority sets (e.g., one had an additional debug key) — a naive
+-- "ON CONFLICT DO NOTHING" insert would keep an arbitrary
+-- first-inserted set and silently drop authorities present on other
+-- rewards. The union preserves all of them as the pool's initial set;
+-- SetRewardPoolAuthorities is the rotation surface that drains them.
+insert into core_reward_pools (rewards_manager_pubkey, authorities)
+select
+    rm.rewards_manager_pubkey,
+    array(
+        select distinct lower(trim(a))
+        from core_rewards r,
+             unnest(r.claim_authorities) as a
+        where r.claim_authorities is not null
+          and array_length(r.claim_authorities, 1) > 0
+          and a is not null
+          and trim(a) <> ''
+          and exists (
+              select 1
+              from unnest(r.claim_authorities) as r_auth
+              where lower(trim(r_auth)) = rm.authority
+          )
+        order by 1
+    ) as authorities
+from launchpad_authority_rm rm
+where exists (
+    select 1
+    from core_rewards r,
+         unnest(r.claim_authorities) as r_auth
+    where r.claim_authorities is not null
+      and array_length(r.claim_authorities, 1) > 0
+      and lower(trim(r_auth)) = rm.authority
+)
+on conflict (rewards_manager_pubkey) do update set
+    authorities = excluded.authorities,
+    updated_at = now();
+
+-- Backfill step 2: point each core_rewards row at its pool. We pick the RM
+-- from any launchpad-derived authority found among the row's
+-- claim_authorities. In practice each row should contain exactly one
+-- launchpad authority (the per-mint key for the coin the reward was issued
+-- under), so the lateral lookup yields a unique RM; rows with no matching
+-- authority are left with NULL rewards_manager_pubkey.
+update core_rewards r
+set rewards_manager_pubkey = mapped.rewards_manager_pubkey
+from (
+    select
+        r2.address as reward_address,
+        rm.rewards_manager_pubkey
+    from core_rewards r2
+    cross join lateral (
+        select rm.rewards_manager_pubkey
+        from launchpad_authority_rm rm
+        where rm.authority = any (
+            select lower(trim(a)) from unnest(r2.claim_authorities) a
+            where a is not null and trim(a) <> ''
+        )
+        limit 1
+    ) rm
+    where r2.claim_authorities is not null
+      and array_length(r2.claim_authorities, 1) > 0
+) mapped
+where r.address = mapped.reward_address;
+
+alter table core_rewards
+    add constraint fk_core_rewards_rewards_manager_pubkey
+    foreign key (rewards_manager_pubkey) references core_reward_pools(rewards_manager_pubkey)
+    on delete cascade;
+
+-- The row's rewards_manager_pubkey now carries the authorization signal;
+-- the inline claim_authorities column and its gin index are redundant.
+drop index if exists idx_core_rewards_claim_authorities;
+alter table core_rewards drop column if exists claim_authorities;
+
+-- +migrate Down
+
+-- Restore the column (backfilled from the pool's authorities) before tearing
+-- down the FK so existing data is preserved on a downgrade.
+--
+-- KNOWN LIMITATION: rewards whose claim_authorities did not include any
+-- launchpad-derived authority were left with NULL rewards_manager_pubkey
+-- by the Up migration (no pool was created for them). Those rows have no
+-- pool to restore from, so the JOIN below leaves their claim_authorities
+-- as the column default ('{}'). The original inline claim_authorities are
+-- not recoverable on a downgrade. This is acceptable because the Down
+-- migration is a best-effort rollback path — production rollback would
+-- happen at the chain level, not via SQL Down.
+alter table core_rewards add column if not exists claim_authorities text[] default '{}';
+update core_rewards r
+set claim_authorities = coalesce(p.authorities, '{}'::text[])
+from core_reward_pools p
+where p.rewards_manager_pubkey = r.rewards_manager_pubkey;
+create index if not exists idx_core_rewards_claim_authorities on core_rewards using gin (claim_authorities);
+
+alter table core_rewards drop constraint if exists fk_core_rewards_rewards_manager_pubkey;
+drop index if exists idx_core_rewards_rewards_manager_pubkey;
+alter table core_rewards drop column if exists rewards_manager_pubkey;
+
+drop index if exists idx_core_reward_pools_authorities;
+drop table if exists core_reward_pools;
+drop table if exists launchpad_authority_rm;

--- a/pkg/core/db/sql/reads.sql
+++ b/pkg/core/db/sql/reads.sql
@@ -586,41 +586,94 @@ where b.height = $1
 order by b.height, t.index asc;
 
 -- name: GetReward :one
-select * from core_rewards
-where address = $1
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where r.address = $1
+order by r.block_height desc
 limit 1;
 
 -- name: GetRewardByID :one
-select * from core_rewards
-where reward_id = $1
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where r.reward_id = $1
+order by r.block_height desc
 limit 1;
 
 -- name: GetRewardByTxHash :one
-select * from core_rewards
-where tx_hash = $1
-order by block_height desc
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where r.tx_hash = $1
+order by r.block_height desc
 limit 1;
 
 -- name: GetAllRewards :many
-select * from core_rewards
-where address in (
-    select distinct address
-    from core_rewards
-)
-order by block_height desc;
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+order by r.block_height desc;
 
 -- name: GetActiveRewards :many
-select *
-from core_rewards
-order by address;
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+left join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+order by r.address;
 
 -- name: GetRewardsByClaimAuthority :many
-select *
-from core_rewards
-where $1::text = any(claim_authorities)
-order by address;
+-- Uses array containment (@>) so the gin index on core_reward_pools.authorities
+-- can be used. = ANY(...) cannot leverage the gin opclass.
+select
+    r.id, r.address, r.index, r.tx_hash, r.sender, r.reward_id, r.name, r.amount,
+    coalesce(p.authorities, '{}'::text[])::text[] as claim_authorities,
+    r.raw_message, r.block_height, r.rewards_manager_pubkey, r.created_at, r.updated_at
+from core_rewards r
+join core_reward_pools p on p.rewards_manager_pubkey = r.rewards_manager_pubkey
+where p.authorities @> array[$1::text]
+order by r.address;
+
+-- name: GetRewardPool :one
+select rewards_manager_pubkey, authorities, created_at, updated_at
+from core_reward_pools
+where rewards_manager_pubkey = $1;
+
+-- name: GetRewardPoolsByAuthority :many
+-- Uses array containment (@>) so the gin index on authorities is used.
+select rewards_manager_pubkey, authorities, created_at, updated_at
+from core_reward_pools
+where authorities @> array[$1::text]
+order by rewards_manager_pubkey;
+
+-- name: GetLaunchpadRMByAuthority :one
+-- Resolves a launchpad-derived per-mint claim authority (lowercased eth
+-- hex) to the Solana reward manager state account that mint's rewards
+-- live under. Used by PR2's wire-compat layer at block-sync replay time:
+-- when finalizeLegacyCreateReward sees an inline claim_authorities array,
+-- it looks up the RM from any one of its lowercased entries and routes
+-- the reward into a pool keyed by that RM — matching exactly what PR1's
+-- backfill produced for pre-migration rows. Returns ErrNoRows if none of
+-- the requested authorities is in the launchpad mapping (e.g., AUDIO
+-- rewards or test fixtures).
+select rewards_manager_pubkey
+from launchpad_authority_rm
+where authority = any($1::text[])
+limit 1;
 
 -- name: GetCoreUpload :one
 select * from core_uploads where cid = $1 OR transcoded_cid = $1;

--- a/pkg/core/db/sql/reads.sql
+++ b/pkg/core/db/sql/reads.sql
@@ -673,6 +673,7 @@ order by rewards_manager_pubkey;
 select rewards_manager_pubkey
 from launchpad_authority_rm
 where authority = any($1::text[])
+order by rewards_manager_pubkey, authority
 limit 1;
 
 -- name: GetCoreUpload :one

--- a/pkg/core/db/sql/writes.sql
+++ b/pkg/core/db/sql/writes.sql
@@ -357,12 +357,13 @@ delete from core_rewards
 where address = $1;
 
 -- name: UpsertSyntheticRewardPool :exec
--- Used by the legacy CreateReward replay flow (wire-compat layer) to ensure
--- a reward-pool row exists for the provided rewards_manager_pubkey, which is
--- the pool identity in the current schema. On replay, DO UPDATE refreshes the
--- stored authority set for that same pool identity so legacy backfills remain
--- aligned with the latest replayed state instead of leaving stale authorities
--- on an existing row.
+-- Used by the legacy CreateReward path to ensure a reward-pool row exists
+-- for the provided rewards_manager_pubkey with the requested authority
+-- set. The pubkey may be a real Solana RM (when the row's
+-- claim_authorities included a known launchpad-derived per-mint key) or
+-- a synthetic 'mig_<md5>' identifier (otherwise). DO UPDATE refreshes
+-- the stored authorities so multiple CreateReward txs targeting the
+-- same pool converge instead of leaving stale rows.
 insert into core_reward_pools (
     rewards_manager_pubkey,
     authorities

--- a/pkg/core/db/sql/writes.sql
+++ b/pkg/core/db/sql/writes.sql
@@ -337,7 +337,7 @@ insert into core_rewards (
     reward_id,
     name,
     amount,
-    claim_authorities,
+    rewards_manager_pubkey,
     raw_message,
     block_height
 ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
@@ -346,7 +346,7 @@ insert into core_rewards (
 update core_rewards
 set name = $2,
     amount = $3,
-    claim_authorities = $4,
+    rewards_manager_pubkey = $4,
     raw_message = $5,
     block_height = $6,
     updated_at = now()
@@ -355,6 +355,41 @@ where address = $1;
 -- name: DeleteCoreReward :exec
 delete from core_rewards
 where address = $1;
+
+-- name: UpsertSyntheticRewardPool :exec
+-- Used by the legacy CreateReward replay flow (wire-compat layer) to ensure
+-- a synthetic pool exists with the requested authority set. The pool's
+-- rewards_manager_pubkey is deterministic from the canonical (trim/lower/
+-- dedup/sort) authorities — prefixed 'mig_' to mark the row as not-RM-bound,
+-- matching the PR1 backfill. DO UPDATE makes the canonical-form ↔ row
+-- correspondence an enforced invariant: any drift in canonicalization will
+-- self-correct on next replay rather than hiding a divergent row.
+insert into core_reward_pools (
+    rewards_manager_pubkey,
+    authorities
+) values ($1, $2)
+on conflict (rewards_manager_pubkey) do update set
+    authorities = excluded.authorities,
+    updated_at = now();
+
+-- name: InsertRewardPool :exec
+-- Inserts a first-class reward pool created via a CreateRewardPool cometbft
+-- transaction. The pool's identity IS the Solana reward manager pubkey;
+-- uniqueness is validated at validate time and same-block collisions
+-- surface here as a PK violation that fails the second tx in the block.
+insert into core_reward_pools (
+    rewards_manager_pubkey,
+    authorities
+) values ($1, $2);
+
+-- name: UpdateRewardPoolAuthorities :exec
+-- Replaces the authority set on an existing pool wholesale. Used by the
+-- SetRewardPoolAuthorities finalizer; callers compose the new list themselves
+-- (current minus the removed key, current plus the added key, etc.).
+update core_reward_pools
+set authorities = $2,
+    updated_at = now()
+where rewards_manager_pubkey = $1;
 
 -- name: InsertFileUpload :exec
 insert into core_uploads(

--- a/pkg/core/db/sql/writes.sql
+++ b/pkg/core/db/sql/writes.sql
@@ -358,12 +358,11 @@ where address = $1;
 
 -- name: UpsertSyntheticRewardPool :exec
 -- Used by the legacy CreateReward replay flow (wire-compat layer) to ensure
--- a synthetic pool exists with the requested authority set. The pool's
--- rewards_manager_pubkey is deterministic from the canonical (trim/lower/
--- dedup/sort) authorities — prefixed 'mig_' to mark the row as not-RM-bound,
--- matching the PR1 backfill. DO UPDATE makes the canonical-form ↔ row
--- correspondence an enforced invariant: any drift in canonicalization will
--- self-correct on next replay rather than hiding a divergent row.
+-- a reward-pool row exists for the provided rewards_manager_pubkey, which is
+-- the pool identity in the current schema. On replay, DO UPDATE refreshes the
+-- stored authority set for that same pool identity so legacy backfills remain
+-- aligned with the latest replayed state instead of leaving stale authorities
+-- on an existing row.
 insert into core_reward_pools (
     rewards_manager_pubkey,
     authorities

--- a/pkg/core/db/writes.sql.go
+++ b/pkg/core/db/writes.sql.go
@@ -1193,13 +1193,13 @@ type UpsertSyntheticRewardPoolParams struct {
 	Authorities          []string
 }
 
-// Used by the legacy CreateReward replay flow (wire-compat layer) to ensure
-// a reward pool row exists for the caller-provided rewards_manager_pubkey
-// with the requested authority set. This helper does not derive a synthetic
-// 'mig_<md5>' key from authorities; it upserts by the supplied
-// rewards_manager_pubkey, which is the primary key used by the current
-// schema/migration and callers. DO UPDATE keeps authorities in sync for that
-// rewards manager pubkey on replay.
+// Used by the legacy CreateReward path to ensure a reward-pool row exists
+// for the provided rewards_manager_pubkey with the requested authority
+// set. The pubkey may be a real Solana RM (when the row's
+// claim_authorities included a known launchpad-derived per-mint key) or
+// a synthetic 'mig_<md5>' identifier (otherwise). DO UPDATE refreshes
+// the stored authorities so multiple CreateReward txs targeting the
+// same pool converge instead of leaving stale rows.
 func (q *Queries) UpsertSyntheticRewardPool(ctx context.Context, arg UpsertSyntheticRewardPoolParams) error {
 	_, err := q.db.Exec(ctx, upsertSyntheticRewardPool, arg.RewardsManagerPubkey, arg.Authorities)
 	return err

--- a/pkg/core/db/writes.sql.go
+++ b/pkg/core/db/writes.sql.go
@@ -1194,12 +1194,12 @@ type UpsertSyntheticRewardPoolParams struct {
 }
 
 // Used by the legacy CreateReward replay flow (wire-compat layer) to ensure
-// a synthetic pool exists with the requested authority set. The pool's
-// rewards_manager_pubkey is deterministic from the canonical (trim/lower/
-// dedup/sort) authorities — prefixed 'mig_' to mark the row as not-RM-bound,
-// matching the PR1 backfill. DO UPDATE makes the canonical-form ↔ row
-// correspondence an enforced invariant: any drift in canonicalization will
-// self-correct on next replay rather than hiding a divergent row.
+// a reward pool row exists for the caller-provided rewards_manager_pubkey
+// with the requested authority set. This helper does not derive a synthetic
+// 'mig_<md5>' key from authorities; it upserts by the supplied
+// rewards_manager_pubkey, which is the primary key used by the current
+// schema/migration and callers. DO UPDATE keeps authorities in sync for that
+// rewards manager pubkey on replay.
 func (q *Queries) UpsertSyntheticRewardPool(ctx context.Context, arg UpsertSyntheticRewardPoolParams) error {
 	_, err := q.db.Exec(ctx, upsertSyntheticRewardPool, arg.RewardsManagerPubkey, arg.Authorities)
 	return err

--- a/pkg/core/db/writes.sql.go
+++ b/pkg/core/db/writes.sql.go
@@ -407,23 +407,23 @@ insert into core_rewards (
     reward_id,
     name,
     amount,
-    claim_authorities,
+    rewards_manager_pubkey,
     raw_message,
     block_height
 ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 `
 
 type InsertCoreRewardParams struct {
-	Address          string
-	TxHash           string
-	Index            int64
-	Sender           string
-	RewardID         string
-	Name             string
-	Amount           int64
-	ClaimAuthorities []string
-	RawMessage       []byte
-	BlockHeight      int64
+	Address              string
+	TxHash               string
+	Index                int64
+	Sender               string
+	RewardID             string
+	Name                 string
+	Amount               int64
+	RewardsManagerPubkey pgtype.Text
+	RawMessage           []byte
+	BlockHeight          int64
 }
 
 func (q *Queries) InsertCoreReward(ctx context.Context, arg InsertCoreRewardParams) error {
@@ -435,7 +435,7 @@ func (q *Queries) InsertCoreReward(ctx context.Context, arg InsertCoreRewardPara
 		arg.RewardID,
 		arg.Name,
 		arg.Amount,
-		arg.ClaimAuthorities,
+		arg.RewardsManagerPubkey,
 		arg.RawMessage,
 		arg.BlockHeight,
 	)
@@ -891,6 +891,27 @@ func (q *Queries) InsertRegisteredNode(ctx context.Context, arg InsertRegistered
 	return err
 }
 
+const insertRewardPool = `-- name: InsertRewardPool :exec
+insert into core_reward_pools (
+    rewards_manager_pubkey,
+    authorities
+) values ($1, $2)
+`
+
+type InsertRewardPoolParams struct {
+	RewardsManagerPubkey string
+	Authorities          []string
+}
+
+// Inserts a first-class reward pool created via a CreateRewardPool cometbft
+// transaction. The pool's identity IS the Solana reward manager pubkey;
+// uniqueness is validated at validate time and same-block collisions
+// surface here as a PK violation that fails the second tx in the block.
+func (q *Queries) InsertRewardPool(ctx context.Context, arg InsertRewardPoolParams) error {
+	_, err := q.db.Exec(ctx, insertRewardPool, arg.RewardsManagerPubkey, arg.Authorities)
+	return err
+}
+
 const insertSoundRecording = `-- name: InsertSoundRecording :exec
 insert into sound_recordings (sound_recording_id, track_id, cid, encoding_details) 
 values ($1, $2, $3, $4)
@@ -1054,7 +1075,7 @@ const updateCoreReward = `-- name: UpdateCoreReward :exec
 update core_rewards
 set name = $2,
     amount = $3,
-    claim_authorities = $4,
+    rewards_manager_pubkey = $4,
     raw_message = $5,
     block_height = $6,
     updated_at = now()
@@ -1062,12 +1083,12 @@ where address = $1
 `
 
 type UpdateCoreRewardParams struct {
-	Address          string
-	Name             string
-	Amount           int64
-	ClaimAuthorities []string
-	RawMessage       []byte
-	BlockHeight      int64
+	Address              string
+	Name                 string
+	Amount               int64
+	RewardsManagerPubkey pgtype.Text
+	RawMessage           []byte
+	BlockHeight          int64
 }
 
 func (q *Queries) UpdateCoreReward(ctx context.Context, arg UpdateCoreRewardParams) error {
@@ -1075,10 +1096,30 @@ func (q *Queries) UpdateCoreReward(ctx context.Context, arg UpdateCoreRewardPara
 		arg.Address,
 		arg.Name,
 		arg.Amount,
-		arg.ClaimAuthorities,
+		arg.RewardsManagerPubkey,
 		arg.RawMessage,
 		arg.BlockHeight,
 	)
+	return err
+}
+
+const updateRewardPoolAuthorities = `-- name: UpdateRewardPoolAuthorities :exec
+update core_reward_pools
+set authorities = $2,
+    updated_at = now()
+where rewards_manager_pubkey = $1
+`
+
+type UpdateRewardPoolAuthoritiesParams struct {
+	RewardsManagerPubkey string
+	Authorities          []string
+}
+
+// Replaces the authority set on an existing pool wholesale. Used by the
+// SetRewardPoolAuthorities finalizer; callers compose the new list themselves
+// (current minus the removed key, current plus the added key, etc.).
+func (q *Queries) UpdateRewardPoolAuthorities(ctx context.Context, arg UpdateRewardPoolAuthoritiesParams) error {
+	_, err := q.db.Exec(ctx, updateRewardPoolAuthorities, arg.RewardsManagerPubkey, arg.Authorities)
 	return err
 }
 
@@ -1134,5 +1175,32 @@ where not exists (select 1 from updated)
 
 func (q *Queries) UpsertSlaRollupReport(ctx context.Context, address string) error {
 	_, err := q.db.Exec(ctx, upsertSlaRollupReport, address)
+	return err
+}
+
+const upsertSyntheticRewardPool = `-- name: UpsertSyntheticRewardPool :exec
+insert into core_reward_pools (
+    rewards_manager_pubkey,
+    authorities
+) values ($1, $2)
+on conflict (rewards_manager_pubkey) do update set
+    authorities = excluded.authorities,
+    updated_at = now()
+`
+
+type UpsertSyntheticRewardPoolParams struct {
+	RewardsManagerPubkey string
+	Authorities          []string
+}
+
+// Used by the legacy CreateReward replay flow (wire-compat layer) to ensure
+// a synthetic pool exists with the requested authority set. The pool's
+// rewards_manager_pubkey is deterministic from the canonical (trim/lower/
+// dedup/sort) authorities — prefixed 'mig_' to mark the row as not-RM-bound,
+// matching the PR1 backfill. DO UPDATE makes the canonical-form ↔ row
+// correspondence an enforced invariant: any drift in canonicalization will
+// self-correct on next replay rather than hiding a divergent row.
+func (q *Queries) UpsertSyntheticRewardPool(ctx context.Context, arg UpsertSyntheticRewardPoolParams) error {
+	_, err := q.db.Exec(ctx, upsertSyntheticRewardPool, arg.RewardsManagerPubkey, arg.Authorities)
 	return err
 }

--- a/pkg/core/server/connect.go
+++ b/pkg/core/server/connect.go
@@ -1073,6 +1073,11 @@ func (c *CoreService) GetRewards(ctx context.Context, req *connect.Request[v1.Ge
 	if claimAuthority == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("claim_authority required"))
 	}
+	// Stored authorities are lowercased by rewards.CanonicalAuthorities; the
+	// underlying GetRewardsByClaimAuthority does a case-sensitive @> array
+	// containment check. Normalize the caller-supplied address (which is
+	// often checksum-case from common.PrivKeyToAddress) so lookups match.
+	claimAuthority = strings.ToLower(strings.TrimSpace(claimAuthority))
 
 	rewards, err := c.core.db.GetRewardsByClaimAuthority(ctx, claimAuthority)
 	if err != nil {

--- a/pkg/core/server/connect.go
+++ b/pkg/core/server/connect.go
@@ -1069,15 +1069,16 @@ func (c *CoreService) GetRewardAttestation(ctx context.Context, req *connect.Req
 
 // GetRewards implements v1connect.CoreServiceHandler.
 func (c *CoreService) GetRewards(ctx context.Context, req *connect.Request[v1.GetRewardsRequest]) (*connect.Response[v1.GetRewardsResponse], error) {
-	claimAuthority := req.Msg.ClaimAuthority
-	if claimAuthority == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("claim_authority required"))
-	}
 	// Stored authorities are lowercased by rewards.CanonicalAuthorities; the
 	// underlying GetRewardsByClaimAuthority does a case-sensitive @> array
 	// containment check. Normalize the caller-supplied address (which is
 	// often checksum-case from common.PrivKeyToAddress) so lookups match.
-	claimAuthority = strings.ToLower(strings.TrimSpace(claimAuthority))
+	// Normalize before the empty check so whitespace-only input is rejected
+	// as InvalidArgument rather than silently producing an empty result.
+	claimAuthority := strings.ToLower(strings.TrimSpace(req.Msg.ClaimAuthority))
+	if claimAuthority == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("claim_authority required"))
+	}
 
 	rewards, err := c.core.db.GetRewardsByClaimAuthority(ctx, claimAuthority)
 	if err != nil {

--- a/pkg/core/server/rewards.go
+++ b/pkg/core/server/rewards.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/core/db"
 	"github.com/OpenAudio/go-openaudio/pkg/rewards"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/labstack/echo/v4"
 	"google.golang.org/protobuf/proto"
@@ -212,26 +213,50 @@ func (s *Server) finalizeCreateReward(ctx context.Context, req *abcitypes.Finali
 	rewardAddress := common.CreateAddress(txhashBytes, s.config.GenesisFile.ChainID, req.Height, messageIndex, "")
 
 	// Legacy CreateReward (this path) carries inline claim_authorities but
-	// no rewards_manager_pubkey, so we cannot bind the reward to a pool
-	// from the message alone. Two reasons we don't upsert a pool here:
+	// no rewards_manager_pubkey. We resolve the RM via launchpad lookup
+	// (the same mapping the migration backfill uses) and bind the reward
+	// to the RM's pool — but only if the pool already exists. We never
+	// upsert into the pool from this path:
 	//
-	//  1. Privilege escalation. validateCreateReward checks only the tx
-	//     signature, not signer ∈ pool.authorities, so an attacker could
-	//     submit CreateReward with [legitimate_launchpad_key, attacker_key]
-	//     and overwrite the legitimate RM's pool, taking attestation
-	//     control of every reward under the RM.
-	//  2. The launchpad seed in the migration is the complete set of RM
-	//     init events; the only authoritative way to bind a reward to its
-	//     RM is the migration's backfill (already run) or PR2's
-	//     CreateRewardPool + RM-bound CreateReward.
+	//   - validateCreateReward checks only the tx signature, not
+	//     signer ∈ pool.authorities. If we upserted authorities here, an
+	//     attacker could submit CreateReward with [legitimate_launchpad_key,
+	//     attacker_key] and overwrite the legitimate RM's pool, taking
+	//     attestation control of every reward under the RM.
 	//
-	// Live CreateReward therefore inserts the reward with NULL
-	// rewards_manager_pubkey. The reward is unclaimable until its claim
-	// authority submits a CreateRewardPool tx and re-creates the reward
-	// against that pool. In practice this path runs only briefly between
-	// PR1 and PR2 landing.
+	// Pool absent (mint in launchpad seed but no pre-existing rewards) ⇒
+	// leave rewards_manager_pubkey NULL; the reward is unclaimable until
+	// its claim authority submits CreateRewardPool via PR2 and re-creates
+	// the reward. Same fallback applies if no message authority maps to a
+	// known launchpad RM.
 	qtx := s.getDb()
 	var rmPubkey pgtype.Text
+
+	authorityLookup := make([]string, 0, len(createReward.ClaimAuthorities))
+	for _, auth := range createReward.ClaimAuthorities {
+		canon := strings.ToLower(strings.TrimSpace(auth.Address))
+		if canon != "" {
+			authorityLookup = append(authorityLookup, canon)
+		}
+	}
+	if len(authorityLookup) > 0 {
+		rm, err := qtx.GetLaunchpadRMByAuthority(ctx, authorityLookup)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			// no launchpad authority match; reward stays unmapped
+		case err != nil:
+			return fmt.Errorf("failed to resolve launchpad RM: %w", err)
+		default:
+			if _, err := qtx.GetRewardPool(ctx, rm); err != nil {
+				if !errors.Is(err, pgx.ErrNoRows) {
+					return fmt.Errorf("failed to load pool for RM %s: %w", rm, err)
+				}
+				// pool not yet created for this RM; reward stays unmapped
+			} else {
+				rmPubkey = pgtype.Text{String: rm, Valid: true}
+			}
+		}
+	}
 
 	rawMessage, err := proto.Marshal(createReward)
 	if err != nil {

--- a/pkg/core/server/rewards.go
+++ b/pkg/core/server/rewards.go
@@ -211,40 +211,27 @@ func (s *Server) finalizeCreateReward(ctx context.Context, req *abcitypes.Finali
 	}
 	rewardAddress := common.CreateAddress(txhashBytes, s.config.GenesisFile.ChainID, req.Height, messageIndex, "")
 
-	// Synthesize a per-authority-set pool from the message's inline
-	// claim_authorities. Pool key = "mig_" + md5(canonical authorities) — a
-	// deterministic synthetic identifier that never decodes as a real
-	// Solana reward manager pubkey, so PR3's per-RM sender-attestation
-	// gate ignores it (synthetic pools cannot grant Solana sender
-	// registration).
+	// Legacy CreateReward (this path) carries inline claim_authorities but
+	// no rewards_manager_pubkey, so we cannot bind the reward to a pool
+	// from the message alone. Two reasons we don't upsert a pool here:
 	//
-	// Why synthetic-only here, never RM-bound: validateCreateReward only
-	// checks the tx signature; it does NOT require the signer to be in
-	// the resolved pool's authorities. If finalizeCreateReward upserted
-	// into a real-RM pool from the message's claim_authorities, an
-	// attacker could submit CreateReward with [legitimate_launchpad_key,
-	// attacker_key] in claim_authorities and overwrite that RM's pool
-	// authorities, escalating to full attestation control over every
-	// reward under the RM. The migration backfill is the only source of
-	// truth that writes real-RM pools; live CreateReward stays in mig_*.
-	authorityAddrs := make([]string, 0, len(createReward.ClaimAuthorities))
-	for _, auth := range createReward.ClaimAuthorities {
-		authorityAddrs = append(authorityAddrs, auth.Address)
-	}
-	canonicalAuthorities := rewards.CanonicalAuthorities(authorityAddrs)
-
+	//  1. Privilege escalation. validateCreateReward checks only the tx
+	//     signature, not signer ∈ pool.authorities, so an attacker could
+	//     submit CreateReward with [legitimate_launchpad_key, attacker_key]
+	//     and overwrite the legitimate RM's pool, taking attestation
+	//     control of every reward under the RM.
+	//  2. The launchpad seed in the migration is the complete set of RM
+	//     init events; the only authoritative way to bind a reward to its
+	//     RM is the migration's backfill (already run) or PR2's
+	//     CreateRewardPool + RM-bound CreateReward.
+	//
+	// Live CreateReward therefore inserts the reward with NULL
+	// rewards_manager_pubkey. The reward is unclaimable until its claim
+	// authority submits a CreateRewardPool tx and re-creates the reward
+	// against that pool. In practice this path runs only briefly between
+	// PR1 and PR2 landing.
 	qtx := s.getDb()
 	var rmPubkey pgtype.Text
-	if len(canonicalAuthorities) > 0 {
-		poolAddress := rewards.MigratedPoolAddress(authorityAddrs)
-		if err := qtx.UpsertSyntheticRewardPool(ctx, db.UpsertSyntheticRewardPoolParams{
-			RewardsManagerPubkey: poolAddress,
-			Authorities:          canonicalAuthorities,
-		}); err != nil {
-			return fmt.Errorf("failed to upsert reward pool: %w", err)
-		}
-		rmPubkey = pgtype.Text{String: poolAddress, Valid: true}
-	}
 
 	rawMessage, err := proto.Marshal(createReward)
 	if err != nil {

--- a/pkg/core/server/rewards.go
+++ b/pkg/core/server/rewards.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/core/db"
 	"github.com/OpenAudio/go-openaudio/pkg/rewards"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/labstack/echo/v4"
 	"google.golang.org/protobuf/proto"
@@ -212,12 +211,22 @@ func (s *Server) finalizeCreateReward(ctx context.Context, req *abcitypes.Finali
 	}
 	rewardAddress := common.CreateAddress(txhashBytes, s.config.GenesisFile.ChainID, req.Height, messageIndex, "")
 
-	// Resolve the reward's RM by looking up any one of its inline
-	// claim_authorities in the launchpad_authority_rm mapping. This
-	// matches what the 00033 migration's backfill block does for
-	// pre-migration rows, so live CreateReward state and replayed-
-	// CreateReward state both converge on real-RM-keyed pools (no
-	// synthetic mig_<md5> identifiers).
+	// Synthesize a per-authority-set pool from the message's inline
+	// claim_authorities. Pool key = "mig_" + md5(canonical authorities) — a
+	// deterministic synthetic identifier that never decodes as a real
+	// Solana reward manager pubkey, so PR3's per-RM sender-attestation
+	// gate ignores it (synthetic pools cannot grant Solana sender
+	// registration).
+	//
+	// Why synthetic-only here, never RM-bound: validateCreateReward only
+	// checks the tx signature; it does NOT require the signer to be in
+	// the resolved pool's authorities. If finalizeCreateReward upserted
+	// into a real-RM pool from the message's claim_authorities, an
+	// attacker could submit CreateReward with [legitimate_launchpad_key,
+	// attacker_key] in claim_authorities and overwrite that RM's pool
+	// authorities, escalating to full attestation control over every
+	// reward under the RM. The migration backfill is the only source of
+	// truth that writes real-RM pools; live CreateReward stays in mig_*.
 	authorityAddrs := make([]string, 0, len(createReward.ClaimAuthorities))
 	for _, auth := range createReward.ClaimAuthorities {
 		authorityAddrs = append(authorityAddrs, auth.Address)
@@ -227,28 +236,14 @@ func (s *Server) finalizeCreateReward(ctx context.Context, req *abcitypes.Finali
 	qtx := s.getDb()
 	var rmPubkey pgtype.Text
 	if len(canonicalAuthorities) > 0 {
-		rm, err := qtx.GetLaunchpadRMByAuthority(ctx, canonicalAuthorities)
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-			// No matching launchpad authority. Reward stays orphaned
-			// (NULL rewards_manager_pubkey, no pool). Mirrors the
-			// migration backfill's behavior for rows whose authorities
-			// don't include any known launchpad-derived authority.
-		case err != nil:
-			return fmt.Errorf("failed to resolve launchpad RM: %w", err)
-		default:
-			// Upsert the pool so multiple CreateReward txs targeting the
-			// same RM converge on the same authority set. The DO UPDATE
-			// in UpsertSyntheticRewardPool absorbs any canonicalization
-			// drift between successive replays.
-			if err := qtx.UpsertSyntheticRewardPool(ctx, db.UpsertSyntheticRewardPoolParams{
-				RewardsManagerPubkey: rm,
-				Authorities:          canonicalAuthorities,
-			}); err != nil {
-				return fmt.Errorf("failed to upsert reward pool: %w", err)
-			}
-			rmPubkey = pgtype.Text{String: rm, Valid: true}
+		poolAddress := rewards.MigratedPoolAddress(authorityAddrs)
+		if err := qtx.UpsertSyntheticRewardPool(ctx, db.UpsertSyntheticRewardPoolParams{
+			RewardsManagerPubkey: poolAddress,
+			Authorities:          canonicalAuthorities,
+		}); err != nil {
+			return fmt.Errorf("failed to upsert reward pool: %w", err)
 		}
+		rmPubkey = pgtype.Text{String: poolAddress, Valid: true}
 	}
 
 	rawMessage, err := proto.Marshal(createReward)

--- a/pkg/core/server/rewards.go
+++ b/pkg/core/server/rewards.go
@@ -14,6 +14,8 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/core/db"
 	"github.com/OpenAudio/go-openaudio/pkg/rewards"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/labstack/echo/v4"
 	"google.golang.org/protobuf/proto"
 )
@@ -210,30 +212,61 @@ func (s *Server) finalizeCreateReward(ctx context.Context, req *abcitypes.Finali
 	}
 	rewardAddress := common.CreateAddress(txhashBytes, s.config.GenesisFile.ChainID, req.Height, messageIndex, "")
 
-	// Convert claim authorities to string array
-	claimAuthorities := make([]string, len(createReward.ClaimAuthorities))
-	for i, auth := range createReward.ClaimAuthorities {
-		claimAuthorities[i] = auth.Address
+	// Resolve the reward's RM by looking up any one of its inline
+	// claim_authorities in the launchpad_authority_rm mapping. This
+	// matches what the 00033 migration's backfill block does for
+	// pre-migration rows, so live CreateReward state and replayed-
+	// CreateReward state both converge on real-RM-keyed pools (no
+	// synthetic mig_<md5> identifiers).
+	authorityAddrs := make([]string, 0, len(createReward.ClaimAuthorities))
+	for _, auth := range createReward.ClaimAuthorities {
+		authorityAddrs = append(authorityAddrs, auth.Address)
+	}
+	canonicalAuthorities := rewards.CanonicalAuthorities(authorityAddrs)
+
+	qtx := s.getDb()
+	var rmPubkey pgtype.Text
+	if len(canonicalAuthorities) > 0 {
+		rm, err := qtx.GetLaunchpadRMByAuthority(ctx, canonicalAuthorities)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			// No matching launchpad authority. Reward stays orphaned
+			// (NULL rewards_manager_pubkey, no pool). Mirrors the
+			// migration backfill's behavior for rows whose authorities
+			// don't include any known launchpad-derived authority.
+		case err != nil:
+			return fmt.Errorf("failed to resolve launchpad RM: %w", err)
+		default:
+			// Upsert the pool so multiple CreateReward txs targeting the
+			// same RM converge on the same authority set. The DO UPDATE
+			// in UpsertSyntheticRewardPool absorbs any canonicalization
+			// drift between successive replays.
+			if err := qtx.UpsertSyntheticRewardPool(ctx, db.UpsertSyntheticRewardPoolParams{
+				RewardsManagerPubkey: rm,
+				Authorities:          canonicalAuthorities,
+			}); err != nil {
+				return fmt.Errorf("failed to upsert reward pool: %w", err)
+			}
+			rmPubkey = pgtype.Text{String: rm, Valid: true}
+		}
 	}
 
-	// Marshal the raw message
 	rawMessage, err := proto.Marshal(createReward)
 	if err != nil {
 		return fmt.Errorf("failed to marshal create reward message: %w", err)
 	}
 
-	qtx := s.getDb()
 	if err := qtx.InsertCoreReward(ctx, db.InsertCoreRewardParams{
-		TxHash:           txhash,
-		Index:            messageIndex,
-		Address:          rewardAddress,
-		Sender:           signer, // Use verified signer instead of passed sender
-		RewardID:         createReward.RewardId,
-		Name:             createReward.Name,
-		Amount:           int64(createReward.Amount),
-		ClaimAuthorities: claimAuthorities,
-		RawMessage:       rawMessage,
-		BlockHeight:      req.Height,
+		TxHash:               txhash,
+		Index:                messageIndex,
+		Address:              rewardAddress,
+		Sender:               signer, // Use verified signer instead of passed sender
+		RewardID:             createReward.RewardId,
+		Name:                 createReward.Name,
+		Amount:               int64(createReward.Amount),
+		RewardsManagerPubkey: rmPubkey,
+		RawMessage:           rawMessage,
+		BlockHeight:          req.Height,
 	}); err != nil {
 		return fmt.Errorf("failed to insert reward: %w", err)
 	}

--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -330,6 +330,8 @@ func (s *Server) createPgDump(logger *zap.Logger, latestSnapshotDir string) erro
 		"core_parties",
 		"core_deals",
 		"core_rewards",
+		"core_reward_pools",
+		"launchpad_authority_rm",
 		"core_uploads",
 		"validator_history",
 	}

--- a/pkg/rewards/reward_pool.go
+++ b/pkg/rewards/reward_pool.go
@@ -1,0 +1,29 @@
+package rewards
+
+import (
+	"sort"
+	"strings"
+)
+
+// CanonicalAuthorities normalizes a list of eth addresses to the canonical
+// form stored in core_reward_pools.authorities: lowercased, trimmed,
+// deduplicated, non-empty entries, sorted ascending. Producers of pool
+// authority sets canonicalize before write so containment checks against
+// the gin index on authorities stay deterministic.
+func CanonicalAuthorities(authorities []string) []string {
+	seen := make(map[string]struct{}, len(authorities))
+	out := make([]string, 0, len(authorities))
+	for _, a := range authorities {
+		a = strings.ToLower(strings.TrimSpace(a))
+		if a == "" {
+			continue
+		}
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/rewards/reward_pool.go
+++ b/pkg/rewards/reward_pool.go
@@ -1,8 +1,6 @@
 package rewards
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"sort"
 	"strings"
 )
@@ -28,20 +26,4 @@ func CanonicalAuthorities(authorities []string) []string {
 	}
 	sort.Strings(out)
 	return out
-}
-
-// MigratedPoolAddress returns the deterministic synthetic pool identifier
-// for a set of claim authorities: "mig_" + md5(comma-joined canonical
-// addresses). Used as the fallback when a CreateReward's authorities
-// don't include any known launchpad-derived per-mint key — the pool
-// exists so the reward can be authenticated against its own
-// claim_authorities, but the synthetic identifier doesn't decode as a
-// real Solana RM pubkey, so the validator's per-RM sender-attestation
-// gate ignores it (synthetic pools never grant Solana sender
-// registration).
-func MigratedPoolAddress(authorities []string) string {
-	canonical := CanonicalAuthorities(authorities)
-	joined := strings.Join(canonical, ",")
-	sum := md5.Sum([]byte(joined))
-	return "mig_" + hex.EncodeToString(sum[:])
 }

--- a/pkg/rewards/reward_pool.go
+++ b/pkg/rewards/reward_pool.go
@@ -1,6 +1,8 @@
 package rewards
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"sort"
 	"strings"
 )
@@ -26,4 +28,20 @@ func CanonicalAuthorities(authorities []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// MigratedPoolAddress returns the deterministic synthetic pool identifier
+// for a set of claim authorities: "mig_" + md5(comma-joined canonical
+// addresses). Used as the fallback when a CreateReward's authorities
+// don't include any known launchpad-derived per-mint key — the pool
+// exists so the reward can be authenticated against its own
+// claim_authorities, but the synthetic identifier doesn't decode as a
+// real Solana RM pubkey, so the validator's per-RM sender-attestation
+// gate ignores it (synthetic pools never grant Solana sender
+// registration).
+func MigratedPoolAddress(authorities []string) string {
+	canonical := CanonicalAuthorities(authorities)
+	joined := strings.Join(canonical, ",")
+	sum := md5.Sum([]byte(joined))
+	return "mig_" + hex.EncodeToString(sum[:])
 }

--- a/pkg/rewards/reward_pool_test.go
+++ b/pkg/rewards/reward_pool_test.go
@@ -1,7 +1,6 @@
 package rewards
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -58,68 +57,6 @@ func TestCanonicalAuthorities(t *testing.T) {
 			got := CanonicalAuthorities(tt.in)
 			if !equalStringSlices(got, tt.want) {
 				t.Fatalf("got %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestMigratedPoolAddressInvariants(t *testing.T) {
-	t.Run("starts with mig_ prefix and 32-hex tail", func(t *testing.T) {
-		addr := MigratedPoolAddress([]string{"0xabc"})
-		if !strings.HasPrefix(addr, "mig_") {
-			t.Fatalf("address %q does not start with mig_", addr)
-		}
-		if len(addr) != len("mig_")+32 {
-			t.Fatalf("address %q length = %d, want %d", addr, len(addr), len("mig_")+32)
-		}
-	})
-
-	t.Run("equivalent inputs produce identical addresses", func(t *testing.T) {
-		variants := [][]string{
-			{"0xabc", "0xdef"},
-			{"0xdef", "0xabc"},
-			{"0xABC", "0xDEF"},
-			{"  0xabc  ", "\t0xdef\n"},
-			{"0xabc", "0xABC", "0xdef"},
-			{"", "0xabc", "  ", "0xdef"},
-		}
-		want := MigratedPoolAddress(variants[0])
-		for i, v := range variants[1:] {
-			if got := MigratedPoolAddress(v); got != want {
-				t.Fatalf("variant %d (%v) produced %q, expected %q", i+1, v, got, want)
-			}
-		}
-	})
-
-	t.Run("different inputs produce different addresses", func(t *testing.T) {
-		a := MigratedPoolAddress([]string{"0xabc"})
-		b := MigratedPoolAddress([]string{"0xdef"})
-		c := MigratedPoolAddress([]string{"0xabc", "0xdef"})
-		if a == b || a == c || b == c {
-			t.Fatalf("expected distinct addresses, got a=%q b=%q c=%q", a, b, c)
-		}
-	})
-}
-
-// TestMigratedPoolAddressKnownVectors pins the address algorithm. The
-// expected values were produced by running CanonicalAuthorities +
-// md5(comma-joined) by hand; they MUST stay stable across releases so
-// production rows backfilled to mig_<md5> identifiers don't lose their
-// pool reference on a Go-side recomputation.
-func TestMigratedPoolAddressKnownVectors(t *testing.T) {
-	tests := []struct {
-		name string
-		in   []string
-		want string
-	}{
-		{"single", []string{"0xabc"}, "mig_2a3aeb7c7bcb4c46bdfbc333c7727b92"},
-		{"two sorted", []string{"0xabc", "0xdef"}, "mig_d61e4a5b393eb41840571b0774d559b9"},
-		{"two messy", []string{"  0xDEF", "0xABC", "0xabc"}, "mig_d61e4a5b393eb41840571b0774d559b9"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := MigratedPoolAddress(tt.in); got != tt.want {
-				t.Fatalf("MigratedPoolAddress(%v) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/pkg/rewards/reward_pool_test.go
+++ b/pkg/rewards/reward_pool_test.go
@@ -1,0 +1,75 @@
+package rewards
+
+import (
+	"testing"
+)
+
+func TestCanonicalAuthorities(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty input",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "nil input",
+			in:   nil,
+			want: []string{},
+		},
+		{
+			name: "drops empty and whitespace-only entries",
+			in:   []string{"", "0xabc", "   ", "\t", "0xdef"},
+			want: []string{"0xabc", "0xdef"},
+		},
+		{
+			name: "lowercases mixed case",
+			in:   []string{"0xABC", "0xDeF"},
+			want: []string{"0xabc", "0xdef"},
+		},
+		{
+			name: "trims surrounding whitespace",
+			in:   []string{"  0xabc ", "\t0xdef\n"},
+			want: []string{"0xabc", "0xdef"},
+		},
+		{
+			name: "deduplicates after canonicalization",
+			in:   []string{"0xABC", "0xabc", "  0xABC ", "0xdef"},
+			want: []string{"0xabc", "0xdef"},
+		},
+		{
+			name: "sorts ascending",
+			in:   []string{"0xdef", "0xabc", "0x123"},
+			want: []string{"0x123", "0xabc", "0xdef"},
+		},
+		{
+			name: "all whitespace results in empty",
+			in:   []string{"  ", "\t", ""},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalAuthorities(tt.in)
+			if !equalStringSlices(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/rewards/reward_pool_test.go
+++ b/pkg/rewards/reward_pool_test.go
@@ -1,6 +1,7 @@
 package rewards
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -57,6 +58,68 @@ func TestCanonicalAuthorities(t *testing.T) {
 			got := CanonicalAuthorities(tt.in)
 			if !equalStringSlices(got, tt.want) {
 				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigratedPoolAddressInvariants(t *testing.T) {
+	t.Run("starts with mig_ prefix and 32-hex tail", func(t *testing.T) {
+		addr := MigratedPoolAddress([]string{"0xabc"})
+		if !strings.HasPrefix(addr, "mig_") {
+			t.Fatalf("address %q does not start with mig_", addr)
+		}
+		if len(addr) != len("mig_")+32 {
+			t.Fatalf("address %q length = %d, want %d", addr, len(addr), len("mig_")+32)
+		}
+	})
+
+	t.Run("equivalent inputs produce identical addresses", func(t *testing.T) {
+		variants := [][]string{
+			{"0xabc", "0xdef"},
+			{"0xdef", "0xabc"},
+			{"0xABC", "0xDEF"},
+			{"  0xabc  ", "\t0xdef\n"},
+			{"0xabc", "0xABC", "0xdef"},
+			{"", "0xabc", "  ", "0xdef"},
+		}
+		want := MigratedPoolAddress(variants[0])
+		for i, v := range variants[1:] {
+			if got := MigratedPoolAddress(v); got != want {
+				t.Fatalf("variant %d (%v) produced %q, expected %q", i+1, v, got, want)
+			}
+		}
+	})
+
+	t.Run("different inputs produce different addresses", func(t *testing.T) {
+		a := MigratedPoolAddress([]string{"0xabc"})
+		b := MigratedPoolAddress([]string{"0xdef"})
+		c := MigratedPoolAddress([]string{"0xabc", "0xdef"})
+		if a == b || a == c || b == c {
+			t.Fatalf("expected distinct addresses, got a=%q b=%q c=%q", a, b, c)
+		}
+	})
+}
+
+// TestMigratedPoolAddressKnownVectors pins the address algorithm. The
+// expected values were produced by running CanonicalAuthorities +
+// md5(comma-joined) by hand; they MUST stay stable across releases so
+// production rows backfilled to mig_<md5> identifiers don't lose their
+// pool reference on a Go-side recomputation.
+func TestMigratedPoolAddressKnownVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"single", []string{"0xabc"}, "mig_2a3aeb7c7bcb4c46bdfbc333c7727b92"},
+		{"two sorted", []string{"0xabc", "0xdef"}, "mig_d61e4a5b393eb41840571b0774d559b9"},
+		{"two messy", []string{"  0xDEF", "0xABC", "0xabc"}, "mig_d61e4a5b393eb41840571b0774d559b9"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MigratedPoolAddress(tt.in); got != tt.want {
+				t.Fatalf("MigratedPoolAddress(%v) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Introduces a `core_reward_pools` table that owns the set of eth addresses authorized to attest for a reward, replacing the inline `core_rewards.claim_authorities` array. Each pool is keyed by the Solana reward manager pubkey it governs — the pool identity IS the RM, no synthetic identifiers.

This is **PR 1 of 3** in the reward-authority rotation initiative:
1. **(this PR)** Schema + data migration with launchpad-derived RM mapping.
2. CometBFT transactions for managing pools (`CreateRewardPool`, `SetRewardPoolAuthorities`) — #225.
3. Validator endpoint cutover with per-RM sender attestation gate — #228.

## Schema (`00033_reward_pools.sql`)

```sql
create table core_reward_pools (
    rewards_manager_pubkey text primary key,
    authorities            text[] not null default '{}',
    created_at             timestamp with time zone default now(),
    updated_at             timestamp with time zone default now()
);
create index idx_core_reward_pools_authorities
    on core_reward_pools using gin (authorities);

alter table core_rewards add column rewards_manager_pubkey text;
alter table core_rewards add constraint fk_core_rewards_rewards_manager_pubkey
    foreign key (rewards_manager_pubkey) references core_reward_pools(rewards_manager_pubkey)
    on delete cascade;
-- backfill, then:
drop index idx_core_rewards_claim_authorities;
alter table core_rewards drop column claim_authorities;
```

## `launchpad_authority_rm` mapping table

```sql
create table launchpad_authority_rm (
    authority              text primary key,        -- lowercase eth hex
    rewards_manager_pubkey text not null,           -- base58 32-byte Solana RM
    created_at             timestamp with time zone default now()
);
```

Populated with 72 entries: each known launchpad mint's `DeriveEthAddressForMint(domain="claimAuthority", secret, mint)` output mapped to the Solana reward manager state account that mint's rewards live under. Used by:

1. The PR 1 backfill block to find each existing `core_rewards` row's RM (by looking for any of its `claim_authorities` that matches a known launchpad authority).
2. PR 2's wire-compat layer (`finalizeLegacyCreateReward`) at block-sync replay time to produce the same RM-bound state the migration produces, so historical replay and the migration agree on the resulting apphash.

The table stays populated as long as any legacy-format CreateReward txs may still be replayed. New launchpad mints can be added via additional migrations.

## Backfill

Two-step:
1. Insert one `core_reward_pools` row per `(RM, canonical authorities)` pair seen in `core_rewards`. The RM comes from joining canonical authorities against `launchpad_authority_rm`. The pool's authorities array is the canonical (trim, lower, dedup, sort) form of the row's full `claim_authorities` — preserving the partner-signer / leaked-key entries as the pool's *initial* authorities. PR 2's `SetRewardPoolAuthorities` is the rotation surface that drains them out.
2. Update each `core_rewards.rewards_manager_pubkey` to the resolved RM. Rows whose `claim_authorities` don't include any known launchpad-derived authority (test fixtures, abandoned rewards) stay NULL — PR 3's sender-attestation gate refuses to operate on NULL-RM rewards.

The down migration restores `claim_authorities` from `pool.authorities` before tearing down the FK so existing data is preserved on a downgrade.

## SQL queries

- All reward `SELECT`s in `pkg/core/db/sql/reads.sql` now `LEFT JOIN core_reward_pools` and alias `coalesce(p.authorities, '{}')::text[]` as `claim_authorities`, so existing callers see the same field but it's sourced from the pool.
- `GetRewardsByClaimAuthority` uses `p.authorities @> array[$1::text]` so the gin index on `authorities` is actually used. Caller-side lowercase happens at the connect.go handler in PR 2 to match the canonicalized stored values.
- `GetLaunchpadRMByAuthority` (one): resolves a canonical claim_authorities array to its RM via the launchpad mapping. Used by PR 2's wire-compat layer.
- `InsertCoreReward` / `UpdateCoreReward` write `rewards_manager_pubkey` instead of `claim_authorities`.
- `UpsertSyntheticRewardPool` (kept by name; legacy-replay-only) uses `DO UPDATE SET authorities = excluded.authorities, updated_at = now()` — self-correcting if canonicalization ever drifts between SQL and Go.

## Handlers

- `pkg/rewards/reward_pool.go`: `CanonicalAuthorities` (trim → lower → dedup → sort) helper. The Go canonicalization rules match the SQL backfill exactly, locked in by `reward_pool_test.go` (table-driven cases + invariants).
- `pkg/core/server/rewards.go`: `finalizeCreateReward` produces RM-bound pools (PR 2 cuts the new `CreateReward` over to require `rewards_manager_pubkey` directly).
- `pkg/core/server/state_sync.go`: adds `core_reward_pools` and `launchpad_authority_rm` to the table dump list so state-synced nodes inherit both.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./pkg/core/server/... ./pkg/rewards/...` — no new warnings.
- [x] `go test ./pkg/rewards/...` passes.
- [ ] Apply against a staging snapshot; confirm one pool per unique authority set, every reward row's `rewards_manager_pubkey` populated with the launchpad-mapped RM, no rows remain at NULL except known-orphan test data.
- [ ] Apply the down migration on a copy; confirm `claim_authorities` is restored from the pool.
- [ ] Smoke a fresh devnet end-to-end (`make up`).