### PR TITLE
Add separate archive bucket for store_all content

### DIFF
--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -123,6 +123,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 	spOwnerWallet := walletAddress
 	dir := fmt.Sprintf("/tmp/mediorum_dev_%d", spID)
 	blobStoreDSN := ""
+	archiveBlobStoreDSN := ""
 	moveFromBlobStoreDSN := ""
 
 	notDev := isProd || isStage
@@ -132,6 +133,8 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		dir = "/tmp/mediorum"
 		// Support OPENAUDIO_STORAGE_DRIVER_URL with fallback to AUDIUS_STORAGE_DRIVER_URL for backwards compatibility
 		blobStoreDSN = getenvWithDefault("OPENAUDIO_STORAGE_DRIVER_URL", os.Getenv("AUDIUS_STORAGE_DRIVER_URL"))
+		// Optional separate bucket for archive (StoreAll-only) content.
+		archiveBlobStoreDSN = getenvWithDefault("OPENAUDIO_ARCHIVE_STORAGE_DRIVER_URL", os.Getenv("AUDIUS_ARCHIVE_STORAGE_DRIVER_URL"))
 		// Support OPENAUDIO_STORAGE_DRIVER_URL_MOVE_FROM with fallback to AUDIUS_STORAGE_DRIVER_URL_MOVE_FROM for backwards compatibility
 		moveFromBlobStoreDSN = getenvWithDefault("OPENAUDIO_STORAGE_DRIVER_URL_MOVE_FROM", os.Getenv("AUDIUS_STORAGE_DRIVER_URL_MOVE_FROM"))
 	}
@@ -161,6 +164,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		Dir:                       dir,
 		PostgresDSN:               getenvWithDefault("dbUrl", "postgres://postgres:postgres@db:5432/audius_creator_node"),
 		BlobStoreDSN:              blobStoreDSN,
+		ArchiveBlobStoreDSN:       archiveBlobStoreDSN,
 		MoveFromBlobStoreDSN:      moveFromBlobStoreDSN,
 		TrustedNotifierID:         trustedNotifierID,
 		SPID:                      spID,

--- a/pkg/mediorum/server/audio_analysis.go
+++ b/pkg/mediorum/server/audio_analysis.go
@@ -78,13 +78,13 @@ func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work 
 
 		cid, ok := upload.TranscodeResults["320"]
 		if !ok {
-			if exists, _ := ss.bucket.Exists(ctx, upload.OrigFileCID); exists {
+			if exists, _ := ss.bucketForCID(upload.OrigFileCID, nil).Exists(ctx, upload.OrigFileCID); exists {
 				ss.transcode(ctx, upload)
 				cid, ok = upload.TranscodeResults["320"]
 			}
 		}
 		if ok {
-			if exists, _ := ss.bucket.Exists(ctx, cid); exists {
+			if exists, _ := ss.bucketForCID(cid, nil).Exists(ctx, cid); exists {
 				work <- upload
 			}
 		}
@@ -145,7 +145,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 	// pull transcoded file from bucket
 	cid, ok := upload.TranscodeResults["320"]
 	if !ok {
-		if exists, _ := ss.bucket.Exists(ctx, upload.OrigFileCID); exists {
+		if exists, _ := ss.bucketForCID(upload.OrigFileCID, nil).Exists(ctx, upload.OrigFileCID); exists {
 			ss.transcode(ctx, upload)
 			cid, ok = upload.TranscodeResults["320"]
 		}
@@ -159,7 +159,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 	// so that the next mirror may pick the job up
 	logger = logger.With(zap.String("cid", cid))
 	key := cidutil.ShardCID(cid)
-	attrs, err := ss.bucket.Attributes(ctx, key)
+	attrs, err := ss.bucketForCID(cid, nil).Attributes(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return errors.New("failed to find audio file on node")
@@ -172,7 +172,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 		logger.Error("failed to create temp file", zap.Error(err))
 		return err
 	}
-	r, err := ss.bucket.NewReader(ctx, key, nil)
+	r, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
 	if err != nil {
 		logger.Error("failed to read blob", zap.Error(err))
 		return err

--- a/pkg/mediorum/server/audio_analysis.go
+++ b/pkg/mediorum/server/audio_analysis.go
@@ -78,15 +78,13 @@ func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work 
 
 		cid, ok := upload.TranscodeResults["320"]
 		if !ok {
-			origKey := cidutil.ShardCID(upload.OrigFileCID)
-			if exists, _ := ss.bucketForCID(upload.OrigFileCID, upload.PlacementHosts).Exists(ctx, origKey); exists {
+			if ss.blobExists(ctx, cidutil.ShardCID(upload.OrigFileCID)) {
 				ss.transcode(ctx, upload)
 				cid, ok = upload.TranscodeResults["320"]
 			}
 		}
 		if ok {
-			transcodedKey := cidutil.ShardCID(cid)
-			if exists, _ := ss.bucketForCID(cid, upload.PlacementHosts).Exists(ctx, transcodedKey); exists {
+			if ss.blobExists(ctx, cidutil.ShardCID(cid)) {
 				work <- upload
 			}
 		}
@@ -147,8 +145,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 	// pull transcoded file from bucket
 	cid, ok := upload.TranscodeResults["320"]
 	if !ok {
-		origKey := cidutil.ShardCID(upload.OrigFileCID)
-		if exists, _ := ss.bucketForCID(upload.OrigFileCID, upload.PlacementHosts).Exists(ctx, origKey); exists {
+		if ss.blobExists(ctx, cidutil.ShardCID(upload.OrigFileCID)) {
 			ss.transcode(ctx, upload)
 			cid, ok = upload.TranscodeResults["320"]
 		}
@@ -162,8 +159,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 	// so that the next mirror may pick the job up
 	logger = logger.With(zap.String("cid", cid))
 	key := cidutil.ShardCID(cid)
-	srcBucket := ss.bucketForCID(cid, upload.PlacementHosts)
-	attrs, err := srcBucket.Attributes(ctx, key)
+	attrs, _, err := ss.blobAttrs(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return errors.New("failed to find audio file on node")
@@ -176,7 +172,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 		logger.Error("failed to create temp file", zap.Error(err))
 		return err
 	}
-	r, err := srcBucket.NewReader(ctx, key, nil)
+	r, _, err := ss.readBlob(ctx, key)
 	if err != nil {
 		logger.Error("failed to read blob", zap.Error(err))
 		return err

--- a/pkg/mediorum/server/audio_analysis.go
+++ b/pkg/mediorum/server/audio_analysis.go
@@ -78,13 +78,15 @@ func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work 
 
 		cid, ok := upload.TranscodeResults["320"]
 		if !ok {
-			if exists, _ := ss.bucketForCID(upload.OrigFileCID, nil).Exists(ctx, upload.OrigFileCID); exists {
+			origKey := cidutil.ShardCID(upload.OrigFileCID)
+			if exists, _ := ss.bucketForCID(upload.OrigFileCID, upload.PlacementHosts).Exists(ctx, origKey); exists {
 				ss.transcode(ctx, upload)
 				cid, ok = upload.TranscodeResults["320"]
 			}
 		}
 		if ok {
-			if exists, _ := ss.bucketForCID(cid, nil).Exists(ctx, cid); exists {
+			transcodedKey := cidutil.ShardCID(cid)
+			if exists, _ := ss.bucketForCID(cid, upload.PlacementHosts).Exists(ctx, transcodedKey); exists {
 				work <- upload
 			}
 		}
@@ -145,7 +147,8 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 	// pull transcoded file from bucket
 	cid, ok := upload.TranscodeResults["320"]
 	if !ok {
-		if exists, _ := ss.bucketForCID(upload.OrigFileCID, nil).Exists(ctx, upload.OrigFileCID); exists {
+		origKey := cidutil.ShardCID(upload.OrigFileCID)
+		if exists, _ := ss.bucketForCID(upload.OrigFileCID, upload.PlacementHosts).Exists(ctx, origKey); exists {
 			ss.transcode(ctx, upload)
 			cid, ok = upload.TranscodeResults["320"]
 		}
@@ -159,7 +162,8 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 	// so that the next mirror may pick the job up
 	logger = logger.With(zap.String("cid", cid))
 	key := cidutil.ShardCID(cid)
-	attrs, err := ss.bucketForCID(cid, nil).Attributes(ctx, key)
+	srcBucket := ss.bucketForCID(cid, upload.PlacementHosts)
+	attrs, err := srcBucket.Attributes(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return errors.New("failed to find audio file on node")
@@ -172,7 +176,7 @@ func (ss *MediorumServer) analyzeAudio(ctx context.Context, upload *Upload, dead
 		logger.Error("failed to create temp file", zap.Error(err))
 		return err
 	}
-	r, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
+	r, err := srcBucket.NewReader(ctx, key, nil)
 	if err != nil {
 		logger.Error("failed to read blob", zap.Error(err))
 		return err

--- a/pkg/mediorum/server/bucket_select.go
+++ b/pkg/mediorum/server/bucket_select.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"gocloud.dev/blob"
+	"golang.org/x/exp/slices"
+)
+
+// bucketForCID returns the bucket that should hold this CID on this node.
+//
+// A CID is routed to archiveBucket only when all of:
+//   - archiveBucket is configured
+//   - StoreAll is enabled (otherwise the node never holds archive content)
+//   - the CID is not in an explicit placementHosts list (placement always
+//     uses the primary bucket; placement implies the CID is required, not archive)
+//   - this node's rendezvous rank for the CID is >= ReplicationFactor, i.e. the
+//     only reason this node holds the CID is StoreAll
+//
+// Otherwise the primary bucket is returned. When archiveBucket is unset, this
+// always returns the primary bucket — preserving current behavior.
+func (ss *MediorumServer) bucketForCID(cid string, placementHosts []string) *blob.Bucket {
+	if ss.archiveBucket == nil {
+		return ss.bucket
+	}
+	if !ss.Config.StoreAll {
+		return ss.bucket
+	}
+	if len(placementHosts) > 0 {
+		// explicit placement: never archive
+		return ss.bucket
+	}
+	orderedHosts := ss.rendezvousHasher.Rank(cid)
+	myRank := slices.Index(orderedHosts, ss.Config.Self.Host)
+	if myRank >= 0 && myRank < ss.Config.ReplicationFactor {
+		return ss.bucket
+	}
+	return ss.archiveBucket
+}
+
+// isArchiveCID reports whether the given CID would be routed to the archive bucket
+// on this node. Used by callers that need to branch on archive-ness without
+// taking the bucket itself (e.g. repair counters, disk-space gating).
+func (ss *MediorumServer) isArchiveCID(cid string, placementHosts []string) bool {
+	return ss.archiveBucket != nil && ss.bucketForCID(cid, placementHosts) == ss.archiveBucket
+}

--- a/pkg/mediorum/server/bucket_select.go
+++ b/pkg/mediorum/server/bucket_select.go
@@ -30,7 +30,10 @@ func (ss *MediorumServer) bucketForCID(cid string, placementHosts []string) *blo
 	}
 	orderedHosts := ss.rendezvousHasher.Rank(cid)
 	myRank := slices.Index(orderedHosts, ss.Config.Self.Host)
-	if myRank >= 0 && myRank < ss.Config.ReplicationFactor {
+	// myRank < 0 means self isn't in the hash ring (misconfigured or
+	// mid-registration); route to primary so we don't silently divert
+	// everything to cold storage during a transient bad state.
+	if myRank < 0 || myRank < ss.Config.ReplicationFactor {
 		return ss.bucket
 	}
 	return ss.archiveBucket

--- a/pkg/mediorum/server/bucket_select.go
+++ b/pkg/mediorum/server/bucket_select.go
@@ -71,3 +71,14 @@ func (ss *MediorumServer) bucketForCID(cid string, placementHosts []string) *blo
 func (ss *MediorumServer) isArchiveCID(cid string, placementHosts []string) bool {
 	return ss.archiveBucket != nil && ss.bucketForCID(cid, placementHosts) == ss.archiveBucket
 }
+
+// presenceCacheKey scopes a storage-key cache entry to a specific bucket.
+// attrCache and knownPresent must use this — without bucket scoping, a
+// presence record from one bucket can mask a true miss in the other after
+// a rank flip or via placement-aware lookups.
+func (ss *MediorumServer) presenceCacheKey(key string, bucket *blob.Bucket) string {
+	if bucket == ss.archiveBucket {
+		return "a:" + key
+	}
+	return "p:" + key
+}

--- a/pkg/mediorum/server/bucket_select.go
+++ b/pkg/mediorum/server/bucket_select.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 	"golang.org/x/exp/slices"
 )
 
@@ -81,4 +83,55 @@ func (ss *MediorumServer) presenceCacheKey(key string, bucket *blob.Bucket) stri
 		return "a:" + key
 	}
 	return "p:" + key
+}
+
+// blobAttrs reads attributes from primary first, falling back to archive on
+// NotFound when archive is configured. Returns the bucket the blob was found
+// in. Reads should always go through this (or readBlob/blobExists) rather
+// than calling bucketForCID directly — bucketForCID is for picking write
+// destinations; on reads we want hot first, archive as a tier.
+func (ss *MediorumServer) blobAttrs(ctx context.Context, key string) (*blob.Attributes, *blob.Bucket, error) {
+	attrs, err := ss.bucket.Attributes(ctx, key)
+	if err == nil {
+		return attrs, ss.bucket, nil
+	}
+	if ss.archiveBucket == nil || gcerrors.Code(err) != gcerrors.NotFound {
+		return nil, nil, err
+	}
+	a2, err2 := ss.archiveBucket.Attributes(ctx, key)
+	if err2 == nil {
+		return a2, ss.archiveBucket, nil
+	}
+	// Surface the original primary error (callers distinguish on NotFound).
+	return nil, nil, err
+}
+
+// readBlob opens a reader from primary first, falling back to archive on
+// NotFound. Returns the bucket the blob was found in.
+func (ss *MediorumServer) readBlob(ctx context.Context, key string) (*blob.Reader, *blob.Bucket, error) {
+	r, err := ss.bucket.NewReader(ctx, key, nil)
+	if err == nil {
+		return r, ss.bucket, nil
+	}
+	if ss.archiveBucket == nil || gcerrors.Code(err) != gcerrors.NotFound {
+		return nil, nil, err
+	}
+	r2, err2 := ss.archiveBucket.NewReader(ctx, key, nil)
+	if err2 == nil {
+		return r2, ss.archiveBucket, nil
+	}
+	return nil, nil, err
+}
+
+// blobExists reports whether the blob is in either bucket.
+func (ss *MediorumServer) blobExists(ctx context.Context, key string) bool {
+	if ok, _ := ss.bucket.Exists(ctx, key); ok {
+		return true
+	}
+	if ss.archiveBucket != nil {
+		if ok, _ := ss.archiveBucket.Exists(ctx, key); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/mediorum/server/bucket_select.go
+++ b/pkg/mediorum/server/bucket_select.go
@@ -1,9 +1,35 @@
 package server
 
 import (
+	"net/http"
+	"strings"
+
 	"gocloud.dev/blob"
 	"golang.org/x/exp/slices"
 )
+
+// placementHostsHeader carries upload placement context across peer-to-peer
+// /internal/blobs requests. Without it, a receiver on a StoreAll node with an
+// archive bucket configured would route purely by rendezvous rank and could
+// place a placement-required CID into archive while readers with placement
+// context expect it in primary.
+//
+// The header is unsigned (no auth value to manipulating it; effect is local
+// routing only) and absent on the wire means "no placement context — route by
+// rank," matching pre-header behavior for backwards compatibility.
+const placementHostsHeader = "X-Placement-Hosts"
+
+func encodePlacementHosts(hosts []string) string {
+	return strings.Join(hosts, ",")
+}
+
+func decodePlacementHosts(h http.Header) []string {
+	v := h.Get(placementHostsHeader)
+	if v == "" {
+		return nil
+	}
+	return strings.Split(v, ",")
+}
 
 // bucketForCID returns the bucket that should hold this CID on this node.
 //

--- a/pkg/mediorum/server/bucket_select.go
+++ b/pkg/mediorum/server/bucket_select.go
@@ -90,6 +90,11 @@ func (ss *MediorumServer) presenceCacheKey(key string, bucket *blob.Bucket) stri
 // in. Reads should always go through this (or readBlob/blobExists) rather
 // than calling bucketForCID directly — bucketForCID is for picking write
 // destinations; on reads we want hot first, archive as a tier.
+//
+// Error semantics: a transient/permission error from archive surfaces to the
+// caller rather than being masked by the primary's NotFound, so upstream code
+// distinguishes "blob doesn't exist anywhere" from "archive is unhealthy."
+// Only when both buckets report NotFound do we return the primary NotFound.
 func (ss *MediorumServer) blobAttrs(ctx context.Context, key string) (*blob.Attributes, *blob.Bucket, error) {
 	attrs, err := ss.bucket.Attributes(ctx, key)
 	if err == nil {
@@ -102,12 +107,18 @@ func (ss *MediorumServer) blobAttrs(ctx context.Context, key string) (*blob.Attr
 	if err2 == nil {
 		return a2, ss.archiveBucket, nil
 	}
-	// Surface the original primary error (callers distinguish on NotFound).
+	if gcerrors.Code(err2) != gcerrors.NotFound {
+		// Real archive failure (permission, transient I/O). Surface it so
+		// callers see the actual problem instead of a misleading 404.
+		return nil, nil, err2
+	}
 	return nil, nil, err
 }
 
 // readBlob opens a reader from primary first, falling back to archive on
-// NotFound. Returns the bucket the blob was found in.
+// NotFound. Returns the bucket the blob was found in. Same error semantics
+// as blobAttrs: archive failures surface; only both-NotFound returns
+// primary's NotFound.
 func (ss *MediorumServer) readBlob(ctx context.Context, key string) (*blob.Reader, *blob.Bucket, error) {
 	r, err := ss.bucket.NewReader(ctx, key, nil)
 	if err == nil {
@@ -119,6 +130,9 @@ func (ss *MediorumServer) readBlob(ctx context.Context, key string) (*blob.Reade
 	r2, err2 := ss.archiveBucket.NewReader(ctx, key, nil)
 	if err2 == nil {
 		return r2, ss.archiveBucket, nil
+	}
+	if gcerrors.Code(err2) != gcerrors.NotFound {
+		return nil, nil, err2
 	}
 	return nil, nil, err
 }

--- a/pkg/mediorum/server/bucket_select_test.go
+++ b/pkg/mediorum/server/bucket_select_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OpenAudio/go-openaudio/pkg/common"
+	"github.com/OpenAudio/go-openaudio/pkg/registrar"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/memblob"
+)
+
+// makeBucketSelectorServer returns a *MediorumServer wired with just enough
+// fields for bucketForCID / isArchiveCID / disk-space helpers to exercise their
+// logic. No DB, no HTTP, no peers — just config + buckets + hasher.
+//
+// Hosts are five fake URLs; selfIdx picks which one is "this node." The
+// ranking depends on the CID, so tests pick CIDs whose rank is known via
+// rendezvousAllHosts.
+func makeBucketSelectorServer(t *testing.T, primary, archive *blob.Bucket, storeAll bool, replicationFactor, selfIdx int) *MediorumServer {
+	t.Helper()
+	hosts := []string{
+		"http://node1.test",
+		"http://node2.test",
+		"http://node3.test",
+		"http://node4.test",
+		"http://node5.test",
+	}
+	hasher := common.NewRendezvousHasher(hosts, nil)
+	return &MediorumServer{
+		bucket:           primary,
+		archiveBucket:    archive,
+		rendezvousHasher: hasher,
+		logger:           zap.NewNop(),
+		Config: MediorumConfig{
+			Self:              registrar.Peer{Host: hosts[selfIdx]},
+			ReplicationFactor: replicationFactor,
+			StoreAll:          storeAll,
+		},
+	}
+}
+
+// findCIDByRank returns a CID string whose rendezvous rank for hosts[selfIdx]
+// matches wantRank. We brute-force a handful of candidates because the test
+// only needs *some* CID with a known rank, not a specific one.
+func findCIDByRank(t *testing.T, ss *MediorumServer, wantRank int) string {
+	t.Helper()
+	for i := 0; i < 5000; i++ {
+		cid := "QmTestCID" + string(rune('A'+(i%26))) + string(rune('a'+((i/26)%26))) + string(rune('0'+(i/(26*26)%10)))
+		ordered := ss.rendezvousHasher.Rank(cid)
+		for rank, h := range ordered {
+			if h == ss.Config.Self.Host && rank == wantRank {
+				return cid
+			}
+		}
+	}
+	t.Fatalf("could not synthesize CID with rank %d", wantRank)
+	return ""
+}
+
+func openMemBucket(t *testing.T) *blob.Bucket {
+	t.Helper()
+	b, err := blob.OpenBucket(context.Background(), "mem://")
+	if err != nil {
+		t.Fatalf("openMemBucket: %v", err)
+	}
+	t.Cleanup(func() { b.Close() })
+	return b
+}
+
+// TestBucketForCID covers the full truth table for the selector.
+func TestBucketForCID(t *testing.T) {
+	primary := openMemBucket(t)
+	archive := openMemBucket(t)
+
+	t.Run("archive nil always returns primary", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, nil, true, 3, 0)
+		cid := findCIDByRank(t, ss, 4) // would be archive if archive were set
+		assert.Same(t, primary, ss.bucketForCID(cid, nil))
+		assert.False(t, ss.isArchiveCID(cid, nil))
+	})
+
+	t.Run("StoreAll false returns primary even with archive set", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, false, 3, 0)
+		cid := findCIDByRank(t, ss, 4)
+		assert.Same(t, primary, ss.bucketForCID(cid, nil))
+		assert.False(t, ss.isArchiveCID(cid, nil))
+	})
+
+	t.Run("rank in replication range -> primary", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, true, 3, 0)
+		cid := findCIDByRank(t, ss, 0) // top of the rank
+		assert.Same(t, primary, ss.bucketForCID(cid, nil))
+		assert.False(t, ss.isArchiveCID(cid, nil))
+	})
+
+	t.Run("rank exactly at boundary (== ReplicationFactor) -> archive", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, true, 3, 0)
+		cid := findCIDByRank(t, ss, 3) // == ReplicationFactor, so out of range
+		assert.Same(t, archive, ss.bucketForCID(cid, nil))
+		assert.True(t, ss.isArchiveCID(cid, nil))
+	})
+
+	t.Run("rank well past replication range -> archive", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, true, 3, 0)
+		cid := findCIDByRank(t, ss, 4)
+		assert.Same(t, archive, ss.bucketForCID(cid, nil))
+		assert.True(t, ss.isArchiveCID(cid, nil))
+	})
+
+	t.Run("placementHosts always uses primary", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, true, 3, 0)
+		cid := findCIDByRank(t, ss, 4)
+		// placement-driven uploads must never go to archive even when StoreAll
+		// would otherwise route there
+		placement := []string{ss.Config.Self.Host, "http://other.test"}
+		assert.Same(t, primary, ss.bucketForCID(cid, placement))
+		assert.False(t, ss.isArchiveCID(cid, placement))
+	})
+
+	t.Run("ReplicationFactor=1, rank 1 -> archive", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, true, 1, 0)
+		cid := findCIDByRank(t, ss, 1)
+		assert.Same(t, archive, ss.bucketForCID(cid, nil))
+	})
+
+	t.Run("ReplicationFactor=1, rank 0 -> primary", func(t *testing.T) {
+		ss := makeBucketSelectorServer(t, primary, archive, true, 1, 0)
+		cid := findCIDByRank(t, ss, 0)
+		assert.Same(t, primary, ss.bucketForCID(cid, nil))
+	})
+}

--- a/pkg/mediorum/server/bucket_select_test.go
+++ b/pkg/mediorum/server/bucket_select_test.go
@@ -131,4 +131,14 @@ func TestBucketForCID(t *testing.T) {
 		cid := findCIDByRank(t, ss, 0)
 		assert.Same(t, primary, ss.bucketForCID(cid, nil))
 	})
+
+	t.Run("self not in hash ring (myRank<0) -> primary", func(t *testing.T) {
+		// Build a server whose Self.Host isn't in the rendezvous host list,
+		// simulating misconfiguration / mid-registration.
+		ss := makeBucketSelectorServer(t, primary, archive, true, 3, 0)
+		ss.Config.Self = registrar.Peer{Host: "http://stranger.test"}
+		// any CID will rank stranger.test at -1
+		assert.Same(t, primary, ss.bucketForCID("QmTestCIDA", nil))
+		assert.False(t, ss.isArchiveCID("QmTestCIDA", nil))
+	})
 }

--- a/pkg/mediorum/server/disk_space_test.go
+++ b/pkg/mediorum/server/disk_space_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/memblob"
 )
 
 // makeDiskSpaceServer is a minimal MediorumServer wired only for disk-space

--- a/pkg/mediorum/server/disk_space_test.go
+++ b/pkg/mediorum/server/disk_space_test.go
@@ -75,20 +75,40 @@ func TestDiskHasSpace_FilePrimaryUsesFallbackFreeBytes(t *testing.T) {
 }
 
 func TestDiskHasSpace_ArchiveBucketChecked(t *testing.T) {
-	// When archive is configured, diskHasSpace must AND-together both buckets.
+	// Archive disk only matters when archive can actually receive writes:
+	// archiveBucket open AND StoreAll true. Use a real (mem) archive bucket
+	// so archiveBucket is non-nil; gating still operates off DSN free-bytes.
+	archive := openMemBucket(t)
+
 	t.Run("primary plenty, archive tight -> false", func(t *testing.T) {
 		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
-			plentyFree, tightFree, nil, false)
+			plentyFree, tightFree, archive, true)
 		assert.False(t, ss.diskHasSpace())
 	})
 	t.Run("primary tight, archive plenty -> false", func(t *testing.T) {
 		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
-			tightFree, plentyFree, nil, false)
+			tightFree, plentyFree, archive, true)
 		assert.False(t, ss.diskHasSpace())
 	})
 	t.Run("both plenty -> true", func(t *testing.T) {
 		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
-			plentyFree, plentyFree, nil, false)
+			plentyFree, plentyFree, archive, true)
+		assert.True(t, ss.diskHasSpace())
+	})
+
+	t.Run("archive open but StoreAll=false -> archive ignored", func(t *testing.T) {
+		// non-StoreAll node with stray archive DSN: archive is logged as
+		// "unused" at startup and no CID will ever route there. Don't gate
+		// writes on its disk pressure.
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
+			plentyFree, tightFree, archive, false)
+		assert.True(t, ss.diskHasSpace())
+	})
+
+	t.Run("archive DSN set but bucket nil -> archive ignored", func(t *testing.T) {
+		// Defensive case: DSN string set but bucket open failed / not opened.
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
+			plentyFree, tightFree, nil, true)
 		assert.True(t, ss.diskHasSpace())
 	})
 }

--- a/pkg/mediorum/server/disk_space_test.go
+++ b/pkg/mediorum/server/disk_space_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/OpenAudio/go-openaudio/pkg/common"
+	"github.com/OpenAudio/go-openaudio/pkg/registrar"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gocloud.dev/blob"
+)
+
+// makeDiskSpaceServer is a minimal MediorumServer wired only for disk-space
+// helpers. Cached free-bytes values are passed in directly so we don't depend
+// on a real filesystem (the helpers fall back to the cached value when the DSN
+// can't be statfs'd).
+func makeDiskSpaceServer(env, primaryDSN, archiveDSN string, primaryFree, archiveFree uint64, archive *blob.Bucket, storeAll bool) *MediorumServer {
+	hosts := []string{
+		"http://node1.test",
+		"http://node2.test",
+		"http://node3.test",
+		"http://node4.test",
+		"http://node5.test",
+	}
+	return &MediorumServer{
+		archiveBucket:    archive,
+		mediorumPathFree: primaryFree,
+		archivePathFree:  archiveFree,
+		rendezvousHasher: common.NewRendezvousHasher(hosts, nil),
+		logger:           zap.NewNop(),
+		Config: MediorumConfig{
+			Env:                  env,
+			Self:                 registrar.Peer{Host: hosts[0]},
+			ReplicationFactor:    3,
+			BlobStoreDSN:         primaryDSN,
+			ArchiveBlobStoreDSN:  archiveDSN,
+			StoreAll:             storeAll,
+		},
+	}
+}
+
+const (
+	gb         = uint64(1e9)
+	plentyFree = 100 * gb
+	tightFree  = 5 * gb // below the 10GB threshold
+)
+
+func TestDiskHasSpace_NonProdAlwaysAllows(t *testing.T) {
+	// dev/stage/test should never gate writes on disk pressure
+	for _, env := range []string{"dev", "stage", "test", ""} {
+		ss := makeDiskSpaceServer(env, "file:///tmp/nope", "", tightFree, 0, nil, false)
+		assert.True(t, ss.diskHasSpace(), "env=%s should always allow", env)
+	}
+}
+
+func TestDiskHasSpace_NonFileBackendAlwaysAllows(t *testing.T) {
+	// S3 / GCS / Azure don't have local disk constraints; the helper must
+	// short-circuit to true regardless of the cached free-bytes value.
+	ss := makeDiskSpaceServer("prod", "s3://my-bucket?region=us-east-1", "", tightFree, 0, nil, false)
+	assert.True(t, ss.diskHasSpace())
+}
+
+func TestDiskHasSpace_FilePrimaryUsesFallbackFreeBytes(t *testing.T) {
+	// The DSN points at a path we can't statfs, so the helper falls back to
+	// the cached mediorumPathFree value (this mirrors the real prod path
+	// when the mount is briefly unavailable).
+	t.Run("plenty of space", func(t *testing.T) {
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/path", "", plentyFree, 0, nil, false)
+		assert.True(t, ss.diskHasSpace())
+	})
+	t.Run("below threshold", func(t *testing.T) {
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/path", "", tightFree, 0, nil, false)
+		assert.False(t, ss.diskHasSpace())
+	})
+}
+
+func TestDiskHasSpace_ArchiveBucketChecked(t *testing.T) {
+	// When archive is configured, diskHasSpace must AND-together both buckets.
+	t.Run("primary plenty, archive tight -> false", func(t *testing.T) {
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
+			plentyFree, tightFree, nil, false)
+		assert.False(t, ss.diskHasSpace())
+	})
+	t.Run("primary tight, archive plenty -> false", func(t *testing.T) {
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
+			tightFree, plentyFree, nil, false)
+		assert.False(t, ss.diskHasSpace())
+	})
+	t.Run("both plenty -> true", func(t *testing.T) {
+		ss := makeDiskSpaceServer("prod", "file:///nonexistent/primary", "file:///nonexistent/archive",
+			plentyFree, plentyFree, nil, false)
+		assert.True(t, ss.diskHasSpace())
+	})
+}
+
+func TestDiskHasSpaceForCID_RoutesToCorrectBucket(t *testing.T) {
+	// Use a real (mem) archive bucket so bucketForCID can route — disk-space
+	// gating logic operates off the DSN string, not the bucket itself.
+	archive := openMemBucket(t)
+	primary := openMemBucket(t)
+	hosts := []string{
+		"http://node1.test", "http://node2.test", "http://node3.test",
+		"http://node4.test", "http://node5.test",
+	}
+	hasher := common.NewRendezvousHasher(hosts, nil)
+
+	build := func(primaryFree, archiveFree uint64) *MediorumServer {
+		return &MediorumServer{
+			bucket:           primary,
+			archiveBucket:    archive,
+			mediorumPathFree: primaryFree,
+			archivePathFree:  archiveFree,
+			rendezvousHasher: hasher,
+			logger:           zap.NewNop(),
+			Config: MediorumConfig{
+				Env:                 "prod",
+				Self:                registrar.Peer{Host: hosts[0]},
+				ReplicationFactor:   3,
+				StoreAll:            true,
+				BlobStoreDSN:        "file:///nonexistent/primary",
+				ArchiveBlobStoreDSN: "file:///nonexistent/archive",
+			},
+		}
+	}
+
+	primaryCID := findCIDByRank(t, build(plentyFree, plentyFree), 0)  // routes to primary
+	archiveCID := findCIDByRank(t, build(plentyFree, plentyFree), 4) // routes to archive
+
+	t.Run("archive full does not block primary write", func(t *testing.T) {
+		ss := build(plentyFree, tightFree)
+		assert.True(t, ss.diskHasSpaceForCID(primaryCID, nil))
+		assert.False(t, ss.diskHasSpaceForCID(archiveCID, nil))
+	})
+
+	t.Run("primary full does not block archive write", func(t *testing.T) {
+		ss := build(tightFree, plentyFree)
+		assert.False(t, ss.diskHasSpaceForCID(primaryCID, nil))
+		assert.True(t, ss.diskHasSpaceForCID(archiveCID, nil))
+	})
+
+	t.Run("placementHosts force primary path even for high-rank CID", func(t *testing.T) {
+		// archive is full, primary has space; if the upload comes with an
+		// explicit placement list, the disk check must use primary's
+		// free-bytes (because writes will go to primary)
+		ss := build(plentyFree, tightFree)
+		placement := []string{ss.Config.Self.Host, hosts[1]}
+		assert.True(t, ss.diskHasSpaceForCID(archiveCID, placement))
+	})
+
+	t.Run("non-prod always true", func(t *testing.T) {
+		ss := build(tightFree, tightFree)
+		ss.Config.Env = "dev"
+		assert.True(t, ss.diskHasSpaceForCID(primaryCID, nil))
+		assert.True(t, ss.diskHasSpaceForCID(archiveCID, nil))
+	})
+}

--- a/pkg/mediorum/server/monitor.go
+++ b/pkg/mediorum/server/monitor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,7 +13,6 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/crudr"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
-	gcblob "gocloud.dev/blob"
 	"golang.org/x/exp/slices"
 	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
@@ -203,27 +201,19 @@ func (ss *MediorumServer) updateDiskAndDbStatus(ctx context.Context) {
 		slog.Error("Error getting mediorum disk status", "err", err, "path", diskPath)
 	}
 
-	// Archive bucket disk status (file:// only) and blob count.
-	if ss.archiveBucket != nil {
-		if strings.HasPrefix(ss.Config.ArchiveBlobStoreDSN, "file://") {
-			_, uri, found := strings.Cut(ss.Config.ArchiveBlobStoreDSN, "://")
-			if found {
-				archivePath := strings.Split(uri, "?")[0]
-				archiveTotal, archiveFree, archiveErr := getDiskStatus(archivePath)
-				if archiveErr == nil {
-					ss.archivePathFree = archiveFree
-					ss.archivePathUsed = archiveTotal - archiveFree
-					ss.archivePathSize = archiveTotal
-				} else {
-					slog.Error("Error getting archive disk status", "err", archiveErr, "path", archivePath)
-				}
+	// Archive bucket disk status (file:// only — mirrors primary's behavior).
+	if ss.archiveBucket != nil && strings.HasPrefix(ss.Config.ArchiveBlobStoreDSN, "file://") {
+		_, uri, found := strings.Cut(ss.Config.ArchiveBlobStoreDSN, "://")
+		if found {
+			archivePath := strings.Split(uri, "?")[0]
+			archiveTotal, archiveFree, archiveErr := getDiskStatus(archivePath)
+			if archiveErr == nil {
+				ss.archivePathFree = archiveFree
+				ss.archivePathUsed = archiveTotal - archiveFree
+				ss.archivePathSize = archiveTotal
+			} else {
+				slog.Error("Error getting archive disk status", "err", archiveErr, "path", archivePath)
 			}
-		}
-
-		if count, countErr := countBucketBlobs(ctx, ss.archiveBucket); countErr == nil {
-			ss.archiveBlobCount = count
-		} else {
-			slog.Error("Error counting archive bucket blobs", "err", countErr)
 		}
 	}
 
@@ -233,27 +223,6 @@ func (ss *MediorumServer) updateDiskAndDbStatus(ctx context.Context) {
 	slog.Info("running job")
 	if err != nil {
 		slog.Error("Error getting storage expectation", "err", err.Error())
-	}
-}
-
-func countBucketBlobs(ctx context.Context, bucket *gcblob.Bucket) (int64, error) {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
-	var count int64
-	iter := bucket.List(nil)
-	for {
-		obj, err := iter.Next(ctx)
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return count, nil
-			}
-			return count, err
-		}
-		if obj == nil || obj.IsDir {
-			continue
-		}
-		count++
 	}
 }
 

--- a/pkg/mediorum/server/monitor.go
+++ b/pkg/mediorum/server/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/crudr"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
+	gcblob "gocloud.dev/blob"
 	"golang.org/x/exp/slices"
 	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
@@ -200,12 +202,58 @@ func (ss *MediorumServer) updateDiskAndDbStatus(ctx context.Context) {
 	} else {
 		slog.Error("Error getting mediorum disk status", "err", err, "path", diskPath)
 	}
+
+	// Archive bucket disk status (file:// only) and blob count.
+	if ss.archiveBucket != nil {
+		if strings.HasPrefix(ss.Config.ArchiveBlobStoreDSN, "file://") {
+			_, uri, found := strings.Cut(ss.Config.ArchiveBlobStoreDSN, "://")
+			if found {
+				archivePath := strings.Split(uri, "?")[0]
+				archiveTotal, archiveFree, archiveErr := getDiskStatus(archivePath)
+				if archiveErr == nil {
+					ss.archivePathFree = archiveFree
+					ss.archivePathUsed = archiveTotal - archiveFree
+					ss.archivePathSize = archiveTotal
+				} else {
+					slog.Error("Error getting archive disk status", "err", archiveErr, "path", archivePath)
+				}
+			}
+		}
+
+		if count, countErr := countBucketBlobs(ctx, ss.archiveBucket); countErr == nil {
+			ss.archiveBlobCount = count
+		} else {
+			slog.Error("Error counting archive bucket blobs", "err", countErr)
+		}
+	}
+
 	ss.storageExpectation, err = getStorageExpectation(ctx, ss.pgPool, ss.Config.ReplicationFactor)
 	slog.Info("Storage expectation", "size", ss.storageExpectation)
 	slog.Info("Replication factor", "replicationFactor", ss.Config.ReplicationFactor)
 	slog.Info("running job")
 	if err != nil {
 		slog.Error("Error getting storage expectation", "err", err.Error())
+	}
+}
+
+func countBucketBlobs(ctx context.Context, bucket *gcblob.Bucket) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	var count int64
+	iter := bucket.List(nil)
+	for {
+		obj, err := iter.Next(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return count, nil
+			}
+			return count, err
+		}
+		if obj == nil || obj.IsDir {
+			continue
+		}
+		count++
 	}
 }
 

--- a/pkg/mediorum/server/pos.go
+++ b/pkg/mediorum/server/pos.go
@@ -72,7 +72,7 @@ func (ss *MediorumServer) startPoSHandler(ctx context.Context) error {
 func (ss *MediorumServer) getStorageProof(ctx context.Context, cid string, nonce []byte) ([]byte, error) {
 	key := cidutil.ShardCID(cid)
 	var proof []byte
-	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
+	blob, _, err := ss.readBlob(ctx, key)
 	if err != nil {
 		return proof, err
 	}

--- a/pkg/mediorum/server/pos.go
+++ b/pkg/mediorum/server/pos.go
@@ -72,7 +72,7 @@ func (ss *MediorumServer) startPoSHandler(ctx context.Context) error {
 func (ss *MediorumServer) getStorageProof(ctx context.Context, cid string, nonce []byte) ([]byte, error) {
 	key := cidutil.ShardCID(cid)
 	var proof []byte
-	blob, err := ss.bucket.NewReader(ctx, key, nil)
+	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
 	if err != nil {
 		return proof, err
 	}

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -382,11 +382,14 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	}
 
 	// Resolve blob presence: use the presence index (from bucket.List) if
-	// available, otherwise fall back to per-key HeadObject.
+	// available, otherwise fall back to per-key HeadObject. The lookup is
+	// bucket-scoped — if the key only exists in the *other* bucket
+	// (rank-flip orphan), treat as missing so the repair pull below writes
+	// it into the bucket the routing decision selected.
 	alreadyHave := false
 	attrs := &blob.Attributes{}
 	if presenceIndex != nil {
-		if entry, ok := presenceIndex.Lookup(key); ok {
+		if entry, ok := presenceIndex.Lookup(key, bucket); ok {
 			alreadyHave = true
 			attrs.Size = entry.Size
 			attrs.ModTime = entry.ModTime

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -352,6 +352,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	key := cidutil.ShardCID(cid)
 	bucket := ss.bucketForCID(cid, placementHosts)
 	isArchive := ss.archiveBucket != nil && bucket == ss.archiveBucket
+	presenceKey := ss.presenceCacheKey(key, bucket)
 
 	// Per-cycle dedupe: repair iterates uploads, audio_previews, and qm_cids,
 	// and the same CID can appear across those tables. Skip the duplicate
@@ -372,7 +373,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	// previous cycle. Cleanup cycles bypass the cache because they need
 	// ModTime for over-replication decisions and run full blob validation.
 	if !tracker.CleanupMode {
-		if size, ok := ss.knownPresent.Get(key); ok {
+		if size, ok := ss.knownPresent.Get(presenceKey); ok {
 			tracker.SeenKeys[key] = seenKeyResult{alreadyHave: true, size: size}
 			tracker.Counters["already_have"]++
 			tracker.Counters["repair_known_present"]++
@@ -441,7 +442,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 				if errDel := bucket.Delete(ctx, key); errDel == nil {
 					tracker.Counters["delete_invalid_success"]++
 					tracker.SeenKeys[key] = seenKeyResult{alreadyHave: false, size: 0}
-					ss.knownPresent.Remove(key)
+					ss.knownPresent.Remove(presenceKey)
 				} else {
 					tracker.Counters["delete_invalid_fail"]++
 					logger.Error("failed to delete invalid CID", zap.Error(errDel))
@@ -471,7 +472,8 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 				tracker.Counters["delete_resized_image_failed"]++
 			} else {
 				tracker.Counters["delete_resized_image_ok"]++
-				ss.knownPresent.Remove(key)
+				// Variants always live in primary; only the primary cache key matters.
+				ss.knownPresent.Remove(ss.presenceCacheKey(key, ss.bucket))
 			}
 		}
 		return nil
@@ -480,7 +482,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	if alreadyHave {
 		// Populate cross-cycle cache after all validation and cleanup has passed,
 		// so that corrupt or about-to-be-deleted blobs are never cached.
-		ss.knownPresent.Set(key, attrs.Size, imcache.WithNoExpiration())
+		ss.knownPresent.Set(presenceKey, attrs.Size, imcache.WithNoExpiration())
 		tracker.Counters["already_have"]++
 		tracker.ContentSize += attrs.Size
 	}

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -459,15 +459,19 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		}
 	}
 
-	// delete derived image variants since they'll be dynamically resized
+	// Delete derived image variants since they'll be dynamically resized.
+	// Variants are pure cache — generated on-demand by serveImage and
+	// always written to the primary bucket regardless of where the
+	// original lives — so cleanup only needs to touch primary.
 	if strings.HasSuffix(cid, ".jpg") && !strings.HasSuffix(cid, "original.jpg") {
 		if tracker.CleanupMode && alreadyHave {
-			err := ss.dropFromMyBucket(cid, placementHosts)
-			if err != nil {
+			err := ss.bucket.Delete(ctx, key)
+			if err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 				logger.Error("delete_resized_image_failed", zap.Error(err))
 				tracker.Counters["delete_resized_image_failed"]++
 			} else {
 				tracker.Counters["delete_resized_image_ok"]++
+				ss.knownPresent.Remove(key)
 			}
 		}
 		return nil

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -394,6 +394,9 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 			attrs.Size = entry.Size
 			attrs.ModTime = entry.ModTime
 			tracker.Counters["qm_cids_list_index_hit"]++
+			if isArchive {
+				tracker.Counters["archive_blob_present"]++
+			}
 		} else {
 			tracker.Counters["qm_cids_list_index_miss"]++
 		}

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -544,7 +544,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > rankThreshold && !wasReplicatedThisWeek {
 		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
 		tracker.Counters["delete_over_replicated_needed"]++
-		err := ss.dropFromMyBucket(cid, placementHosts)
+		err := ss.dropFromMyBucket(cid)
 		if err != nil {
 			tracker.Counters["delete_over_replicated_fail"]++
 			logger.Error("delete failed", zap.Error(err))

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -456,7 +456,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	// delete derived image variants since they'll be dynamically resized
 	if strings.HasSuffix(cid, ".jpg") && !strings.HasSuffix(cid, "original.jpg") {
 		if tracker.CleanupMode && alreadyHave {
-			err := ss.dropFromMyBucket(cid)
+			err := ss.dropFromMyBucket(cid, placementHosts)
 			if err != nil {
 				logger.Error("delete_resized_image_failed", zap.Error(err))
 				tracker.Counters["delete_resized_image_failed"]++
@@ -485,7 +485,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 			if host == ss.Config.Self.Host {
 				continue
 			}
-			err := ss.pullFileFromHost(ctx, host, cid)
+			err := ss.pullFileFromHost(ctx, host, cid, placementHosts)
 			if err != nil {
 				tracker.Counters["pull_mine_fail"]++
 				logger.Error("pull failed (blob I should have)", zap.Error(err), zap.String("host", host))
@@ -532,7 +532,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > rankThreshold && !wasReplicatedThisWeek {
 		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
 		tracker.Counters["delete_over_replicated_needed"]++
-		err := ss.dropFromMyBucket(cid)
+		err := ss.dropFromMyBucket(cid, placementHosts)
 		if err != nil {
 			tracker.Counters["delete_over_replicated_fail"]++
 			logger.Error("delete failed", zap.Error(err))

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -350,6 +350,8 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	myRank := slices.Index(preferredHosts, ss.Config.Self.Host)
 
 	key := cidutil.ShardCID(cid)
+	bucket := ss.bucketForCID(cid, placementHosts)
+	isArchive := ss.archiveBucket != nil && bucket == ss.archiveBucket
 
 	// Per-cycle dedupe: repair iterates uploads, audio_previews, and qm_cids,
 	// and the same CID can appear across those tables. Skip the duplicate
@@ -394,17 +396,23 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		}
 	} else {
 		var err error
-		attrs, err = ss.bucket.Attributes(ctx, key)
+		attrs, err = bucket.Attributes(ctx, key)
 		if err != nil {
 			if gcerrors.Code(err) == gcerrors.NotFound || strings.Contains(err.Error(), "notFound") {
 				attrs = &blob.Attributes{}
 			} else {
 				tracker.Counters["read_attrs_fail"]++
+				if isArchive {
+					tracker.Counters["archive_blob_attrs_fail"]++
+				}
 				logger.Error("exist check failed", zap.Error(err))
 				attrs = &blob.Attributes{}
 			}
 		} else {
 			alreadyHave = true
+			if isArchive {
+				tracker.Counters["archive_blob_present"]++
+			}
 		}
 	}
 
@@ -414,7 +422,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	// in cleanup mode do some extra checks:
 	// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
 	if tracker.CleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
-		if r, errRead := ss.bucket.NewReader(ctx, key, nil); errRead == nil {
+		if r, errRead := bucket.NewReader(ctx, key, nil); errRead == nil {
 			computed, errCompute := cidutil.ComputeFileCID(r)
 			errClose := r.Close()
 			if errCompute != nil {
@@ -424,7 +432,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 			} else if computed != cid {
 				tracker.Counters["delete_invalid_needed"]++
 				logger.Error("deleting invalid CID", zap.String("expected", cid), zap.String("computed", computed))
-				if errDel := ss.bucket.Delete(ctx, key); errDel == nil {
+				if errDel := bucket.Delete(ctx, key); errDel == nil {
 					tracker.Counters["delete_invalid_success"]++
 					tracker.SeenKeys[key] = seenKeyResult{alreadyHave: false, size: 0}
 					ss.knownPresent.Remove(key)
@@ -468,7 +476,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	}
 
 	// get blobs that I should have (regardless of health of other nodes)
-	if isMine && !alreadyHave && ss.diskHasSpace() {
+	if isMine && !alreadyHave && ss.diskHasSpaceForCID(cid, placementHosts) {
 		tracker.Counters["pull_mine_needed"]++
 
 		success := false
@@ -483,10 +491,13 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 				logger.Error("pull failed (blob I should have)", zap.Error(err), zap.String("host", host))
 			} else {
 				tracker.Counters["pull_mine_success"]++
+				if isArchive {
+					tracker.Counters["archive_blob_pulled"]++
+				}
 				logger.Debug("pull OK (blob I should have)", zap.String("host", host))
 				success = true
 
-				pulledAttrs, errAttrs := ss.bucket.Attributes(ctx, key)
+				pulledAttrs, errAttrs := bucket.Attributes(ctx, key)
 				if errAttrs == nil {
 					tracker.ContentSize += pulledAttrs.Size
 				}

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -11,36 +11,34 @@ import (
 type presenceEntry struct {
 	Size    int64
 	ModTime time.Time
-	// Bucket records which bucket the listing came from. Repair must check
-	// this against bucketForCID(cid, placementHosts) for each lookup; a key
-	// present in the *wrong* bucket (e.g. an orphan from a rank flip) must
-	// be treated as missing so the repair pull lands in the correct bucket.
-	Bucket *blob.Bucket
+}
+
+// indexKey scopes a presence entry to a specific bucket. A CID can legitimately
+// exist in both buckets (e.g. a rank-flip orphan plus the freshly-pulled correct
+// copy); a single map keyed only by storage key would have the second listing
+// overwrite the first, hiding the bucket the caller is asking about.
+type indexKey struct {
+	key    string
+	bucket *blob.Bucket
 }
 
 // repairPresenceIndex holds the result of a bucket.List call as an in-memory
 // map, allowing O(1) presence checks instead of per-key HeadObject calls.
 type repairPresenceIndex struct {
-	entries map[string]presenceEntry
+	entries map[indexKey]presenceEntry
 }
 
-// Lookup returns the entry for key only if the listing came from wantBucket.
-// A merged index that contains the key under a different bucket reports
-// "missing" — repair will then pull the blob into the bucket it expects.
+// Lookup returns the entry for key in wantBucket. A key that exists only in
+// the *other* bucket (rank-flip orphan) reports missing here so repair will
+// pull a fresh copy into the bucket bucketForCID selected.
 func (idx *repairPresenceIndex) Lookup(key string, wantBucket *blob.Bucket) (presenceEntry, bool) {
-	entry, ok := idx.entries[key]
-	if !ok {
-		return entry, false
-	}
-	if entry.Bucket != wantBucket {
-		return presenceEntry{}, false
-	}
-	return entry, true
+	entry, ok := idx.entries[indexKey{key: key, bucket: wantBucket}]
+	return entry, ok
 }
 
 func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repairPresenceIndex, error) {
 	index := &repairPresenceIndex{
-		entries: make(map[string]presenceEntry),
+		entries: make(map[indexKey]presenceEntry),
 	}
 
 	if err := listIntoIndex(ctx, ss.bucket, index); err != nil {
@@ -67,10 +65,9 @@ func listIntoIndex(ctx context.Context, bucket *blob.Bucket, index *repairPresen
 		if obj == nil || obj.IsDir {
 			continue
 		}
-		index.entries[obj.Key] = presenceEntry{
+		index.entries[indexKey{key: obj.Key, bucket: bucket}] = presenceEntry{
 			Size:    obj.Size,
 			ModTime: obj.ModTime,
-			Bucket:  bucket,
 		}
 	}
 }

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -44,7 +44,10 @@ func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repair
 	if err := listIntoIndex(ctx, ss.bucket, index); err != nil {
 		return nil, err
 	}
-	if ss.archiveBucket != nil {
+	// Only list archive when it can actually receive routing. With StoreAll
+	// off, bucketForCID never returns archive — listing it is pure overhead
+	// (and potentially expensive for cloud backends with many objects).
+	if ss.archiveBucket != nil && ss.Config.StoreAll {
 		if err := listIntoIndex(ctx, ss.archiveBucket, index); err != nil {
 			return nil, err
 		}

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -11,6 +11,11 @@ import (
 type presenceEntry struct {
 	Size    int64
 	ModTime time.Time
+	// Bucket records which bucket the listing came from. Repair must check
+	// this against bucketForCID(cid, placementHosts) for each lookup; a key
+	// present in the *wrong* bucket (e.g. an orphan from a rank flip) must
+	// be treated as missing so the repair pull lands in the correct bucket.
+	Bucket *blob.Bucket
 }
 
 // repairPresenceIndex holds the result of a bucket.List call as an in-memory
@@ -19,9 +24,18 @@ type repairPresenceIndex struct {
 	entries map[string]presenceEntry
 }
 
-func (idx *repairPresenceIndex) Lookup(key string) (presenceEntry, bool) {
+// Lookup returns the entry for key only if the listing came from wantBucket.
+// A merged index that contains the key under a different bucket reports
+// "missing" — repair will then pull the blob into the bucket it expects.
+func (idx *repairPresenceIndex) Lookup(key string, wantBucket *blob.Bucket) (presenceEntry, bool) {
 	entry, ok := idx.entries[key]
-	return entry, ok
+	if !ok {
+		return entry, false
+	}
+	if entry.Bucket != wantBucket {
+		return presenceEntry{}, false
+	}
+	return entry, true
 }
 
 func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repairPresenceIndex, error) {
@@ -56,6 +70,7 @@ func listIntoIndex(ctx context.Context, bucket *blob.Bucket, index *repairPresen
 		index.entries[obj.Key] = presenceEntry{
 			Size:    obj.Size,
 			ModTime: obj.ModTime,
+			Bucket:  bucket,
 		}
 	}
 }

--- a/pkg/mediorum/server/repair_presence_index.go
+++ b/pkg/mediorum/server/repair_presence_index.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"time"
+
+	"gocloud.dev/blob"
 )
 
 type presenceEntry struct {
@@ -23,18 +25,30 @@ func (idx *repairPresenceIndex) Lookup(key string) (presenceEntry, bool) {
 }
 
 func (ss *MediorumServer) buildRepairPresenceIndex(ctx context.Context) (*repairPresenceIndex, error) {
-	iter := ss.bucket.List(nil)
 	index := &repairPresenceIndex{
 		entries: make(map[string]presenceEntry),
 	}
 
+	if err := listIntoIndex(ctx, ss.bucket, index); err != nil {
+		return nil, err
+	}
+	if ss.archiveBucket != nil {
+		if err := listIntoIndex(ctx, ss.archiveBucket, index); err != nil {
+			return nil, err
+		}
+	}
+	return index, nil
+}
+
+func listIntoIndex(ctx context.Context, bucket *blob.Bucket, index *repairPresenceIndex) error {
+	iter := bucket.List(nil)
 	for {
 		obj, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
-				return index, nil
+				return nil
 			}
-			return nil, err
+			return err
 		}
 		if obj == nil || obj.IsDir {
 			continue

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -50,7 +50,7 @@ func TestRepair(t *testing.T) {
 	data := []byte("repair test")
 	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
 	assert.NoError(t, err)
-	err = ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data))
+	err = ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data), nil)
 	assert.NoError(t, err)
 
 	// create a dummy upload for it?
@@ -103,7 +103,7 @@ func TestRepair(t *testing.T) {
 	// now over-replicate file
 	//
 	for _, server := range testNetwork {
-		ss.replicateFileToHost(ctx, server.Config.Self.Host, cid, bytes.NewReader(data))
+		ss.replicateFileToHost(ctx, server.Config.Self.Host, cid, bytes.NewReader(data), nil)
 	}
 
 	// assert over-replicated
@@ -137,7 +137,7 @@ func TestRepair(t *testing.T) {
 
 		// make leader lose file
 		leader := rendezvousOrder[0]
-		leader.dropFromMyBucket(cid)
+		leader.dropFromMyBucket(cid, nil)
 
 		// normally a standby server wouldn't pull this file
 		standby := rendezvousOrder[replicationFactor+2]
@@ -170,7 +170,7 @@ func TestBuildRepairPresenceIndexIncludesLocalBlob(t *testing.T) {
 	data := []byte("presence-index-local-blob")
 	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
 	assert.NoError(t, err)
-	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data), nil))
 
 	index, err := ss.buildRepairPresenceIndex(ctx)
 	assert.NoError(t, err)
@@ -187,14 +187,14 @@ func TestRepairCidWithPresenceIndexUsesListedState(t *testing.T) {
 	data := []byte("presence-index-repair-path")
 	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
 	assert.NoError(t, err)
-	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data), nil))
 
 	index, err := ss.buildRepairPresenceIndex(ctx)
 	assert.NoError(t, err)
 
 	key := cidutil.ShardCID(cid)
 	ss.knownPresent.Remove(key)
-	assert.NoError(t, ss.dropFromMyBucket(cid))
+	assert.NoError(t, ss.dropFromMyBucket(cid, nil))
 
 	tracker := &RepairTracker{
 		StartedAt:   time.Now(),
@@ -215,7 +215,7 @@ func TestRepairCidUsesKnownPresentOutsideCleanup(t *testing.T) {
 	data := []byte("known-present-fast-path")
 	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
 	assert.NoError(t, err)
-	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data)))
+	assert.NoError(t, ss.replicateToMyBucket(ctx, cid, bytes.NewReader(data), nil))
 
 	tracker := &RepairTracker{
 		StartedAt:   time.Now(),

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -193,7 +193,7 @@ func TestRepairCidWithPresenceIndexUsesListedState(t *testing.T) {
 	assert.NoError(t, err)
 
 	key := cidutil.ShardCID(cid)
-	ss.knownPresent.Remove(key)
+	ss.knownPresent.Remove(ss.presenceCacheKey(key, ss.bucket))
 	assert.NoError(t, ss.dropFromMyBucket(cid, nil))
 
 	tracker := &RepairTracker{

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -137,7 +137,7 @@ func TestRepair(t *testing.T) {
 
 		// make leader lose file
 		leader := rendezvousOrder[0]
-		leader.dropFromMyBucket(cid, nil)
+		leader.dropFromMyBucket(cid)
 
 		// normally a standby server wouldn't pull this file
 		standby := rendezvousOrder[replicationFactor+2]
@@ -194,7 +194,7 @@ func TestRepairCidWithPresenceIndexUsesListedState(t *testing.T) {
 
 	key := cidutil.ShardCID(cid)
 	ss.knownPresent.Remove(ss.presenceCacheKey(key, ss.bucket))
-	assert.NoError(t, ss.dropFromMyBucket(cid, nil))
+	assert.NoError(t, ss.dropFromMyBucket(cid))
 
 	tracker := &RepairTracker{
 		StartedAt:   time.Now(),

--- a/pkg/mediorum/server/repair_test.go
+++ b/pkg/mediorum/server/repair_test.go
@@ -175,7 +175,7 @@ func TestBuildRepairPresenceIndexIncludesLocalBlob(t *testing.T) {
 	index, err := ss.buildRepairPresenceIndex(ctx)
 	assert.NoError(t, err)
 
-	entry, ok := index.Lookup(cidutil.ShardCID(cid))
+	entry, ok := index.Lookup(cidutil.ShardCID(cid), ss.bucket)
 	assert.True(t, ok)
 	assert.Equal(t, int64(len(data)), entry.Size)
 }

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -23,16 +23,20 @@ import (
 func (ss *MediorumServer) replicateFileParallel(ctx context.Context, cid string, filePath string, placementHosts []string) ([]string, error) {
 	replicaCount := ss.Config.ReplicationFactor
 
-	if len(placementHosts) > 0 {
-		// use all explicit placement hosts
-		replicaCount = len(placementHosts)
+	// Preserve the original placement context separately from the host list
+	// we iterate. bucketForCID treats any non-empty placementHosts as "force
+	// primary," so we must NOT pass the rendezvous-expanded list when the
+	// upload had no explicit placement.
+	originalPlacement := placementHosts
+	hosts := placementHosts
+	if len(hosts) > 0 {
+		replicaCount = len(hosts)
 	} else {
-		// use rendezvous
-		placementHosts, _ = ss.rendezvousAllHosts(cid)
+		hosts, _ = ss.rendezvousAllHosts(cid)
 	}
 
-	queue := make(chan string, len(placementHosts))
-	for _, p := range placementHosts {
+	queue := make(chan string, len(hosts))
+	for _, p := range hosts {
 		queue <- p
 	}
 
@@ -54,7 +58,7 @@ func (ss *MediorumServer) replicateFileParallel(ctx context.Context, cid string,
 			defer file.Close()
 			for peer := range queue {
 				file.Seek(0, 0)
-				err := ss.replicateFileToHost(ctx, peer, cid, file)
+				err := ss.replicateFileToHost(ctx, peer, cid, file, originalPlacement)
 				if err == nil {
 					mu.Lock()
 					results = append(results, peer)
@@ -81,7 +85,7 @@ func (ss *MediorumServer) replicateFile(ctx context.Context, fileName string, fi
 		logger.Debug("replicating")
 
 		file.Seek(0, 0)
-		err := ss.replicateFileToHost(ctx, peer, fileName, file)
+		err := ss.replicateFileToHost(ctx, peer, fileName, file, nil)
 		if err != nil {
 			logger.Error("replication failed", zap.Error(err))
 		} else {
@@ -96,12 +100,16 @@ func (ss *MediorumServer) replicateFile(ctx context.Context, fileName string, fi
 	return success, nil
 }
 
-func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName string, file io.Reader) error {
+// replicateToMyBucket writes the blob to the bucket selected by bucketForCID.
+// placementHosts MUST be passed when the caller has placement context (repair,
+// upload replication path) so writes go to the same bucket reads expect.
+// Pass nil for opportunistic peer pushes that have no placement context.
+func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName string, file io.Reader, placementHosts []string) error {
 	logger := ss.logger.With(zap.String("task", "replicateToMyBucket"), zap.String("cid", fileName))
 	logger.Debug("replicateToMyBucket")
 	key := cidutil.ShardCID(fileName)
 
-	w, err := ss.bucketForCID(fileName, nil).NewWriter(ctx, key, nil)
+	w, err := ss.bucketForCID(fileName, placementHosts).NewWriter(ctx, key, nil)
 	if err != nil {
 		return err
 	}
@@ -119,13 +127,13 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 	return nil
 }
 
-func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
+func (ss *MediorumServer) dropFromMyBucket(fileName string, placementHosts []string) error {
 	logger := ss.logger.With(zap.String("task", "dropFromMyBucket"), zap.String("cid", fileName))
 	logger.Debug("deleting blob")
 
 	key := cidutil.ShardCID(fileName)
 	ctx := context.Background()
-	err := ss.bucketForCID(fileName, nil).Delete(ctx, key)
+	err := ss.bucketForCID(fileName, placementHosts).Delete(ctx, key)
 	if err != nil {
 		logger.Error("failed to delete", zap.Error(err))
 	} else {
@@ -135,17 +143,17 @@ func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
 	return nil
 }
 
-func (ss *MediorumServer) haveInMyBucket(fileName string) bool {
+func (ss *MediorumServer) haveInMyBucket(fileName string, placementHosts []string) bool {
 	shardedCid := cidutil.ShardCID(fileName)
 	ctx := context.Background()
-	exists, _ := ss.bucketForCID(fileName, nil).Exists(ctx, shardedCid)
+	exists, _ := ss.bucketForCID(fileName, placementHosts).Exists(ctx, shardedCid)
 	return exists
 }
 
-func (ss *MediorumServer) replicateFileToHost(ctx context.Context, peer string, fileName string, file io.Reader) error {
+func (ss *MediorumServer) replicateFileToHost(ctx context.Context, peer string, fileName string, file io.Reader, placementHosts []string) error {
 	// logger := ss.logger.With()
 	if peer == ss.Config.Self.Host {
-		return ss.replicateToMyBucket(ctx, fileName, file)
+		return ss.replicateToMyBucket(ctx, fileName, file, placementHosts)
 	}
 
 	r, w := io.Pipe()
@@ -212,7 +220,11 @@ func (ss *MediorumServer) hostGetBlobInfo(host, key string) (*blob.Attributes, e
 	return attr, nil
 }
 
-func (ss *MediorumServer) pullFileFromHost(ctx context.Context, host, cid string) error {
+// pullFileFromHost fetches a CID from a peer and writes it to the bucket
+// selected by bucketForCID(cid, placementHosts). Pass placementHosts when the
+// caller has placement context (repair) so the local write lands in the same
+// bucket reads expect; pass nil for opportunistic pulls (e.g. serveBlob fallback).
+func (ss *MediorumServer) pullFileFromHost(ctx context.Context, host, cid string, placementHosts []string) error {
 	if host == ss.Config.Self.Host {
 		return errors.New("should not pull blob from self")
 	}
@@ -233,7 +245,7 @@ func (ss *MediorumServer) pullFileFromHost(ctx context.Context, host, cid string
 		return fmt.Errorf("pull blob: bad status: %d cid: %s host: %s", resp.StatusCode, cid, host)
 	}
 
-	return ss.replicateToMyBucket(ctx, cid, resp.Body)
+	return ss.replicateToMyBucket(ctx, cid, resp.Body, placementHosts)
 }
 
 // dsnHasSpace reports whether a file:// DSN has enough free disk to accept new
@@ -275,9 +287,10 @@ func (ss *MediorumServer) dsnHasSpace(dsn string, fallbackFreeBytes uint64) bool
 	return hasSpace
 }
 
-// diskHasSpace returns true only when every configured bucket has headroom.
-// Used by paths that don't have a CID yet (e.g. the inbound /internal/blobs
-// precheck) so we don't accept a write that we can't actually place.
+// diskHasSpace returns true only when every configured bucket that can
+// actually receive writes has headroom. Used by paths that don't have a CID
+// yet (e.g. the inbound /internal/blobs precheck) so we don't accept a write
+// we can't place.
 func (ss *MediorumServer) diskHasSpace() bool {
 	if ss.Config.Env != "prod" {
 		return true
@@ -285,7 +298,10 @@ func (ss *MediorumServer) diskHasSpace() bool {
 	if !ss.dsnHasSpace(ss.Config.BlobStoreDSN, ss.mediorumPathFree) {
 		return false
 	}
-	if ss.Config.ArchiveBlobStoreDSN != "" {
+	// Archive only routes when archiveBucket is open AND StoreAll is on. If
+	// the DSN is set but StoreAll is false, archive is logged as "unused" at
+	// startup and no CID will ever land there — don't gate writes on it.
+	if ss.archiveBucket != nil && ss.Config.StoreAll {
 		if !ss.dsnHasSpace(ss.Config.ArchiveBlobStoreDSN, ss.archivePathFree) {
 			return false
 		}

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -101,7 +101,7 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 	logger.Debug("replicateToMyBucket")
 	key := cidutil.ShardCID(fileName)
 
-	w, err := ss.bucket.NewWriter(ctx, key, nil)
+	w, err := ss.bucketForCID(fileName, nil).NewWriter(ctx, key, nil)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
 
 	key := cidutil.ShardCID(fileName)
 	ctx := context.Background()
-	err := ss.bucket.Delete(ctx, key)
+	err := ss.bucketForCID(fileName, nil).Delete(ctx, key)
 	if err != nil {
 		logger.Error("failed to delete", zap.Error(err))
 	} else {
@@ -138,7 +138,7 @@ func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
 func (ss *MediorumServer) haveInMyBucket(fileName string) bool {
 	shardedCid := cidutil.ShardCID(fileName)
 	ctx := context.Background()
-	exists, _ := ss.bucket.Exists(ctx, shardedCid)
+	exists, _ := ss.bucketForCID(fileName, nil).Exists(ctx, shardedCid)
 	return exists
 }
 
@@ -236,41 +236,32 @@ func (ss *MediorumServer) pullFileFromHost(ctx context.Context, host, cid string
 	return ss.replicateToMyBucket(ctx, cid, resp.Body)
 }
 
-// if the node is using local (disk) storage, do not replicate if there is <10GB remaining
-func (ss *MediorumServer) diskHasSpace() bool {
-	// don't worry about running out of space on dev or stage
-	if ss.Config.Env != "prod" {
+// dsnHasSpace reports whether a file:// DSN has enough free disk to accept new
+// blobs. Non-file DSNs (S3/GCS/etc) always return true. The fallbackFreeBytes
+// argument is used when we can't statfs the path (e.g. it doesn't exist yet);
+// callers pass the most relevant cached free-bytes count for their bucket.
+func (ss *MediorumServer) dsnHasSpace(dsn string, fallbackFreeBytes uint64) bool {
+	if !strings.HasPrefix(dsn, "file://") {
 		return true
 	}
 
-	// If not using file storage, always allow (S3, GCS, etc. don't have local disk constraints)
-	if !strings.HasPrefix(ss.Config.BlobStoreDSN, "file://") {
-		return true
-	}
-
-	// Extract the path from file:// URL (e.g., "file:///data/blobs?no_tmp_dir=true" -> "/data/blobs")
-	_, uri, found := strings.Cut(ss.Config.BlobStoreDSN, "://")
+	_, uri, found := strings.Cut(dsn, "://")
 	if !found {
-		// Malformed URL, fall back to checking Config.Dir
-		ss.logger.Warn("malformed BlobStoreDSN, falling back to Config.Dir check",
-			zap.String("blobStoreDSN", ss.Config.BlobStoreDSN))
-		return ss.mediorumPathFree/uint64(1e9) > 10
+		ss.logger.Warn("malformed blob store DSN, falling back to cached free-bytes check",
+			zap.String("dsn", dsn))
+		return fallbackFreeBytes/uint64(1e9) > 10
 	}
 
-	// Remove query parameters if present (e.g., "?no_tmp_dir=true")
 	blobPath := strings.Split(uri, "?")[0]
 
-	// Check disk space on the actual blob storage path
 	_, free, err := getDiskStatus(blobPath)
 	if err != nil {
-		// If we can't check the blob path (e.g., doesn't exist yet), fall back to Config.Dir
-		ss.logger.Warn("failed to check blob storage disk space, falling back to Config.Dir",
+		ss.logger.Warn("failed to check blob storage disk space, falling back to cached free-bytes",
 			zap.String("blobPath", blobPath),
 			zap.Error(err))
-		return ss.mediorumPathFree/uint64(1e9) > 10
+		return fallbackFreeBytes/uint64(1e9) > 10
 	}
 
-	// Check if free space > 10GB on the actual blob storage path
 	freeGB := free / uint64(1e9)
 	hasSpace := freeGB > 10
 
@@ -278,8 +269,39 @@ func (ss *MediorumServer) diskHasSpace() bool {
 		ss.logger.Warn("blob storage disk space below threshold",
 			zap.String("blobPath", blobPath),
 			zap.Uint64("freeGB", freeGB),
-			zap.Uint64("thresholdGB", 200))
+			zap.Uint64("thresholdGB", 10))
 	}
 
 	return hasSpace
+}
+
+// diskHasSpace returns true only when every configured bucket has headroom.
+// Used by paths that don't have a CID yet (e.g. the inbound /internal/blobs
+// precheck) so we don't accept a write that we can't actually place.
+func (ss *MediorumServer) diskHasSpace() bool {
+	if ss.Config.Env != "prod" {
+		return true
+	}
+	if !ss.dsnHasSpace(ss.Config.BlobStoreDSN, ss.mediorumPathFree) {
+		return false
+	}
+	if ss.Config.ArchiveBlobStoreDSN != "" {
+		if !ss.dsnHasSpace(ss.Config.ArchiveBlobStoreDSN, ss.archivePathFree) {
+			return false
+		}
+	}
+	return true
+}
+
+// diskHasSpaceForCID checks only the bucket the given CID would land in. Use
+// this anywhere the CID is known so we don't reject writes to a healthy primary
+// because the archive bucket is full (or vice versa).
+func (ss *MediorumServer) diskHasSpaceForCID(cid string, placementHosts []string) bool {
+	if ss.Config.Env != "prod" {
+		return true
+	}
+	if ss.archiveBucket != nil && ss.bucketForCID(cid, placementHosts) == ss.archiveBucket {
+		return ss.dsnHasSpace(ss.Config.ArchiveBlobStoreDSN, ss.archivePathFree)
+	}
+	return ss.dsnHasSpace(ss.Config.BlobStoreDSN, ss.mediorumPathFree)
 }

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -108,7 +108,7 @@ func (ss *MediorumServer) replicateFile(ctx context.Context, fileName string, fi
 // placementHosts MUST be passed when the caller has placement context (repair,
 // upload replication path) so writes go to the same bucket reads expect.
 // Pass nil for opportunistic peer pushes that have no placement context.
-func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName string, file io.Reader, placementHosts []string) error {
+func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName string, file io.Reader, placementHosts []string) (err error) {
 	logger := ss.logger.With(zap.String("task", "replicateToMyBucket"), zap.String("cid", fileName))
 	logger.Debug("replicateToMyBucket")
 	key := cidutil.ShardCID(fileName)
@@ -118,13 +118,19 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 	if err != nil {
 		return err
 	}
+	// Ensure the writer is always closed. For most blob drivers, failing to
+	// Close after a partial write leaks resources or leaves uncommitted
+	// objects. Surface a Close error only when the operation otherwise
+	// succeeded — when the io.Copy below failed, that error is more useful.
+	defer func() {
+		closeErr := w.Close()
+		if err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
 
 	n, err := io.Copy(w, file)
 	if err != nil {
-		return err
-	}
-
-	if err := w.Close(); err != nil {
 		return err
 	}
 

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -108,7 +108,7 @@ func (ss *MediorumServer) replicateFile(ctx context.Context, fileName string, fi
 // placementHosts MUST be passed when the caller has placement context (repair,
 // upload replication path) so writes go to the same bucket reads expect.
 // Pass nil for opportunistic peer pushes that have no placement context.
-func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName string, file io.Reader, placementHosts []string) (err error) {
+func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName string, file io.Reader, placementHosts []string) error {
 	logger := ss.logger.With(zap.String("task", "replicateToMyBucket"), zap.String("cid", fileName))
 	logger.Debug("replicateToMyBucket")
 	key := cidutil.ShardCID(fileName)
@@ -118,19 +118,20 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 	if err != nil {
 		return err
 	}
-	// Ensure the writer is always closed. For most blob drivers, failing to
-	// Close after a partial write leaks resources or leaves uncommitted
-	// objects. Surface a Close error only when the operation otherwise
-	// succeeded — when the io.Copy below failed, that error is more useful.
-	defer func() {
-		closeErr := w.Close()
-		if err == nil && closeErr != nil {
-			err = closeErr
-		}
-	}()
 
 	n, err := io.Copy(w, file)
 	if err != nil {
+		// Best-effort close so we don't leak temp files / abandon multipart
+		// uploads. The copy error is what matters; ignore close error here.
+		_ = w.Close()
+		return err
+	}
+
+	// Close is the commit step for many blob drivers (S3, GCS multipart).
+	// Only record the blob as locally present after a successful close,
+	// so repair's knownPresent fast-path doesn't think we have a blob whose
+	// upload never actually finalized.
+	if err := w.Close(); err != nil {
 		return err
 	}
 

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -39,6 +39,9 @@ func (ss *MediorumServer) replicateFileParallel(ctx context.Context, cid string,
 	for _, p := range hosts {
 		queue <- p
 	}
+	// Close after enqueueing so workers exit when the buffer drains.
+	// Without this, an all-peers-fail run blocks workers forever on `range queue`.
+	close(queue)
 
 	mu := sync.Mutex{}
 	results := []string{}
@@ -108,8 +111,9 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 	logger := ss.logger.With(zap.String("task", "replicateToMyBucket"), zap.String("cid", fileName))
 	logger.Debug("replicateToMyBucket")
 	key := cidutil.ShardCID(fileName)
+	bucket := ss.bucketForCID(fileName, placementHosts)
 
-	w, err := ss.bucketForCID(fileName, placementHosts).NewWriter(ctx, key, nil)
+	w, err := bucket.NewWriter(ctx, key, nil)
 	if err != nil {
 		return err
 	}
@@ -123,7 +127,7 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 		return err
 	}
 
-	ss.knownPresent.Set(key, n, imcache.WithNoExpiration())
+	ss.knownPresent.Set(ss.presenceCacheKey(key, bucket), n, imcache.WithNoExpiration())
 	return nil
 }
 
@@ -132,12 +136,13 @@ func (ss *MediorumServer) dropFromMyBucket(fileName string, placementHosts []str
 	logger.Debug("deleting blob")
 
 	key := cidutil.ShardCID(fileName)
+	bucket := ss.bucketForCID(fileName, placementHosts)
 	ctx := context.Background()
-	err := ss.bucketForCID(fileName, placementHosts).Delete(ctx, key)
+	err := bucket.Delete(ctx, key)
 	if err != nil {
 		logger.Error("failed to delete", zap.Error(err))
 	} else {
-		ss.knownPresent.Remove(key)
+		ss.knownPresent.Remove(ss.presenceCacheKey(key, bucket))
 	}
 
 	return nil

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
 
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 )
 
 func (ss *MediorumServer) replicateFileParallel(ctx context.Context, cid string, filePath string, placementHosts []string) ([]string, error) {
@@ -131,28 +132,34 @@ func (ss *MediorumServer) replicateToMyBucket(ctx context.Context, fileName stri
 	return nil
 }
 
-func (ss *MediorumServer) dropFromMyBucket(fileName string, placementHosts []string) error {
+// dropFromMyBucket removes the blob from both buckets (NotFound is benign).
+// Reads are hot-first-then-archive, so a blob can legitimately live in either
+// bucket; deleting from both ensures cleanup is complete regardless of which
+// bucket the original write landed in (covers rank-flip orphans too).
+func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
 	logger := ss.logger.With(zap.String("task", "dropFromMyBucket"), zap.String("cid", fileName))
 	logger.Debug("deleting blob")
 
 	key := cidutil.ShardCID(fileName)
-	bucket := ss.bucketForCID(fileName, placementHosts)
 	ctx := context.Background()
-	err := bucket.Delete(ctx, key)
-	if err != nil {
-		logger.Error("failed to delete", zap.Error(err))
-	} else {
-		ss.knownPresent.Remove(ss.presenceCacheKey(key, bucket))
+
+	deleteFrom := func(b *blob.Bucket) {
+		if err := b.Delete(ctx, key); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+			logger.Error("failed to delete", zap.Error(err))
+			return
+		}
+		ss.knownPresent.Remove(ss.presenceCacheKey(key, b))
 	}
 
+	deleteFrom(ss.bucket)
+	if ss.archiveBucket != nil {
+		deleteFrom(ss.archiveBucket)
+	}
 	return nil
 }
 
-func (ss *MediorumServer) haveInMyBucket(fileName string, placementHosts []string) bool {
-	shardedCid := cidutil.ShardCID(fileName)
-	ctx := context.Background()
-	exists, _ := ss.bucketForCID(fileName, placementHosts).Exists(ctx, shardedCid)
-	return exists
+func (ss *MediorumServer) haveInMyBucket(fileName string) bool {
+	return ss.blobExists(context.Background(), cidutil.ShardCID(fileName))
 }
 
 func (ss *MediorumServer) replicateFileToHost(ctx context.Context, peer string, fileName string, file io.Reader, placementHosts []string) error {
@@ -242,9 +249,11 @@ func (ss *MediorumServer) pullFileFromHost(ctx context.Context, host, cid string
 	if err != nil {
 		return err
 	}
-	if len(placementHosts) > 0 {
-		req.Header.Set(placementHostsHeader, encodePlacementHosts(placementHosts))
-	}
+	// Note: placementHosts is NOT sent on the wire. The peer's GET
+	// endpoint uses hot-first-then-archive fallback, so it'll find the
+	// blob wherever it lives without needing routing context. The
+	// placementHosts param here only governs where *this node's* local
+	// write lands after we receive the blob.
 
 	resp, err := ss.peerHTTPClient.Do(req)
 	if err != nil {

--- a/pkg/mediorum/server/replicate.go
+++ b/pkg/mediorum/server/replicate.go
@@ -186,6 +186,9 @@ func (ss *MediorumServer) replicateFileToHost(ctx context.Context, peer string, 
 	if err != nil {
 		return err
 	}
+	if len(placementHosts) > 0 {
+		req.Header.Set(placementHostsHeader, encodePlacementHosts(placementHosts))
+	}
 
 	// send it
 	resp, err := ss.peerHTTPClient.Do(req)
@@ -233,6 +236,9 @@ func (ss *MediorumServer) pullFileFromHost(ctx context.Context, host, cid string
 	req, err := signature.SignedGet(ctx, u, ss.Config.privateKey, ss.Config.Self.Host)
 	if err != nil {
 		return err
+	}
+	if len(placementHosts) > 0 {
+		req.Header.Set(placementHostsHeader, encodePlacementHosts(placementHosts))
 	}
 
 	resp, err := ss.peerHTTPClient.Do(req)

--- a/pkg/mediorum/server/replicate_worker.go
+++ b/pkg/mediorum/server/replicate_worker.go
@@ -200,7 +200,7 @@ func (ss *MediorumServer) replicateToHosts(ctx context.Context, upload *Upload, 
 			}
 			defer reader.Close()
 
-			err = ss.replicateFileToHost(ctx, targetHost, cid, reader)
+			err = ss.replicateFileToHost(ctx, targetHost, cid, reader, upload.PlacementHosts)
 			// TODO: Replicate with TUSD
 			// err = ss.replicateToHost(targetHost, cid, reader, attrs.Size, placementHosts)
 			resultsChan <- replicationResult{host: targetHost, err: err}

--- a/pkg/mediorum/server/replicate_worker.go
+++ b/pkg/mediorum/server/replicate_worker.go
@@ -139,7 +139,8 @@ func (ss *MediorumServer) replicateTranscode(ctx context.Context, upload *Upload
 func (ss *MediorumServer) replicateToHosts(ctx context.Context, upload *Upload, cid string, existingMirrors []string, isTranscoded bool) error {
 	// Get the file from our bucket
 	shardedCid := cidutil.ShardCID(cid)
-	_, err := ss.bucket.Attributes(ctx, shardedCid)
+	srcBucket := ss.bucketForCID(cid, upload.PlacementHosts)
+	_, err := srcBucket.Attributes(ctx, shardedCid)
 	if err != nil {
 		return fmt.Errorf("failed to get file attributes: %w", err)
 	}
@@ -192,7 +193,7 @@ func (ss *MediorumServer) replicateToHosts(ctx context.Context, upload *Upload, 
 			defer wg.Done()
 
 			// Get a fresh reader for this host
-			reader, err := ss.bucket.NewReader(ctx, shardedCid, nil)
+			reader, err := srcBucket.NewReader(ctx, shardedCid, nil)
 			if err != nil {
 				resultsChan <- replicationResult{host: targetHost, err: err}
 				return

--- a/pkg/mediorum/server/replicate_worker.go
+++ b/pkg/mediorum/server/replicate_worker.go
@@ -137,10 +137,10 @@ func (ss *MediorumServer) replicateTranscode(ctx context.Context, upload *Upload
 
 // replicateFile is the shared implementation for replicating files to all necessary mirrors in parallel
 func (ss *MediorumServer) replicateToHosts(ctx context.Context, upload *Upload, cid string, existingMirrors []string, isTranscoded bool) error {
-	// Get the file from our bucket
+	// Get the file from our bucket — hot first, archive fallback so we
+	// source from wherever the blob actually lives on this node.
 	shardedCid := cidutil.ShardCID(cid)
-	srcBucket := ss.bucketForCID(cid, upload.PlacementHosts)
-	_, err := srcBucket.Attributes(ctx, shardedCid)
+	_, srcBucket, err := ss.blobAttrs(ctx, shardedCid)
 	if err != nil {
 		return fmt.Errorf("failed to get file attributes: %w", err)
 	}

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -102,7 +102,7 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 		return c.JSON(200, attr)
 	}
 
-	attr, err := ss.bucket.Attributes(ctx, key)
+	attr, err := ss.bucketForCID(cid, nil).Attributes(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return c.String(404, "blob not found")
@@ -162,7 +162,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
 	}
 
-	blob, err := ss.bucket.NewReader(ctx, key, nil)
+	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
 
 	// If our bucket doesn't have the file, try to pull it first
 	if err != nil {
@@ -176,7 +176,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 			_, pullErr := ss.findAndPullBlob(ctx, cid)
 			if pullErr == nil {
 				// Successfully pulled, try reading again
-				blob, err = ss.bucket.NewReader(ctx, key, nil)
+				blob, err = ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
 				if err == nil {
 					// Successfully read after pull, continue with normal serving
 				} else {
@@ -185,7 +185,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 				}
 			} else {
 				// Pull failed - check if it's due to disk space
-				if !ss.diskHasSpace() {
+				if !ss.diskHasSpaceForCID(cid, nil) {
 					// Disk is full, proxy the request instead of erroring
 					ss.logger.Info("disk full, proxying blob request", zap.String("cid", cid), zap.Error(pullErr))
 					host := ss.findNodeToServeBlob(ctx, cid)
@@ -248,7 +248,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 				durationSeconds, _ := c.Get("trackDurationSeconds").(float64)
 				expiry := presignedURLExpiry(durationSeconds)
 
-				signedURL, err := ss.bucket.SignedURL(ctx, key, &gcblob.SignedURLOptions{
+				signedURL, err := ss.bucketForCID(cid, nil).SignedURL(ctx, key, &gcblob.SignedURLOptions{
 					Expiry: expiry,
 					Method: http.MethodGet,
 				})
@@ -596,7 +596,7 @@ func (ss *MediorumServer) serveInternalBlobGET(c echo.Context) error {
 	cid := c.Param("cid")
 	key := cidutil.ShardCID(cid)
 
-	blob, err := ss.bucket.NewReader(ctx, key, nil)
+	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
 	if err != nil {
 		return err
 	}
@@ -703,7 +703,7 @@ func (ss *MediorumServer) serveTrack(c echo.Context) error {
 		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
 	}
 
-	blob, err := ss.bucket.NewReader(ctx, key, nil)
+	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
 	// If our bucket doesn't have the file, find a different node
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -633,7 +633,7 @@ func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
 	// (rank-based routing).
 	placementHosts := decodePlacementHosts(c.Request().Header)
 	if err := ss.validatePlacementHosts(placementHosts); err != nil {
-		ss.logger.Warn("rejecting invalid X-Placement-Hosts header; routing by rank",
+		ss.logger.Warn("ignoring invalid X-Placement-Hosts header; routing by rank",
 			zap.Strings("placementHosts", placementHosts), zap.Error(err))
 		placementHosts = nil
 	}

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -98,30 +98,21 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 		return c.String(500, "database connection issue")
 	}
 
-	// Bucket selection must happen before the cache lookup: the cache key is
-	// scoped per bucket so that a hit cached for one routing decision can't
-	// satisfy a different one (e.g. cached primary attrs returning 200 for a
-	// later request whose archive routing would correctly return 404).
-	placementHosts := decodePlacementHosts(c.Request().Header)
-	bucket := ss.bucketForCID(cid, placementHosts)
-
-	// Check the cache against both buckets — this endpoint is hit by peers
-	// who don't always have placement context, so the same physical blob may
-	// have been cached under either scope.
-	if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, bucket)); ok {
+	// Reads use hot-first-then-archive: the bucket the blob lives in falls out
+	// of where we find it, not where bucketForCID would route a fresh write.
+	// The attrCache is keyed per bucket so a primary hit doesn't satisfy an
+	// archive request (and vice versa); we check both keys before going to
+	// the bucket.
+	if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, ss.bucket)); ok {
 		return c.JSON(200, attr)
 	}
-	if ss.archiveBucket != nil && bucket != ss.archiveBucket {
+	if ss.archiveBucket != nil {
 		if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, ss.archiveBucket)); ok {
 			return c.JSON(200, attr)
 		}
-	} else if ss.archiveBucket != nil && bucket == ss.archiveBucket {
-		if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, ss.bucket)); ok {
-			return c.JSON(200, attr)
-		}
 	}
 
-	attr, foundIn, err := ss.blobAttributesWithFallback(ctx, cid, key, placementHosts)
+	attr, foundIn, err := ss.blobAttrs(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return c.String(404, "blob not found")
@@ -132,39 +123,6 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 
 	ss.attrCache.Set(ss.presenceCacheKey(key, foundIn), attr, imcache.WithExpiration(60*time.Second))
 	return c.JSON(200, attr)
-}
-
-// blobAttributesWithFallback resolves attrs from the routed bucket and, when
-// placement context is absent and an archive bucket is configured, falls back
-// to the other bucket on NotFound. Required because peer-to-peer presence
-// checks (hostGetBlobInfo) don't carry placement context: a placed CID on a
-// StoreAll+archive node lives in primary, but rank-based routing without a
-// header would check archive and report a false NotFound, breaking peer
-// hostHasBlob/redirect decisions.
-func (ss *MediorumServer) blobAttributesWithFallback(ctx context.Context, cid, key string, placementHosts []string) (*gcblob.Attributes, *gcblob.Bucket, error) {
-	primaryBucket := ss.bucketForCID(cid, placementHosts)
-	attr, err := primaryBucket.Attributes(ctx, key)
-	if err == nil {
-		return attr, primaryBucket, nil
-	}
-	if gcerrors.Code(err) != gcerrors.NotFound {
-		return nil, nil, err
-	}
-	// Only fall back when the caller didn't tell us where to look and we
-	// actually have somewhere else to look.
-	if len(placementHosts) > 0 || ss.archiveBucket == nil {
-		return nil, nil, err
-	}
-	otherBucket := ss.archiveBucket
-	if primaryBucket == ss.archiveBucket {
-		otherBucket = ss.bucket
-	}
-	attr2, err2 := otherBucket.Attributes(ctx, key)
-	if err2 == nil {
-		return attr2, otherBucket, nil
-	}
-	// Return the original NotFound; caller distinguishes on it.
-	return nil, nil, err
 }
 
 func (ss *MediorumServer) ensureNotDelisted(next echo.HandlerFunc) echo.HandlerFunc {
@@ -214,7 +172,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
 	}
 
-	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
+	blob, foundIn, err := ss.readBlob(ctx, key)
 
 	// If our bucket doesn't have the file, try to pull it first
 	if err != nil {
@@ -228,7 +186,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 			_, pullErr := ss.findAndPullBlob(ctx, cid, nil)
 			if pullErr == nil {
 				// Successfully pulled, try reading again
-				blob, err = ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
+				blob, foundIn, err = ss.readBlob(ctx, key)
 				if err == nil {
 					// Successfully read after pull, continue with normal serving
 				} else {
@@ -300,7 +258,11 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 				durationSeconds, _ := c.Get("trackDurationSeconds").(float64)
 				expiry := presignedURLExpiry(durationSeconds)
 
-				signedURL, err := ss.bucketForCID(cid, nil).SignedURL(ctx, key, &gcblob.SignedURLOptions{
+				// Use the bucket the blob was actually found in for the
+				// presigned URL — readBlob's fallback may have located it
+				// in archive even when rank-based routing would have looked
+				// in primary.
+				signedURL, err := foundIn.SignedURL(ctx, key, &gcblob.SignedURLOptions{
 					Expiry: expiry,
 					Method: http.MethodGet,
 				})
@@ -653,26 +615,9 @@ func (ss *MediorumServer) serveInternalBlobGET(c echo.Context) error {
 	cid := c.Param("cid")
 	key := cidutil.ShardCID(cid)
 
-	placementHosts := decodePlacementHosts(c.Request().Header)
-	primaryBucket := ss.bucketForCID(cid, placementHosts)
-	blob, err := primaryBucket.NewReader(ctx, key, nil)
+	blob, _, err := ss.readBlob(ctx, key)
 	if err != nil {
-		// Same fallback as serveBlobInfo: peers calling /internal/blobs/:cid
-		// without a placement header on a StoreAll+archive node need the
-		// "other" bucket checked too, otherwise placed CIDs get false 404s.
-		if gcerrors.Code(err) == gcerrors.NotFound && len(placementHosts) == 0 && ss.archiveBucket != nil {
-			otherBucket := ss.archiveBucket
-			if primaryBucket == ss.archiveBucket {
-				otherBucket = ss.bucket
-			}
-			if blob2, err2 := otherBucket.NewReader(ctx, key, nil); err2 == nil {
-				blob = blob2
-				err = nil
-			}
-		}
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	defer blob.Close()
 
@@ -781,7 +726,7 @@ func (ss *MediorumServer) serveTrack(c echo.Context) error {
 		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
 	}
 
-	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
+	blob, _, err := ss.readBlob(ctx, key)
 	// If our bucket doesn't have the file, find a different node
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -98,12 +98,19 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 		return c.String(500, "database connection issue")
 	}
 
-	if attr, ok := ss.attrCache.Get(key); ok {
+	// Bucket selection must happen before the cache lookup: the cache key is
+	// scoped per bucket so that a hit cached for one routing decision can't
+	// satisfy a different one (e.g. cached primary attrs returning 200 for a
+	// later request whose archive routing would correctly return 404).
+	placementHosts := decodePlacementHosts(c.Request().Header)
+	bucket := ss.bucketForCID(cid, placementHosts)
+	cacheKey := ss.presenceCacheKey(key, bucket)
+
+	if attr, ok := ss.attrCache.Get(cacheKey); ok {
 		return c.JSON(200, attr)
 	}
 
-	placementHosts := decodePlacementHosts(c.Request().Header)
-	attr, err := ss.bucketForCID(cid, placementHosts).Attributes(ctx, key)
+	attr, err := bucket.Attributes(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return c.String(404, "blob not found")
@@ -112,7 +119,7 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 		return err
 	}
 
-	ss.attrCache.Set(key, attr, imcache.WithExpiration(60*time.Second))
+	ss.attrCache.Set(cacheKey, attr, imcache.WithExpiration(60*time.Second))
 	return c.JSON(200, attr)
 }
 

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -625,8 +625,17 @@ func (ss *MediorumServer) serveInternalBlobGET(c echo.Context) error {
 }
 
 func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
-	if !ss.diskHasSpace() {
-		return c.String(http.StatusServiceUnavailable, "disk is too full to accept new blobs")
+	// Peer-driven push. Placement context, when known to the sender, rides
+	// along in the X-Placement-Hosts header. Validate it (must include self,
+	// all hosts must be registered peers) — the header is unsigned, so an
+	// unvalidated value would let any authenticated peer force primary
+	// routing and bypass archive. On invalid input, fall back to nil
+	// (rank-based routing).
+	placementHosts := decodePlacementHosts(c.Request().Header)
+	if err := ss.validatePlacementHosts(placementHosts); err != nil {
+		ss.logger.Warn("rejecting invalid X-Placement-Hosts header; routing by rank",
+			zap.Strings("placementHosts", placementHosts), zap.Error(err))
+		placementHosts = nil
 	}
 
 	form, err := c.MultipartForm()
@@ -639,6 +648,11 @@ func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
 	for _, upload := range files {
 		cid := upload.Filename
 		logger := ss.logger.With(zap.String("cid", cid))
+
+		// Per-CID disk check: only the bucket this CID will write to matters.
+		if !ss.diskHasSpaceForCID(cid, placementHosts) {
+			return c.String(http.StatusServiceUnavailable, "disk is too full to accept new blobs")
+		}
 
 		inp, err := upload.Open()
 		if err != nil {
@@ -654,10 +668,6 @@ func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
 			})
 		}
 
-		// Peer-driven push (/internal/blobs). Placement context, when known
-		// to the sender, rides along in the X-Placement-Hosts header so we
-		// route into the same bucket the sender expects.
-		placementHosts := decodePlacementHosts(c.Request().Header)
 		err = ss.replicateToMyBucket(c.Request().Context(), cid, inp, placementHosts)
 		if err != nil {
 			ss.logger.Error("accept ERR", zap.Error(err))

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -102,7 +102,8 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 		return c.JSON(200, attr)
 	}
 
-	attr, err := ss.bucketForCID(cid, nil).Attributes(ctx, key)
+	placementHosts := decodePlacementHosts(c.Request().Header)
+	attr, err := ss.bucketForCID(cid, placementHosts).Attributes(ctx, key)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return c.String(404, "blob not found")
@@ -601,7 +602,8 @@ func (ss *MediorumServer) serveInternalBlobGET(c echo.Context) error {
 	cid := c.Param("cid")
 	key := cidutil.ShardCID(cid)
 
-	blob, err := ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
+	placementHosts := decodePlacementHosts(c.Request().Header)
+	blob, err := ss.bucketForCID(cid, placementHosts).NewReader(ctx, key, nil)
 	if err != nil {
 		return err
 	}
@@ -640,11 +642,11 @@ func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
 			})
 		}
 
-		// Peer-driven push (/internal/blobs): no placement context on the wire,
-		// route by rendezvous rank only. A peer pushing to a placement target
-		// will only push CIDs the target should hold; opportunistic pushes to
-		// non-target StoreAll nodes correctly route to archive.
-		err = ss.replicateToMyBucket(c.Request().Context(), cid, inp, nil)
+		// Peer-driven push (/internal/blobs). Placement context, when known
+		// to the sender, rides along in the X-Placement-Hosts header so we
+		// route into the same bucket the sender expects.
+		placementHosts := decodePlacementHosts(c.Request().Header)
+		err = ss.replicateToMyBucket(c.Request().Context(), cid, inp, placementHosts)
 		if err != nil {
 			ss.logger.Error("accept ERR", zap.Error(err))
 			return err

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -382,7 +382,7 @@ func (ss *MediorumServer) findAndPullBlob(ctx context.Context, key string) (stri
 
 	hosts, _ := ss.rendezvousAllHosts(key)
 	for _, host := range hosts {
-		err := ss.pullFileFromHost(ctx, host, key)
+		err := ss.pullFileFromHost(ctx, host, key, nil)
 		if err == nil {
 			return host, nil
 		}
@@ -635,7 +635,11 @@ func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
 			})
 		}
 
-		err = ss.replicateToMyBucket(c.Request().Context(), cid, inp)
+		// Peer-driven push (/internal/blobs): no placement context on the wire,
+		// route by rendezvous rank only. A peer pushing to a placement target
+		// will only push CIDs the target should hold; opportunistic pushes to
+		// non-target StoreAll nodes correctly route to archive.
+		err = ss.replicateToMyBucket(c.Request().Context(), cid, inp, nil)
 		if err != nil {
 			ss.logger.Error("accept ERR", zap.Error(err))
 			return err

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -173,7 +173,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 			}
 
 			// Try to pull the file first
-			_, pullErr := ss.findAndPullBlob(ctx, cid)
+			_, pullErr := ss.findAndPullBlob(ctx, cid, nil)
 			if pullErr == nil {
 				// Successfully pulled, try reading again
 				blob, err = ss.bucketForCID(cid, nil).NewReader(ctx, key, nil)
@@ -377,12 +377,17 @@ func (ss *MediorumServer) findNodeToServeBlob(_ context.Context, key string) str
 	return ""
 }
 
-func (ss *MediorumServer) findAndPullBlob(ctx context.Context, key string) (string, error) {
+// findAndPullBlob locates a CID on the network and pulls it into the local
+// bucket selected by bucketForCID(key, placementHosts). Pass placementHosts
+// when the caller has placement context (transcode and similar) so the local
+// write lands in the same bucket subsequent reads will check; pass nil for
+// opportunistic pulls (serveBlob fallback, image originals).
+func (ss *MediorumServer) findAndPullBlob(ctx context.Context, key string, placementHosts []string) (string, error) {
 	// start := time.Now()
 
 	hosts, _ := ss.rendezvousAllHosts(key)
 	for _, host := range hosts {
-		err := ss.pullFileFromHost(ctx, host, key, nil)
+		err := ss.pullFileFromHost(ctx, host, key, placementHosts)
 		if err == nil {
 			return host, nil
 		}

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -104,13 +104,24 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 	// later request whose archive routing would correctly return 404).
 	placementHosts := decodePlacementHosts(c.Request().Header)
 	bucket := ss.bucketForCID(cid, placementHosts)
-	cacheKey := ss.presenceCacheKey(key, bucket)
 
-	if attr, ok := ss.attrCache.Get(cacheKey); ok {
+	// Check the cache against both buckets — this endpoint is hit by peers
+	// who don't always have placement context, so the same physical blob may
+	// have been cached under either scope.
+	if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, bucket)); ok {
 		return c.JSON(200, attr)
 	}
+	if ss.archiveBucket != nil && bucket != ss.archiveBucket {
+		if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, ss.archiveBucket)); ok {
+			return c.JSON(200, attr)
+		}
+	} else if ss.archiveBucket != nil && bucket == ss.archiveBucket {
+		if attr, ok := ss.attrCache.Get(ss.presenceCacheKey(key, ss.bucket)); ok {
+			return c.JSON(200, attr)
+		}
+	}
 
-	attr, err := bucket.Attributes(ctx, key)
+	attr, foundIn, err := ss.blobAttributesWithFallback(ctx, cid, key, placementHosts)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return c.String(404, "blob not found")
@@ -119,8 +130,41 @@ func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 		return err
 	}
 
-	ss.attrCache.Set(cacheKey, attr, imcache.WithExpiration(60*time.Second))
+	ss.attrCache.Set(ss.presenceCacheKey(key, foundIn), attr, imcache.WithExpiration(60*time.Second))
 	return c.JSON(200, attr)
+}
+
+// blobAttributesWithFallback resolves attrs from the routed bucket and, when
+// placement context is absent and an archive bucket is configured, falls back
+// to the other bucket on NotFound. Required because peer-to-peer presence
+// checks (hostGetBlobInfo) don't carry placement context: a placed CID on a
+// StoreAll+archive node lives in primary, but rank-based routing without a
+// header would check archive and report a false NotFound, breaking peer
+// hostHasBlob/redirect decisions.
+func (ss *MediorumServer) blobAttributesWithFallback(ctx context.Context, cid, key string, placementHosts []string) (*gcblob.Attributes, *gcblob.Bucket, error) {
+	primaryBucket := ss.bucketForCID(cid, placementHosts)
+	attr, err := primaryBucket.Attributes(ctx, key)
+	if err == nil {
+		return attr, primaryBucket, nil
+	}
+	if gcerrors.Code(err) != gcerrors.NotFound {
+		return nil, nil, err
+	}
+	// Only fall back when the caller didn't tell us where to look and we
+	// actually have somewhere else to look.
+	if len(placementHosts) > 0 || ss.archiveBucket == nil {
+		return nil, nil, err
+	}
+	otherBucket := ss.archiveBucket
+	if primaryBucket == ss.archiveBucket {
+		otherBucket = ss.bucket
+	}
+	attr2, err2 := otherBucket.Attributes(ctx, key)
+	if err2 == nil {
+		return attr2, otherBucket, nil
+	}
+	// Return the original NotFound; caller distinguishes on it.
+	return nil, nil, err
 }
 
 func (ss *MediorumServer) ensureNotDelisted(next echo.HandlerFunc) echo.HandlerFunc {
@@ -610,9 +654,25 @@ func (ss *MediorumServer) serveInternalBlobGET(c echo.Context) error {
 	key := cidutil.ShardCID(cid)
 
 	placementHosts := decodePlacementHosts(c.Request().Header)
-	blob, err := ss.bucketForCID(cid, placementHosts).NewReader(ctx, key, nil)
+	primaryBucket := ss.bucketForCID(cid, placementHosts)
+	blob, err := primaryBucket.NewReader(ctx, key, nil)
 	if err != nil {
-		return err
+		// Same fallback as serveBlobInfo: peers calling /internal/blobs/:cid
+		// without a placement header on a StoreAll+archive node need the
+		// "other" bucket checked too, otherwise placed CIDs get false 404s.
+		if gcerrors.Code(err) == gcerrors.NotFound && len(placementHosts) == 0 && ss.archiveBucket != nil {
+			otherBucket := ss.archiveBucket
+			if primaryBucket == ss.archiveBucket {
+				otherBucket = ss.bucket
+			}
+			if blob2, err2 := otherBucket.NewReader(ctx, key, nil); err2 == nil {
+				blob = blob2
+				err = nil
+			}
+		}
+		if err != nil {
+			return err
+		}
 	}
 	defer blob.Close()
 

--- a/pkg/mediorum/server/serve_health.go
+++ b/pkg/mediorum/server/serve_health.go
@@ -50,7 +50,6 @@ type HealthData struct {
 	ArchiveStoragePrefix      string                     `json:"archiveStoragePrefix"`
 	ArchivePathUsed           uint64                     `json:"archivePathUsed"` // bytes
 	ArchivePathSize           uint64                     `json:"archivePathSize"` // bytes
-	ArchiveBlobCount          int64                      `json:"archiveBlobCount"`
 	ListenPort                string                     `json:"listenPort"`
 	TrustedNotifierID         int                        `json:"trustedNotifierId"`
 	PeerHealths               map[string]*PeerHealth     `json:"peerHealths"`
@@ -114,7 +113,6 @@ func (ss *MediorumServer) getHealth() HealthData {
 		ArchiveStoragePrefix:      archiveStoragePrefix,
 		ArchivePathUsed:           ss.archivePathUsed,
 		ArchivePathSize:           ss.archivePathSize,
-		ArchiveBlobCount:          ss.archiveBlobCount,
 		ListenPort:                ss.Config.ListenPort,
 		ReplicationFactor:         ss.Config.ReplicationFactor,
 		Env:                       ss.Config.Env,

--- a/pkg/mediorum/server/serve_health.go
+++ b/pkg/mediorum/server/serve_health.go
@@ -46,6 +46,11 @@ type HealthData struct {
 	Dir                       string                     `json:"dir"`
 	BlobStorePrefix           string                     `json:"blobStorePrefix"`
 	MoveFromBlobStorePrefix   string                     `json:"moveFromBlobStorePrefix"`
+	ArchiveStorageConfigured  bool                       `json:"archiveStorageConfigured"`
+	ArchiveStoragePrefix      string                     `json:"archiveStoragePrefix"`
+	ArchivePathUsed           uint64                     `json:"archivePathUsed"` // bytes
+	ArchivePathSize           uint64                     `json:"archivePathSize"` // bytes
+	ArchiveBlobCount          int64                      `json:"archiveBlobCount"`
 	ListenPort                string                     `json:"listenPort"`
 	TrustedNotifierID         int                        `json:"trustedNotifierId"`
 	PeerHealths               map[string]*PeerHealth     `json:"peerHealths"`
@@ -69,6 +74,10 @@ func (ss *MediorumServer) getHealth() HealthData {
 	blobStoreMoveFromPrefix, _, foundBlobStoreMoveFrom := strings.Cut(ss.Config.MoveFromBlobStoreDSN, "://")
 	if !foundBlobStoreMoveFrom {
 		blobStoreMoveFromPrefix = ""
+	}
+	archiveStoragePrefix, _, foundArchive := strings.Cut(ss.Config.ArchiveBlobStoreDSN, "://")
+	if !foundArchive {
+		archiveStoragePrefix = ""
 	}
 
 	// since we're using peerHealth
@@ -101,6 +110,11 @@ func (ss *MediorumServer) getHealth() HealthData {
 		Dir:                       ss.Config.Dir,
 		BlobStorePrefix:           blobStorePrefix,
 		MoveFromBlobStorePrefix:   blobStoreMoveFromPrefix,
+		ArchiveStorageConfigured:  ss.archiveBucket != nil,
+		ArchiveStoragePrefix:      archiveStoragePrefix,
+		ArchivePathUsed:           ss.archivePathUsed,
+		ArchivePathSize:           ss.archivePathSize,
+		ArchiveBlobCount:          ss.archiveBlobCount,
 		ListenPort:                ss.Config.ListenPort,
 		ReplicationFactor:         ss.Config.ReplicationFactor,
 		Env:                       ss.Config.Env,

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -55,7 +55,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	}
 
 	serveSuccess := func(blobPath string) error {
-		if blob, err := ss.bucket.NewReader(ctx, blobPath, nil); err == nil {
+		if blob, err := ss.bucketForCID(containerCID, nil).NewReader(ctx, blobPath, nil); err == nil {
 			return serveSuccessWithReader(blob)
 		} else {
 			return err
@@ -97,7 +97,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 
 	// we already have the resized version
 	if !skipCache {
-		if blob, err := ss.bucket.NewReader(ctx, variantStoragePath, nil); err == nil {
+		if blob, err := ss.bucketForCID(containerCID, nil).NewReader(ctx, variantStoragePath, nil); err == nil {
 			return serveSuccessWithReader(blob)
 		}
 	}
@@ -107,7 +107,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	if cidutil.IsLegacyCID(origImageCID) {
 		origImageCID += "/original.jpg"
 	}
-	origReader, err := ss.bucket.NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
+	origReader, err := ss.bucketForCID(containerCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
 
 	// if we don't have orig, fetch from network
 	if err != nil {
@@ -115,7 +115,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		host, pullErr := ss.findAndPullBlob(ctx, origImageCID)
 		if pullErr != nil {
 			// Pull failed - check if it's due to disk space
-			if !ss.diskHasSpace() {
+			if !ss.diskHasSpaceForCID(containerCID, nil) {
 				// Disk is full, proxy the request instead of erroring
 				// Redirect to a node that can serve this variant
 				redirectHost := ss.findNodeToServeBlob(ctx, origImageCID)
@@ -143,7 +143,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		c.Response().Header().Set("x-fetch-host", host)
 		c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
 
-		origReader, err = ss.bucket.NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
+		origReader, err = ss.bucketForCID(containerCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	if !isOriginalJpg {
 		resizeStart := time.Now()
 		resized, _, _ := Resized(".jpg", origReader, w, h, "fill")
-		w, _ := ss.bucket.NewWriter(ctx, variantStoragePath, nil)
+		w, _ := ss.bucketForCID(containerCID, nil).NewWriter(ctx, variantStoragePath, nil)
 		io.Copy(w, resized)
 		w.Close()
 		c.Response().Header().Set("x-resize-ok", fmt.Sprintf("%.2fs", time.Since(resizeStart).Seconds()))

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
 	"github.com/erni27/imcache"
+	"go.uber.org/zap"
 
 	"github.com/labstack/echo/v4"
 	"gocloud.dev/blob"
@@ -170,9 +171,21 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	if !isOriginalJpg {
 		resizeStart := time.Now()
 		resized, _, _ := Resized(".jpg", origReader, w, h, "fill")
-		w, _ := ss.bucket.NewWriter(ctx, variantStoragePath, nil)
-		io.Copy(w, resized)
-		w.Close()
+		// Variants are best-effort cache. If the write to primary fails (full
+		// disk, transient backend error), log and skip the cache step rather
+		// than nil-deref on io.Copy or fail the user's request — the resized
+		// bytes are served from `serveSuccess` below either way (next request
+		// regenerates the variant).
+		if vw, vwErr := ss.bucket.NewWriter(ctx, variantStoragePath, nil); vwErr == nil {
+			if _, copyErr := io.Copy(vw, resized); copyErr != nil {
+				ss.logger.Warn("variant cache write copy failed", zap.String("path", variantStoragePath), zap.Error(copyErr))
+			}
+			if closeErr := vw.Close(); closeErr != nil {
+				ss.logger.Warn("variant cache write close failed", zap.String("path", variantStoragePath), zap.Error(closeErr))
+			}
+		} else {
+			ss.logger.Warn("variant cache writer open failed", zap.String("path", variantStoragePath), zap.Error(vwErr))
+		}
 		c.Response().Header().Set("x-resize-ok", fmt.Sprintf("%.2fs", time.Since(resizeStart).Seconds()))
 	}
 	origReader.Close()

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -70,15 +70,21 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	// origImageCID is the identifier findAndPullBlob/replicateToMyBucket use
 	// when fetching the original. For non-legacy CIDs it equals containerCID;
 	// for legacy CIDs it's "<cid>/original.jpg" — a *different* rendezvous-rank
-	// input. Route the original AND its derived variants by origImageCID so
-	// reads land in the same bucket the pull wrote to.
+	// input. Route reads of the original by origImageCID so they land in the
+	// same bucket the pull wrote to.
+	//
+	// Variants (resized derivatives) are pure on-demand cache — regenerated
+	// from the original by Resized() below — and always live in the primary
+	// bucket. Putting regeneratable cache in cold storage would force
+	// retrieval fees on every image request that hit a node holding the
+	// original in archive.
 	origImageCID := containerCID
 	if cidutil.IsLegacyCID(origImageCID) {
 		origImageCID += "/original.jpg"
 	}
 
 	serveSuccess := func(blobPath string) error {
-		if blob, err := ss.bucketForCID(origImageCID, nil).NewReader(ctx, blobPath, nil); err == nil {
+		if blob, err := ss.bucket.NewReader(ctx, blobPath, nil); err == nil {
 			return serveSuccessWithReader(blob)
 		} else {
 			return err
@@ -105,9 +111,9 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 
 	c.Response().Header().Set("x-variant-storage-path", variantStoragePath)
 
-	// we already have the resized version
+	// we already have the resized version (variants always live in primary)
 	if !skipCache {
-		if blob, err := ss.bucketForCID(origImageCID, nil).NewReader(ctx, variantStoragePath, nil); err == nil {
+		if blob, err := ss.bucket.NewReader(ctx, variantStoragePath, nil); err == nil {
 			return serveSuccessWithReader(blob)
 		}
 	}
@@ -155,11 +161,11 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		}
 	}
 
-	// do resize if not original.jpg
+	// do resize if not original.jpg. Variants always go to primary — see comment above.
 	if !isOriginalJpg {
 		resizeStart := time.Now()
 		resized, _, _ := Resized(".jpg", origReader, w, h, "fill")
-		w, _ := ss.bucketForCID(origImageCID, nil).NewWriter(ctx, variantStoragePath, nil)
+		w, _ := ss.bucket.NewWriter(ctx, variantStoragePath, nil)
 		io.Copy(w, resized)
 		w.Close()
 		c.Response().Header().Set("x-resize-ok", fmt.Sprintf("%.2fs", time.Since(resizeStart).Seconds()))

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -118,8 +118,9 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		}
 	}
 
-	// open the orig for resizing
-	origReader, err := ss.bucketForCID(origImageCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
+	// open the orig for resizing — readBlob falls back to archive when the
+	// original lives there (e.g. on a StoreAll+archive node).
+	origReader, _, err := ss.readBlob(ctx, cidutil.ShardCID(origImageCID))
 
 	// if we don't have orig, fetch from network
 	if err != nil {
@@ -155,7 +156,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		c.Response().Header().Set("x-fetch-host", host)
 		c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
 
-		origReader, err = ss.bucketForCID(origImageCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
+		origReader, _, err = ss.readBlob(ctx, cidutil.ShardCID(origImageCID))
 		if err != nil {
 			return err
 		}

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -118,7 +118,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	// if we don't have orig, fetch from network
 	if err != nil {
 		startFetch := time.Now()
-		host, pullErr := ss.findAndPullBlob(ctx, origImageCID)
+		host, pullErr := ss.findAndPullBlob(ctx, origImageCID, nil)
 		if pullErr != nil {
 			// Pull failed - check if it's due to disk space
 			if !ss.diskHasSpaceForCID(origImageCID, nil) {

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -54,14 +54,6 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		}
 	}
 
-	serveSuccess := func(blobPath string) error {
-		if blob, err := ss.bucketForCID(containerCID, nil).NewReader(ctx, blobPath, nil); err == nil {
-			return serveSuccessWithReader(blob)
-		} else {
-			return err
-		}
-	}
-
 	// if the client provided a filename, set it in the header to be auto-populated in download prompt
 	filenameForDownload := c.QueryParam("filename")
 	if filenameForDownload != "" {
@@ -73,6 +65,24 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	if cid, err := ss.getUploadOrigCID(containerCID); err == nil {
 		c.Response().Header().Set("x-orig-cid", cid)
 		containerCID = cid
+	}
+
+	// origImageCID is the identifier findAndPullBlob/replicateToMyBucket use
+	// when fetching the original. For non-legacy CIDs it equals containerCID;
+	// for legacy CIDs it's "<cid>/original.jpg" — a *different* rendezvous-rank
+	// input. Route the original AND its derived variants by origImageCID so
+	// reads land in the same bucket the pull wrote to.
+	origImageCID := containerCID
+	if cidutil.IsLegacyCID(origImageCID) {
+		origImageCID += "/original.jpg"
+	}
+
+	serveSuccess := func(blobPath string) error {
+		if blob, err := ss.bucketForCID(origImageCID, nil).NewReader(ctx, blobPath, nil); err == nil {
+			return serveSuccessWithReader(blob)
+		} else {
+			return err
+		}
 	}
 
 	// 2. serve variant
@@ -97,17 +107,13 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 
 	// we already have the resized version
 	if !skipCache {
-		if blob, err := ss.bucketForCID(containerCID, nil).NewReader(ctx, variantStoragePath, nil); err == nil {
+		if blob, err := ss.bucketForCID(origImageCID, nil).NewReader(ctx, variantStoragePath, nil); err == nil {
 			return serveSuccessWithReader(blob)
 		}
 	}
 
 	// open the orig for resizing
-	origImageCID := containerCID
-	if cidutil.IsLegacyCID(origImageCID) {
-		origImageCID += "/original.jpg"
-	}
-	origReader, err := ss.bucketForCID(containerCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
+	origReader, err := ss.bucketForCID(origImageCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
 
 	// if we don't have orig, fetch from network
 	if err != nil {
@@ -115,7 +121,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		host, pullErr := ss.findAndPullBlob(ctx, origImageCID)
 		if pullErr != nil {
 			// Pull failed - check if it's due to disk space
-			if !ss.diskHasSpaceForCID(containerCID, nil) {
+			if !ss.diskHasSpaceForCID(origImageCID, nil) {
 				// Disk is full, proxy the request instead of erroring
 				// Redirect to a node that can serve this variant
 				redirectHost := ss.findNodeToServeBlob(ctx, origImageCID)
@@ -143,7 +149,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 		c.Response().Header().Set("x-fetch-host", host)
 		c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
 
-		origReader, err = ss.bucketForCID(containerCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
+		origReader, err = ss.bucketForCID(origImageCID, nil).NewReader(ctx, cidutil.ShardCID(origImageCID), nil)
 		if err != nil {
 			return err
 		}
@@ -153,7 +159,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	if !isOriginalJpg {
 		resizeStart := time.Now()
 		resized, _, _ := Resized(".jpg", origReader, w, h, "fill")
-		w, _ := ss.bucketForCID(containerCID, nil).NewWriter(ctx, variantStoragePath, nil)
+		w, _ := ss.bucketForCID(origImageCID, nil).NewWriter(ctx, variantStoragePath, nil)
 		io.Copy(w, resized)
 		w.Close()
 		c.Response().Header().Set("x-resize-ok", fmt.Sprintf("%.2fs", time.Since(resizeStart).Seconds()))

--- a/pkg/mediorum/server/serve_image.go
+++ b/pkg/mediorum/server/serve_image.go
@@ -84,7 +84,11 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	}
 
 	serveSuccess := func(blobPath string) error {
-		if blob, err := ss.bucket.NewReader(ctx, blobPath, nil); err == nil {
+		// Use readBlob so original.jpg requests still resolve when the
+		// original lives in archive — variantStoragePath for original.jpg
+		// is the actual original's storage key, and only resized variants
+		// are guaranteed to live in primary.
+		if blob, _, err := ss.readBlob(ctx, blobPath); err == nil {
 			return serveSuccessWithReader(blob)
 		} else {
 			return err

--- a/pkg/mediorum/server/serve_image_test.go
+++ b/pkg/mediorum/server/serve_image_test.go
@@ -25,7 +25,7 @@ func TestServeImage(t *testing.T) {
 
 	s1, s2, s3, s4 := testNetwork[0], testNetwork[1], testNetwork[2], testNetwork[3]
 
-	s2.replicateToMyBucket(ctx, cid, f)
+	s2.replicateToMyBucket(ctx, cid, f, nil)
 
 	// the first time it will go get the orig + generate a resized version
 	// the x-dynamic-resize-ok header should be set
@@ -76,7 +76,7 @@ func TestServeImage(t *testing.T) {
 	// test with some Qm URLs
 	{
 		qmKey := "QmQSGUjVkSfGBJCU4dcPn3LC17ikQXbfikGbFUAzL5rcXt/original.jpg"
-		s2.replicateToMyBucket(ctx, qmKey, f)
+		s2.replicateToMyBucket(ctx, qmKey, f, nil)
 
 		resp, err := http.Get(s1.Config.Self.Host + "/content/" + qmKey)
 		assert.NoError(t, err)

--- a/pkg/mediorum/server/serve_upload.go
+++ b/pkg/mediorum/server/serve_upload.go
@@ -280,7 +280,7 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 			upload.FFProbe.Format.Filename = formFile.Filename
 
 			// replicate to my bucket + others
-			ss.replicateToMyBucket(ctx, formFileCID, tmpFile)
+			ss.replicateToMyBucket(ctx, formFileCID, tmpFile, placementHosts)
 			upload.Mirrors, err = ss.replicateFileParallel(ctx, formFileCID, tmpFile.Name(), placementHosts)
 			if err != nil {
 				upload.Error = err.Error()

--- a/pkg/mediorum/server/serve_upload.go
+++ b/pkg/mediorum/server/serve_upload.go
@@ -280,7 +280,11 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 			upload.FFProbe.Format.Filename = formFile.Filename
 
 			// replicate to my bucket + others
-			ss.replicateToMyBucket(ctx, formFileCID, tmpFile, placementHosts)
+			if err := ss.replicateToMyBucket(ctx, formFileCID, tmpFile, placementHosts); err != nil {
+				ss.logger.Error("local replicateToMyBucket failed", zap.String("uploadID", upload.ID), zap.String("cid", formFileCID), zap.Error(err))
+				upload.Error = err.Error()
+				return err
+			}
 			upload.Mirrors, err = ss.replicateFileParallel(ctx, formFileCID, tmpFile.Name(), placementHosts)
 			if err != nil {
 				upload.Error = err.Error()

--- a/pkg/mediorum/server/serve_upload_grpc.go
+++ b/pkg/mediorum/server/serve_upload_grpc.go
@@ -153,7 +153,7 @@ func (ss *MediorumServer) processUploadedFile(ctx context.Context, upload *Uploa
 	upload.FFProbe.Format.Filename = upload.OrigFileName
 
 	// Replicate to my bucket
-	err = ss.replicateToMyBucket(ctx, formFileCID, tmpFile)
+	err = ss.replicateToMyBucket(ctx, formFileCID, tmpFile, upload.PlacementHosts)
 	if err != nil {
 		return ss.handleUploadError(upload, err, shouldCreate)
 	}

--- a/pkg/mediorum/server/serve_upload_test.go
+++ b/pkg/mediorum/server/serve_upload_test.go
@@ -130,7 +130,7 @@ func TestUploadPlacement(t *testing.T) {
 	}
 
 	// drop from s5
-	s5.dropFromMyBucket(u2.OrigFileCID, nil)
+	s5.dropFromMyBucket(u2.OrigFileCID)
 
 	// run repair
 	testNetworkRunRepair(true)
@@ -234,7 +234,7 @@ func TestUploadPlacementTus(t *testing.T) {
 	}
 
 	// drop from s5
-	s5.dropFromMyBucket(u2.OrigFileCID, nil)
+	s5.dropFromMyBucket(u2.OrigFileCID)
 
 	// run repair
 	testNetworkRunRepair(true)

--- a/pkg/mediorum/server/serve_upload_test.go
+++ b/pkg/mediorum/server/serve_upload_test.go
@@ -130,7 +130,7 @@ func TestUploadPlacement(t *testing.T) {
 	}
 
 	// drop from s5
-	s5.dropFromMyBucket(u2.OrigFileCID)
+	s5.dropFromMyBucket(u2.OrigFileCID, nil)
 
 	// run repair
 	testNetworkRunRepair(true)
@@ -234,7 +234,7 @@ func TestUploadPlacementTus(t *testing.T) {
 	}
 
 	// drop from s5
-	s5.dropFromMyBucket(u2.OrigFileCID)
+	s5.dropFromMyBucket(u2.OrigFileCID, nil)
 
 	// run repair
 	testNetworkRunRepair(true)

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -117,10 +117,9 @@ type MediorumServer struct {
 	storageExpectation uint64
 
 	// archive bucket stats (only populated when ArchiveBlobStoreDSN is set)
-	archivePathUsed  uint64
-	archivePathSize  uint64
-	archivePathFree  uint64
-	archiveBlobCount int64
+	archivePathUsed uint64
+	archivePathSize uint64
+	archivePathFree uint64
 
 	databaseSize          uint64
 	dbSizeErr             string

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -60,6 +60,7 @@ type MediorumConfig struct {
 	ReplicationFactor         int
 	Dir                       string `default:"/tmp/mediorum"`
 	BlobStoreDSN              string `json:"-"`
+	ArchiveBlobStoreDSN       string `json:"-"`
 	MoveFromBlobStoreDSN      string `json:"-"`
 	PostgresDSN               string `json:"-"`
 	PrivateKey                string `json:"-"`
@@ -94,6 +95,7 @@ type MediorumServer struct {
 	lc               *lifecycle.Lifecycle
 	echo             *echo.Echo
 	bucket           *blob.Bucket
+	archiveBucket    *blob.Bucket
 	logger           *zap.Logger
 	crud             *crudr.Crudr
 	pgPool           *pgxpool.Pool
@@ -113,6 +115,12 @@ type MediorumServer struct {
 	mediorumPathSize   uint64
 	mediorumPathFree   uint64
 	storageExpectation uint64
+
+	// archive bucket stats (only populated when ArchiveBlobStoreDSN is set)
+	archivePathUsed  uint64
+	archivePathSize  uint64
+	archivePathFree  uint64
+	archiveBlobCount int64
 
 	databaseSize          uint64
 	dbSizeErr             string
@@ -240,6 +248,23 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		return nil, err
 	}
 
+	// archive bucket: only opened if configured. Routes CIDs that this node
+	// only stores due to StoreAll (rendezvous rank >= ReplicationFactor).
+	var archiveBucket *blob.Bucket
+	if config.ArchiveBlobStoreDSN != "" {
+		if config.ArchiveBlobStoreDSN == config.BlobStoreDSN {
+			return nil, errors.New("OPENAUDIO_ARCHIVE_STORAGE_DRIVER_URL must differ from OPENAUDIO_STORAGE_DRIVER_URL")
+		}
+		if !config.StoreAll {
+			logger.Warn("OPENAUDIO_ARCHIVE_STORAGE_DRIVER_URL is set but STORE_ALL is false; archive bucket will be unused")
+		}
+		archiveBucket, err = persistence.Open(config.ArchiveBlobStoreDSN)
+		if err != nil {
+			logger.Error("failed to open archive storage bucket", zap.Error(err))
+			return nil, err
+		}
+	}
+
 	// bucket to move all files from
 	if config.MoveFromBlobStoreDSN != "" {
 		if config.MoveFromBlobStoreDSN == config.BlobStoreDSN {
@@ -354,6 +379,7 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		lc:               mediorumLifecycle,
 		echo:             echoServer,
 		bucket:           bucket,
+		archiveBucket:    archiveBucket,
 		crud:             crud,
 		pgPool:           pgPool,
 		reqClient:        reqClient,

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -202,17 +202,11 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 
 	if config.BlobStoreDSN == "" {
 		config.BlobStoreDSN = "file://" + config.Dir + "/blobs?no_tmp_dir=true"
-	} else if strings.HasPrefix(config.BlobStoreDSN, "file://") {
-		// If using file storage, ensure no_tmp_dir=true is set to avoid cross-device link errors
-		// when /tmp and the blob storage path are on different mount points
-		if !strings.Contains(config.BlobStoreDSN, "no_tmp_dir") {
-			// Add the parameter, handling existing query params
-			if strings.Contains(config.BlobStoreDSN, "?") {
-				config.BlobStoreDSN += "&no_tmp_dir=true"
-			} else {
-				config.BlobStoreDSN += "?no_tmp_dir=true"
-			}
-		}
+	} else {
+		config.BlobStoreDSN = ensureNoTmpDir(config.BlobStoreDSN)
+	}
+	if config.ArchiveBlobStoreDSN != "" {
+		config.ArchiveBlobStoreDSN = ensureNoTmpDir(config.ArchiveBlobStoreDSN)
 	}
 
 	if pk, err := ethcontracts.ParsePrivateKeyHex(config.PrivateKey); err != nil {
@@ -526,6 +520,22 @@ func setResponseACAOHeaderFromRequest(req http.Request, resp echo.Response) {
 		echo.HeaderAccessControlAllowOrigin,
 		req.Header.Get(echo.HeaderOrigin),
 	)
+}
+
+// ensureNoTmpDir ensures file:// DSNs carry no_tmp_dir=true to avoid cross-device
+// link errors when /tmp and the blob storage path are on different mount points.
+// Non-file DSNs are returned unchanged.
+func ensureNoTmpDir(dsn string) string {
+	if !strings.HasPrefix(dsn, "file://") {
+		return dsn
+	}
+	if strings.Contains(dsn, "no_tmp_dir") {
+		return dsn
+	}
+	if strings.Contains(dsn, "?") {
+		return dsn + "&no_tmp_dir=true"
+	}
+	return dsn + "?no_tmp_dir=true"
 }
 
 func ACAOHeaderOverwriteMiddleware(next echo.HandlerFunc) echo.HandlerFunc {

--- a/pkg/mediorum/server/sniff.go
+++ b/pkg/mediorum/server/sniff.go
@@ -64,7 +64,7 @@ func (ss *MediorumServer) sniffAndFix(ctx context.Context, cid string, fix bool)
 			if a.Attr.Size < best.Attr.Size {
 				break
 			}
-			if err := ss.pullFileFromHost(ctx, a.Host, cid); err == nil {
+			if err := ss.pullFileFromHost(ctx, a.Host, cid, nil); err == nil {
 				break
 			}
 		}

--- a/pkg/mediorum/server/transcode.go
+++ b/pkg/mediorum/server/transcode.go
@@ -357,7 +357,7 @@ func (ss *MediorumServer) transcode(ctx context.Context, upload *Upload) error {
 	logger := ss.logger.With(zap.Any("template", upload.Template), zap.String("cid", fileHash))
 
 	if !ss.haveInMyBucket(fileHash, upload.PlacementHosts) {
-		_, err := ss.findAndPullBlob(ctx, fileHash)
+		_, err := ss.findAndPullBlob(ctx, fileHash, upload.PlacementHosts)
 		if err != nil {
 			logger.Warn("failed to find blob", zap.Error(err))
 			return err

--- a/pkg/mediorum/server/transcode.go
+++ b/pkg/mediorum/server/transcode.go
@@ -285,8 +285,12 @@ func (ss *MediorumServer) transcodeFullAudio(ctx context.Context, upload *Upload
 	}
 	resultKey := resultHash
 
-	// transcode server will retain transcode result for analysis
-	ss.replicateToMyBucket(ctx, resultHash, dest, upload.PlacementHosts)
+	// transcode server will retain transcode result for analysis. If the
+	// local write fails we can't claim to be a transcoded mirror — analysis
+	// and downstream replication would look for the blob here and 404.
+	if err := ss.replicateToMyBucket(ctx, resultHash, dest, upload.PlacementHosts); err != nil {
+		return onError(err, upload.Status, "replicateToMyBucket")
+	}
 
 	upload.TranscodeResults["320"] = resultKey
 

--- a/pkg/mediorum/server/transcode.go
+++ b/pkg/mediorum/server/transcode.go
@@ -286,7 +286,7 @@ func (ss *MediorumServer) transcodeFullAudio(ctx context.Context, upload *Upload
 	resultKey := resultHash
 
 	// transcode server will retain transcode result for analysis
-	ss.replicateToMyBucket(ctx, resultHash, dest)
+	ss.replicateToMyBucket(ctx, resultHash, dest, upload.PlacementHosts)
 
 	upload.TranscodeResults["320"] = resultKey
 
@@ -356,7 +356,7 @@ func (ss *MediorumServer) transcode(ctx context.Context, upload *Upload) error {
 
 	logger := ss.logger.With(zap.Any("template", upload.Template), zap.String("cid", fileHash))
 
-	if !ss.haveInMyBucket(fileHash) {
+	if !ss.haveInMyBucket(fileHash, upload.PlacementHosts) {
 		_, err := ss.findAndPullBlob(ctx, fileHash)
 		if err != nil {
 			logger.Warn("failed to find blob", zap.Error(err))

--- a/pkg/mediorum/server/transcode.go
+++ b/pkg/mediorum/server/transcode.go
@@ -139,14 +139,14 @@ func (ss *MediorumServer) startTranscodeWorker(ctx context.Context) error {
 	}
 }
 
-func (ss *MediorumServer) getKeyToTempFile(fileHash string) (*os.File, error) {
+func (ss *MediorumServer) getKeyToTempFile(fileHash string, placementHosts []string) (*os.File, error) {
 	temp, err := os.CreateTemp("", "mediorumTemp")
 	if err != nil {
 		return nil, err
 	}
 
 	key := cidutil.ShardCID(fileHash)
-	blob, err := ss.bucketForCID(fileHash, nil).NewReader(context.Background(), key, nil)
+	blob, err := ss.bucketForCID(fileHash, placementHosts).NewReader(context.Background(), key, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (ss *MediorumServer) transcode(ctx context.Context, upload *Upload) error {
 		return errMsg
 	}
 
-	temp, err := ss.getKeyToTempFile(fileHash)
+	temp, err := ss.getKeyToTempFile(fileHash, upload.PlacementHosts)
 	if err != nil {
 		return onError(err, upload.Status, "getting file")
 	}

--- a/pkg/mediorum/server/transcode.go
+++ b/pkg/mediorum/server/transcode.go
@@ -146,7 +146,7 @@ func (ss *MediorumServer) getKeyToTempFile(fileHash string) (*os.File, error) {
 	}
 
 	key := cidutil.ShardCID(fileHash)
-	blob, err := ss.bucket.NewReader(context.Background(), key, nil)
+	blob, err := ss.bucketForCID(fileHash, nil).NewReader(context.Background(), key, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mediorum/server/transcode.go
+++ b/pkg/mediorum/server/transcode.go
@@ -139,14 +139,14 @@ func (ss *MediorumServer) startTranscodeWorker(ctx context.Context) error {
 	}
 }
 
-func (ss *MediorumServer) getKeyToTempFile(fileHash string, placementHosts []string) (*os.File, error) {
+func (ss *MediorumServer) getKeyToTempFile(fileHash string) (*os.File, error) {
 	temp, err := os.CreateTemp("", "mediorumTemp")
 	if err != nil {
 		return nil, err
 	}
 
 	key := cidutil.ShardCID(fileHash)
-	blob, err := ss.bucketForCID(fileHash, placementHosts).NewReader(context.Background(), key, nil)
+	blob, _, err := ss.readBlob(context.Background(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +356,7 @@ func (ss *MediorumServer) transcode(ctx context.Context, upload *Upload) error {
 
 	logger := ss.logger.With(zap.Any("template", upload.Template), zap.String("cid", fileHash))
 
-	if !ss.haveInMyBucket(fileHash, upload.PlacementHosts) {
+	if !ss.haveInMyBucket(fileHash) {
 		_, err := ss.findAndPullBlob(ctx, fileHash, upload.PlacementHosts)
 		if err != nil {
 			logger.Warn("failed to find blob", zap.Error(err))
@@ -392,7 +392,7 @@ func (ss *MediorumServer) transcode(ctx context.Context, upload *Upload) error {
 		return errMsg
 	}
 
-	temp, err := ss.getKeyToTempFile(fileHash, upload.PlacementHosts)
+	temp, err := ss.getKeyToTempFile(fileHash)
 	if err != nil {
 		return onError(err, upload.Status, "getting file")
 	}

--- a/pkg/mediorum/server/transcode_preview.go
+++ b/pkg/mediorum/server/transcode_preview.go
@@ -35,16 +35,15 @@ func (ss *MediorumServer) generateAudioPreviewForUpload(ctx context.Context, upl
 // It returns an AudioPreview record, and the client can use that to update a track record.
 func (ss *MediorumServer) generateAudioPreview(ctx context.Context, fileHash string, previewStartSeconds string) (*AudioPreview, error) {
 
-	if !ss.haveInMyBucket(fileHash, nil) {
+	if !ss.haveInMyBucket(fileHash) {
 		_, err := ss.findAndPullBlob(ctx, fileHash, nil)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	// pull to temp file. Preview generation has no upload-level placement
-	// context — pass nil so routing falls back to rendezvous rank.
-	temp, err := ss.getKeyToTempFile(fileHash, nil)
+	// pull to temp file
+	temp, err := ss.getKeyToTempFile(fileHash)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mediorum/server/transcode_preview.go
+++ b/pkg/mediorum/server/transcode_preview.go
@@ -36,7 +36,7 @@ func (ss *MediorumServer) generateAudioPreviewForUpload(ctx context.Context, upl
 func (ss *MediorumServer) generateAudioPreview(ctx context.Context, fileHash string, previewStartSeconds string) (*AudioPreview, error) {
 
 	if !ss.haveInMyBucket(fileHash, nil) {
-		_, err := ss.findAndPullBlob(ctx, fileHash)
+		_, err := ss.findAndPullBlob(ctx, fileHash, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mediorum/server/transcode_preview.go
+++ b/pkg/mediorum/server/transcode_preview.go
@@ -33,6 +33,12 @@ func (ss *MediorumServer) generateAudioPreviewForUpload(ctx context.Context, upl
 
 // generateAudioPreview is the new preview impl which requires only a CID + previewStartSeconds, so that it works with Qm CIDs too.
 // It returns an AudioPreview record, and the client can use that to update a track record.
+//
+// Note: previews are deliberately rendezvous-routed without placement
+// context. The HTTP /generate_preview endpoint takes a bare CID and has
+// no upload row to draw placement from (especially for legacy Qm CIDs);
+// rather than thread placement only through the upload-driven path and
+// leave the HTTP path inconsistent, both go through rendezvous.
 func (ss *MediorumServer) generateAudioPreview(ctx context.Context, fileHash string, previewStartSeconds string) (*AudioPreview, error) {
 
 	if !ss.haveInMyBucket(fileHash) {

--- a/pkg/mediorum/server/transcode_preview.go
+++ b/pkg/mediorum/server/transcode_preview.go
@@ -42,8 +42,9 @@ func (ss *MediorumServer) generateAudioPreview(ctx context.Context, fileHash str
 		}
 	}
 
-	// pull to temp file
-	temp, err := ss.getKeyToTempFile(fileHash)
+	// pull to temp file. Preview generation has no upload-level placement
+	// context — pass nil so routing falls back to rendezvous rank.
+	temp, err := ss.getKeyToTempFile(fileHash, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mediorum/server/transcode_preview.go
+++ b/pkg/mediorum/server/transcode_preview.go
@@ -35,7 +35,7 @@ func (ss *MediorumServer) generateAudioPreviewForUpload(ctx context.Context, upl
 // It returns an AudioPreview record, and the client can use that to update a track record.
 func (ss *MediorumServer) generateAudioPreview(ctx context.Context, fileHash string, previewStartSeconds string) (*AudioPreview, error) {
 
-	if !ss.haveInMyBucket(fileHash) {
+	if !ss.haveInMyBucket(fileHash, nil) {
 		_, err := ss.findAndPullBlob(ctx, fileHash)
 		if err != nil {
 			return nil, err

--- a/pkg/mediorum/server/tusd.go
+++ b/pkg/mediorum/server/tusd.go
@@ -432,9 +432,14 @@ func (ss *MediorumServer) handleTusdUploadComplete(uploadDir string, event handl
 			return
 		}
 
-		// Store in bucket. This is a peer-driven replication push — placement
-		// context isn't carried over the wire, so route by rendezvous rank only.
-		if err := ss.replicateToMyBucket(ctx, filename, file, nil); err != nil {
+		// Store in bucket. The TUS sender (replicateToHost) sets placementHosts
+		// in the upload metadata, so we can route consistent with what the
+		// origin used.
+		var replPlacementHosts []string
+		if hostsStr, ok := event.Upload.MetaData["placementHosts"]; ok && hostsStr != "" {
+			replPlacementHosts = strings.Split(hostsStr, ",")
+		}
+		if err := ss.replicateToMyBucket(ctx, filename, file, replPlacementHosts); err != nil {
 			ss.logger.Error("failed to store replicated file", zap.String("id", event.Upload.ID), zap.String("filename", filename), zap.Error(err))
 			return
 		}

--- a/pkg/mediorum/server/tusd.go
+++ b/pkg/mediorum/server/tusd.go
@@ -392,16 +392,24 @@ func (ss *MediorumServer) handleTusdUploadComplete(uploadDir string, event handl
 
 	// Check if this is a replication request - if so, just store the blob without processing
 	if isReplication, ok := event.Upload.MetaData["isReplication"]; ok && isReplication == "true" {
-		// Disk space check for replication
-		if !ss.diskHasSpace() {
-			ss.logger.Warn("disk is too full to accept replication", zap.String("id", event.Upload.ID))
-			return
-		}
-
 		// Get filename (CID) from metadata
 		filename := event.Upload.MetaData["filename"]
 		if filename == "" {
 			filename = event.Upload.ID
+		}
+
+		// The TUS sender (replicateToHost) sets placementHosts in the upload
+		// metadata, so we can route consistent with what the origin used.
+		var replPlacementHosts []string
+		if hostsStr, ok := event.Upload.MetaData["placementHosts"]; ok && hostsStr != "" {
+			replPlacementHosts = strings.Split(hostsStr, ",")
+		}
+
+		// Per-CID disk space check: only the bucket this CID will write to
+		// matters, so a full archive doesn't block primary writes.
+		if !ss.diskHasSpaceForCID(filename, replPlacementHosts) {
+			ss.logger.Warn("disk is too full to accept replication", zap.String("id", event.Upload.ID))
+			return
 		}
 
 		// Open the uploaded file for validation and storage
@@ -432,13 +440,6 @@ func (ss *MediorumServer) handleTusdUploadComplete(uploadDir string, event handl
 			return
 		}
 
-		// Store in bucket. The TUS sender (replicateToHost) sets placementHosts
-		// in the upload metadata, so we can route consistent with what the
-		// origin used.
-		var replPlacementHosts []string
-		if hostsStr, ok := event.Upload.MetaData["placementHosts"]; ok && hostsStr != "" {
-			replPlacementHosts = strings.Split(hostsStr, ",")
-		}
 		if err := ss.replicateToMyBucket(ctx, filename, file, replPlacementHosts); err != nil {
 			ss.logger.Error("failed to store replicated file", zap.String("id", event.Upload.ID), zap.String("filename", filename), zap.Error(err))
 			return

--- a/pkg/mediorum/server/tusd.go
+++ b/pkg/mediorum/server/tusd.go
@@ -432,8 +432,9 @@ func (ss *MediorumServer) handleTusdUploadComplete(uploadDir string, event handl
 			return
 		}
 
-		// Store in bucket
-		if err := ss.replicateToMyBucket(ctx, filename, file); err != nil {
+		// Store in bucket. This is a peer-driven replication push — placement
+		// context isn't carried over the wire, so route by rendezvous rank only.
+		if err := ss.replicateToMyBucket(ctx, filename, file, nil); err != nil {
 			ss.logger.Error("failed to store replicated file", zap.String("id", event.Upload.ID), zap.String("filename", filename), zap.Error(err))
 			return
 		}


### PR DESCRIPTION
## Summary
- Lets `STORE_ALL=true` nodes route archive content (CIDs they only hold because of `StoreAll`) to a separate bucket configured via `OPENAUDIO_ARCHIVE_STORAGE_DRIVER_URL`. When unset, behavior is unchanged.

### Reads: hot-first-then-archive
- New helpers `blobAttrs` / `readBlob` / `blobExists` try the primary bucket first, fall back to archive on `NotFound`, return the bucket the blob was found in. All read sites use these (`serveBlob`, `serveBlobInfo`, `serveInternalBlobGET`, `serveTrack`, `serve_image` originals, `audio_analysis`, `pos`, `transcode/getKeyToTempFile`, `replicate_worker` source).
- This means reads never need to know about placement context to find a blob — the fallback handles rank-flip orphans, placement edge cases, peer presence checks, and any other write-vs-read routing inconsistency. Variants stay primary-only (cache, regenerable from the original).
- Cost: one extra primary HEAD on archive-bucket cache misses; `attrCache` records which bucket has the blob so warm-cache hits skip the probe.
- This is the foundation a future cold-mode (Glacier-class) flag would layer on: `if !ColdMode { fall back }`. Primary miss with cold-mode on → existing redirect-to-peer logic kicks in.

### Writes: rendezvous + placement
- `bucketForCID(cid, placementHosts)` deterministically picks a write destination. A CID routes to archive iff archive is configured, `StoreAll` is true, the CID isn't in an explicit placement list, and self's rendezvous rank for the CID is `>= ReplicationFactor`.
- `placementHosts` is threaded through every write/pull path (`replicateToMyBucket`, `replicateFileToHost`, `pullFileFromHost`, `findAndPullBlob`) so writes land in the same bucket the routing logic expects.
- `dropFromMyBucket` deletes from both buckets (NotFound benign) — keeps cleanup robust against rank-flip orphans without needing to know which bucket the blob actually lives in.

### Wire protocol
- `X-Placement-Hosts` header is POST-only — `replicateFileToHost` sets it on `/internal/blobs` POST, `serveInternalBlobPOST` parses it. Receivers route writes consistently with what the sender expects.
- GETs (`/internal/blobs/:cid`, `/info`) carry no header. Receivers use the read fallback, so they find the blob wherever it lives without needing routing context.
- TUS replication uses the existing `placementHosts` upload metadata.

### Disk-space gating
- Conservative `diskHasSpace()` (used for the no-CID precheck on `/internal/blobs`) AND-s primary and archive (when archive is configured AND `StoreAll` is true). Per-CID `diskHasSpaceForCID(cid, placementHosts)` checks only the bucket the CID would write to, so a full archive doesn't block primary writes (and vice versa).

### Repair
- Routes through `bucketForCID` (writes), threads `placementHosts` through. Adds `archive_blob_present` / `archive_blob_pulled` / `archive_blob_attrs_fail` counters.
- Presence index lists both buckets (skipped when `StoreAll=false`) and is keyed by `(storage key, bucket)` so a CID present in both is recorded for each.

### Caches
- `attrCache` (`serveBlobInfo`) and `knownPresent` (repair fast path + replicate writes/deletes) are bucket-scoped via a `presenceCacheKey` helper that prefixes by bucket. A cache hit for one bucket can't mask a true miss in the other.

### Health
- `/health-check` surfaces `archiveStorageConfigured`, `archiveStoragePrefix`, `archivePathUsed`, `archivePathSize` (matching primary's surface; `Free` is internal-only and used by the disk check).

## Side fixes (pre-existing bugs flagged during review)
- `audio_analysis.go`'s 3 `Exists()` checks were called with the unsharded CID — silently broken for non-legacy `baeaa…` CIDs (worked only for legacy `Qm…` because `ShardCID` is identity for those).
- `replicateFileParallel`'s worker queue was never closed; if all peer replications failed, workers blocked forever on `range queue` and `wg.Wait()` never returned. Closed after enqueueing.
- File-mode archive DSNs now get the same `no_tmp_dir=true` normalization as the primary DSN, factored into a shared `ensureNoTmpDir` helper.

## v1 limitation
On rendezvous rank flips, the previously-written blob is left in the bucket it originally landed in. Reads use the hot-first-then-archive fallback, so the blob is still served correctly from wherever it lives — the orphan is benign for serving. It's never reaped (`StoreAll` nodes skip the over-replicated cleanup branch in `repair.go`), so dead bytes accumulate over time. A follow-up repair pass could migrate mis-bucketed blobs.

## Test plan
- [x] Unit: `TestBucketForCID` (9 sub-tests) covers the full selector truth table — archive nil, StoreAll false, in/at/past rank boundary, placementHosts override, ReplicationFactor=1 edges, `myRank<0` misconfiguration default.
- [x] Unit: `TestDiskHasSpace*` (11 sub-tests) covers non-prod, S3/GCS shortcut, file:// fallback above/below threshold, both-buckets AND in `diskHasSpace`, archive open but StoreAll false, archive DSN set but bucket nil, per-CID routing in `diskHasSpaceForCID`, placementHosts forcing primary check.
- [ ] CI: `make test-mediorum` passes in the docker harness.
- [ ] Manual: bring up devnet, set `STORE_ALL=true` and `OPENAUDIO_ARCHIVE_STORAGE_DRIVER_URL=file:///tmp/mediorum_archive_node1?no_tmp_dir=true` on one node, upload a track to a different node, and verify archive-rank CIDs land in the archive directory while required CIDs land in primary.
- [ ] Manual: hit `/health-check` on the store_all node and confirm `archiveStorageConfigured: true`, `archiveStoragePrefix: file`, and `archivePathUsed`/`archivePathSize` are populated after upload.
- [ ] Manual: place an explicit upload (`PlacementHosts` set) on a `STORE_ALL=true` node where the upload's rendezvous rank for that node is `>= ReplicationFactor`. Confirm the blob lands in primary (placement wins on writes) and that subsequent reads via `/internal/blobs/:cid` from a peer succeed (read fallback finds it).
- [ ] Manual: backwards compat — with the env var unset, behavior is unchanged (selector returns primary, no new health fields claim a configured archive, fallback never fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)