### PR TITLE
Honor user grants in ETL ValidateSigner

### DIFF
--- a/pkg/etl/processors/entity_manager/grant_test.go
+++ b/pkg/etl/processors/entity_manager/grant_test.go
@@ -2,7 +2,10 @@ package entity_manager
 
 import (
 	"context"
+	"fmt"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestGrantCreate_TxType(t *testing.T) {
@@ -177,4 +180,121 @@ func TestGrantReject_Success(t *testing.T) {
 	if isApproved == nil || *isApproved {
 		t.Error("expected is_approved = false")
 	}
+}
+
+// --- ValidateSigner: grant-based authorization ---
+//
+// These tests use GrantCreate itself as the host action. After establishing an
+// initial grant from user → grantee, we have grantee try to create a *second*
+// grant on the user's behalf — which exercises ValidateSigner's grant-fallback
+// path against the grant we just stored.
+
+func seedAppFor(t *testing.T, pool *pgxpool.Pool, ownerID int64, ownerSigner, address, name string) {
+	t.Helper()
+	meta := fmt.Sprintf(`{"address":%q,"name":%q}`, address, name)
+	mustHandle(t, DeveloperAppCreate(), buildParams(t, pool, EntityTypeDeveloperApp, ActionCreate, ownerID, 1, ownerSigner, meta))
+}
+
+func TestValidateSigner_AppGrant_Allows(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xgrantor", "grantor")
+	seedAppFor(t, pool, uid, "0xGrantor", "0xappa", "AppA")
+	seedAppFor(t, pool, uid, "0xGrantor", "0xappb", "AppB")
+
+	// Grant AppA permission to act for the user.
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, uid, 1, "0xGrantor", `{"grantee_address":"0xappa"}`))
+	// AppA, on the user's behalf, creates a grant for AppB.
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, uid, 2, "0xAppA", `{"grantee_address":"0xappb"}`))
+
+	var exists bool
+	if err := pool.QueryRow(context.Background(),
+		"SELECT EXISTS(SELECT 1 FROM grants WHERE grantee_address = '0xappb' AND user_id = $1 AND is_current = true AND is_revoked = false)",
+		uid).Scan(&exists); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected grant for 0xappb to be created via app-grant signer")
+	}
+}
+
+func TestValidateSigner_UserGrant_Unapproved_Rejects(t *testing.T) {
+	pool := setupTestDB(t)
+	grantor := int64(UserIDOffset + 1)
+	grantee := int64(UserIDOffset + 2)
+	seedUser(t, pool, grantor, "0xgrantor", "grantor")
+	seedUser(t, pool, grantee, "0xgrantee", "grantee")
+	seedAppFor(t, pool, grantor, "0xGrantor", "0xtargetapp", "TargetApp")
+
+	// User-to-user grant created but not yet approved by the grantee.
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 1, "0xGrantor", `{"grantee_address":"0xgrantee"}`))
+
+	// Grantee attempts to use the unapproved grant.
+	mustReject(t, GrantCreate(),
+		buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 2, "0xGrantee", `{"grantee_address":"0xtargetapp"}`),
+		"not approved")
+}
+
+func TestValidateSigner_UserGrant_Approved_Allows(t *testing.T) {
+	pool := setupTestDB(t)
+	grantor := int64(UserIDOffset + 1)
+	grantee := int64(UserIDOffset + 2)
+	seedUser(t, pool, grantor, "0xgrantor", "grantor")
+	seedUser(t, pool, grantee, "0xgrantee", "grantee")
+	seedAppFor(t, pool, grantor, "0xGrantor", "0xtargetapp", "TargetApp")
+
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 1, "0xGrantor", `{"grantee_address":"0xgrantee"}`))
+	approveMeta := fmt.Sprintf(`{"grantee_address":"0xgrantee","grantor_user_id":%d}`, grantor)
+	mustHandle(t, GrantApprove(), buildParams(t, pool, EntityTypeGrant, ActionApprove, grantee, 1, "0xGrantee", approveMeta))
+
+	// Approved grantee can now act on behalf of grantor.
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 2, "0xGrantee", `{"grantee_address":"0xtargetapp"}`))
+}
+
+func TestValidateSigner_RevokedGrant_Rejects(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xgrantor", "grantor")
+	seedAppFor(t, pool, uid, "0xGrantor", "0xrevapp", "RevApp")
+	seedAppFor(t, pool, uid, "0xGrantor", "0xtargetapp", "TargetApp")
+
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, uid, 1, "0xGrantor", `{"grantee_address":"0xrevapp"}`))
+	mustHandle(t, GrantDelete(), buildParams(t, pool, EntityTypeGrant, ActionDelete, uid, 1, "0xGrantor", `{"grantee_address":"0xrevapp"}`))
+
+	mustReject(t, GrantCreate(),
+		buildParams(t, pool, EntityTypeGrant, ActionCreate, uid, 2, "0xRevApp", `{"grantee_address":"0xtargetapp"}`),
+		"revoked")
+}
+
+func TestValidateSigner_NoGrant_Rejects(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xgrantor", "grantor")
+	seedAppFor(t, pool, uid, "0xGrantor", "0xtargetapp", "TargetApp")
+
+	mustReject(t, GrantCreate(),
+		buildParams(t, pool, EntityTypeGrant, ActionCreate, uid, 1, "0xstranger", `{"grantee_address":"0xtargetapp"}`),
+		"not authorized")
+}
+
+func TestValidateSigner_GranteeDeactivated_Rejects(t *testing.T) {
+	pool := setupTestDB(t)
+	grantor := int64(UserIDOffset + 1)
+	grantee := int64(UserIDOffset + 2)
+	seedUser(t, pool, grantor, "0xgrantor", "grantor")
+	seedUser(t, pool, grantee, "0xgrantee", "grantee")
+	seedAppFor(t, pool, grantor, "0xGrantor", "0xtargetapp", "TargetApp")
+
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 1, "0xGrantor", `{"grantee_address":"0xgrantee"}`))
+	approveMeta := fmt.Sprintf(`{"grantee_address":"0xgrantee","grantor_user_id":%d}`, grantor)
+	mustHandle(t, GrantApprove(), buildParams(t, pool, EntityTypeGrant, ActionApprove, grantee, 1, "0xGrantee", approveMeta))
+
+	if _, err := pool.Exec(context.Background(),
+		"UPDATE users SET is_deactivated = true WHERE user_id = $1 AND is_current = true", grantee); err != nil {
+		t.Fatalf("deactivate grantee: %v", err)
+	}
+
+	mustReject(t, GrantCreate(),
+		buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 2, "0xGrantee", `{"grantee_address":"0xtargetapp"}`),
+		"no longer a valid")
 }

--- a/pkg/etl/processors/entity_manager/user_create.go
+++ b/pkg/etl/processors/entity_manager/user_create.go
@@ -144,6 +144,14 @@ func walletExists(ctx context.Context, dbtx db.DBTX, wallet string) (bool, error
 	return exists, err
 }
 
+func activeUserWalletExists(ctx context.Context, dbtx db.DBTX, wallet string) (bool, error) {
+	var exists bool
+	err := dbtx.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM users WHERE wallet = $1 AND is_current = true AND is_deactivated = false)",
+		strings.ToLower(wallet)).Scan(&exists)
+	return exists, err
+}
+
 func developerAppExists(ctx context.Context, dbtx db.DBTX, address string) (bool, error) {
 	var exists bool
 	err := dbtx.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM developer_apps WHERE address = $1 AND is_delete = false)", strings.ToLower(address)).Scan(&exists)

--- a/pkg/etl/processors/entity_manager/validate.go
+++ b/pkg/etl/processors/entity_manager/validate.go
@@ -3,10 +3,12 @@ package entity_manager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"regexp"
 	"strings"
 
 	"github.com/OpenAudio/go-openaudio/etl/db"
+	"github.com/jackc/pgx/v5"
 )
 
 var handleRegexp = regexp.MustCompile(`^[a-z0-9_.]+$`)
@@ -78,9 +80,10 @@ func ValidateDescription(desc string) error {
 	return nil
 }
 
-// ValidateSigner checks that the signer matches the user's wallet or has a valid grant.
-// For now this does a direct wallet comparison. Grant/DeveloperApp authorization
-// will be added as those entity types are implemented.
+// ValidateSigner checks that the signer is the user's wallet or holds a valid
+// grant from the user. Grants come from either a developer app (auto-approved
+// at creation) or another user wallet acting in manager mode (must be approved
+// by the grantor).
 func ValidateSigner(ctx context.Context, params *Params) error {
 	wallet, err := getUserWallet(ctx, params.DBTX, params.UserID)
 	if err != nil {
@@ -89,8 +92,37 @@ func ValidateSigner(ctx context.Context, params *Params) error {
 	if wallet == "" {
 		return NewValidationError("user %d does not exist", params.UserID)
 	}
-	if !strings.EqualFold(wallet, params.Signer) {
-		return NewValidationError("signer %s does not match user %d wallet", params.Signer, params.UserID)
+	if strings.EqualFold(wallet, params.Signer) {
+		return nil
+	}
+
+	signer := strings.ToLower(params.Signer)
+	grant, err := getActiveGrant(ctx, params.DBTX, signer, params.UserID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return NewValidationError("signer %s is not authorized for user %d", params.Signer, params.UserID)
+		}
+		return err
+	}
+	if grant.isRevoked {
+		return NewValidationError("signer %s grant for user %d is revoked", params.Signer, params.UserID)
+	}
+
+	isApp, err := developerAppExists(ctx, params.DBTX, signer)
+	if err != nil {
+		return err
+	}
+	isUser, err := activeUserWalletExists(ctx, params.DBTX, signer)
+	if err != nil {
+		return err
+	}
+	if !isApp && !isUser {
+		return NewValidationError("signer %s is no longer a valid developer app or active user", params.Signer)
+	}
+
+	approved := isApp || (grant.isApproved != nil && *grant.isApproved)
+	if !approved {
+		return NewValidationError("signer %s grant for user %d is not approved", params.Signer, params.UserID)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `ValidateSigner` now accepts a signer that holds an active grant from the user, in addition to the user's own wallet. Previously the grants table was populated but ignored at authorization time, so any signer that wasn't literally the user's wallet was rejected.
- Mirrors the Python ETL's `validate_signer` in `discovery-provider/src/tasks/entity_manager/utils.py`: requires a non-revoked grant, requires the grantee to still resolve to a non-deleted developer app or non-deactivated user, and treats `is_approved == true OR grantee_is_developer_app` as approved (apps are auto-approved at creation).
- Adds a narrow `activeUserWalletExists` helper (filters `is_current` and `is_deactivated`) rather than expanding `walletExists`, since existing callers of `walletExists` use it for "address-taken-ness" rather than "active user".

## Test plan
- [x] `go build ./...` and `go vet ./...` clean in the `pkg/etl` module
- [x] `golangci-lint run ./processors/entity_manager/...` introduces no new findings on changed files
- [x] New `TestValidateSigner_*` tests cover: app-grant allows, user-grant unapproved rejects, user-grant approved allows, revoked grant rejects, no grant rejects, deactivated grantee rejects — all pass against a local Postgres alongside the existing `TestGrant*` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)