### PR TITLE
Fix fork CI: add Postgres service for mediorum unit tests

### DIFF
--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -12,6 +12,20 @@ jobs:
   test:
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: example
+          POSTGRES_DB: mediorum_test
+        ports:
+          - 5454:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Fork PRs run `ci-fork.yml` which executes `go test ./pkg/mediorum/...` directly (no Docker)
- Mediorum tests expect Postgres at `localhost:5454` with user `postgres` / password `example`
- No service was configured, so tests panicked immediately with connection refused
- Adds a `services:` block to spin up Postgres 15 on port 5454 with the correct credentials and a health check

Fixes the `test` job failure seen in PR #202 (and any other fork PRs).

## Test plan

- [ ] Rerun `test` job on a fork PR and confirm mediorum tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)