### PR TITLE
Skip secret-dependent CI on fork PRs

### DIFF
--- a/.github/workflows/buf-publish.yml
+++ b/.github/workflows/buf-publish.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   publish:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create mediorum test databases
+        run: |
+          for i in $(seq 1 9); do
+            PGPASSWORD=example psql -h localhost -p 5454 -U postgres -c "CREATE DATABASE m$i"
+          done
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-test-push:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/docker-build.yml
     with:
       tag: ${{ github.sha }}


### PR DESCRIPTION
## Summary

- `ci.yml` and `buf-publish.yml` need Docker Hub / Buf tokens that fork PRs can't access, causing fast failures on every fork PR
- Adds an `if` guard to skip both workflows when triggered by a fork PR, leaving `ci-fork.yml` as the sole workflow for forks
- Same-repo PRs and push/tag events are unaffected

## Test plan

- [ ] Open a fork PR and confirm only `CI (Fork) / test` runs (no red `CI` or `Buf Publish` jobs)
- [ ] Open a same-repo PR and confirm `CI` and `Buf Publish` still run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)