### PR TITLE
Remove pull_request trigger from Buf Publish

### DIFF
--- a/.github/workflows/buf-publish.yml
+++ b/.github/workflows/buf-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
   workflow_call:
     inputs:


### PR DESCRIPTION
Buf should only publish on push to main and tag events, not on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)