### PR TITLE
chore: temporarily disable edge tag push on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
 
   tag-edge:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: false # temporarily disabled: edge tag pushes trigger auto-upgrade restarts which break snapshot creation (see PR #226)
     needs: build-test-push
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Disables the `:edge` tag push that fires on every merge to `main`
- Each merge → new `:edge` image → auto-upgrader restarts snapshot-serving nodes → nodes spend hours catching up → `createSnapshot` skips every interval during `CatchingUp=true` → no fresh snapshots for ~16 hours → state syncing nodes stall

## Re-enable when

PR #226 is merged and deployed to the snapshot-serving nodes. That PR adds a catch-up snapshot that fires immediately after block sync completes, so restarts no longer create a snapshot gap.

## Test plan

- [ ] Merge this first so no more auto-upgrade restarts break snapshot availability
- [ ] Merge PR #226 (state sync fixes including catch-up snapshot)  
- [ ] Deploy PR #226 image to creatornode.audius.co and creatornode2.audius.co
- [ ] Confirm both nodes create a snapshot on startup
- [ ] Re-enable this workflow condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)