### PR TITLE
feat(etl): port handle_user/track/playlist triggers (parity 1C)

### DIFF
--- a/pkg/etl/db/sql/migrations/0019_content_triggers.down.sql
+++ b/pkg/etl/db/sql/migrations/0019_content_triggers.down.sql
@@ -1,0 +1,11 @@
+DROP TRIGGER IF EXISTS on_playlist ON playlists;
+DROP TRIGGER IF EXISTS on_track ON tracks;
+DROP TRIGGER IF EXISTS on_user ON users;
+
+DROP FUNCTION IF EXISTS handle_playlist();
+DROP FUNCTION IF EXISTS handle_track();
+DROP FUNCTION IF EXISTS handle_user();
+DROP FUNCTION IF EXISTS track_should_notify(tracks, record, varchar);
+DROP FUNCTION IF EXISTS track_is_public(record);
+
+ALTER TABLE aggregate_user DROP COLUMN IF EXISTS total_track_count;

--- a/pkg/etl/db/sql/migrations/0019_content_triggers.up.sql
+++ b/pkg/etl/db/sql/migrations/0019_content_triggers.up.sql
@@ -1,0 +1,333 @@
+-- Add aggregate_user.total_track_count column referenced by handle_track.
+-- (apps#0143_add_user_total_tracks introduced this; ported into the same
+-- migration as the trigger to keep the dependency local.)
+
+ALTER TABLE aggregate_user ADD COLUMN IF NOT EXISTS total_track_count int DEFAULT 0;
+
+-- ============================================================================
+-- handle_user: creates aggregate_user row on user insert. Other triggers
+-- (handle_playlist, handle_track, handle_follow) depend on this row existing.
+-- Ported verbatim from apps/packages/discovery-provider/ddl/functions/handle_user.sql
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION handle_user() RETURNS TRIGGER AS $$
+begin
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  return null;
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+end;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER on_user
+  AFTER INSERT ON users
+  FOR EACH ROW EXECUTE PROCEDURE handle_user();
+EXCEPTION
+  WHEN others THEN NULL;
+END $$;
+
+-- ============================================================================
+-- track_is_public + track_should_notify helpers (used by handle_track)
+-- Ported verbatim from apps/packages/discovery-provider/ddl/functions/handle_track.sql
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION track_is_public(track record) RETURNS boolean AS $$
+begin
+  return track.is_unlisted = false
+     and track.is_available = true
+     and track.is_delete = false
+     and track.stem_of is null;
+end
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION track_should_notify(old_track tracks, new_track record, tg_op varchar) RETURNS boolean AS $$
+begin
+  if tg_op = 'UPDATE' and old_track.track_id is not null then
+    return not track_is_public(old_track) and track_is_public(new_track);
+  else
+    return tg_op = 'INSERT'
+      and track_is_public(new_track)
+    ;
+  end if;
+end
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- handle_track: maintains aggregate_user.{track_count,total_track_count},
+-- aggregate_track row, plus subscriber-create / remix / remix-contest-submission
+-- notifications. Ported verbatim.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION handle_track() RETURNS TRIGGER AS $$
+declare
+  parent_track_owner_id int;
+  subscriber_user_ids int[];
+begin
+  insert into aggregate_track (track_id) values (new.track_id) on conflict do nothing;
+  insert into aggregate_user (user_id) values (new.owner_id) on conflict do nothing;
+
+  update aggregate_user
+  set (track_count, total_track_count) = (
+    select
+      count(*) filter (where t.is_unlisted = false),
+      count(*)
+    from tracks t
+    where t.is_current is true
+      and t.is_delete is false
+      and t.is_available is true
+      and t.stem_of is null
+      and t.owner_id = new.owner_id
+  )
+  where user_id = new.owner_id;
+
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.is_playlist_upload = FALSE THEN
+      select array(
+        select subscriber_id
+          from subscriptions
+          where is_current
+            and not is_delete
+            and user_id = new.owner_id
+      ) into subscriber_user_ids;
+
+      if array_length(subscriber_user_ids, 1) > 0 then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+          (
+            new.blocknumber,
+            subscriber_user_ids,
+            new.updated_at,
+            'create',
+            new.track_id,
+            'create:track:user_id:' || new.owner_id,
+            json_build_object('track_id', new.track_id)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.remix_of is not null THEN
+      select owner_id into parent_track_owner_id from tracks
+      where is_current and track_id = (new.remix_of->'tracks'->0->>'parent_track_id')::int
+      limit 1;
+      if parent_track_owner_id is not null then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+          (
+            new.blocknumber,
+            ARRAY [parent_track_owner_id],
+            new.updated_at,
+            'remix',
+            new.owner_id,
+            'remix:track:' || new.track_id || ':parent_track:' || (new.remix_of->'tracks'->0->>'parent_track_id')::int,
+            json_build_object('track_id', new.track_id, 'parent_track_id', (new.remix_of->'tracks'->0->>'parent_track_id')::int)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.remix_of is not null THEN
+      declare
+        contest_event_id int;
+        contest_creator_id int;
+        submission_count int;
+        milestone int;
+        parent_track_id int := (new.remix_of->'tracks'->0->>'parent_track_id')::int;
+      begin
+        select event_id, user_id
+        into contest_event_id, contest_creator_id
+        from events
+        where event_type = 'remix_contest'
+          and is_deleted = false
+          and end_date > now()
+          and entity_id = parent_track_id
+        limit 1;
+
+        if contest_event_id is not null then
+          select count(*) into submission_count
+          from tracks t
+          join events e on e.event_type = 'remix_contest'
+            and e.is_deleted = false
+            and e.entity_id = parent_track_id
+          where t.is_current = true
+            and t.is_delete = false
+            and t.remix_of is not null
+            and (t.remix_of->'tracks'->0->>'parent_track_id')::int = parent_track_id
+            and t.created_at >= e.created_at;
+
+          FOREACH milestone IN ARRAY ARRAY[1, 10, 50] LOOP
+            IF submission_count = milestone THEN
+              insert into notification
+                (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+                (
+                  new.blocknumber,
+                  ARRAY [contest_creator_id],
+                  new.updated_at,
+                  'artist_remix_contest_submissions',
+                  milestone || ':' || contest_event_id,
+                  'artist_remix_contest_submissions:' || contest_event_id || ':' || milestone,
+                  json_build_object(
+                    'event_id', contest_event_id,
+                    'milestone', milestone,
+                    'entity_id', parent_track_id
+                  )
+                )
+              on conflict do nothing;
+            END IF;
+          END LOOP;
+        end if;
+      end;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+end;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER on_track
+  AFTER INSERT OR UPDATE ON tracks
+  FOR EACH ROW EXECUTE PROCEDURE handle_track();
+EXCEPTION
+  WHEN others THEN NULL;
+END $$;
+
+-- ============================================================================
+-- handle_playlist: maintains aggregate_playlist row, aggregate_user.{playlist_count,
+-- album_count}, plus subscriber-create and track-added-to-playlist notifications.
+--
+-- The apps version reads previous state from `revert_blocks` (apps' reorg
+-- table) to compute delta. go-openaudio doesn't track reverts, so we strip
+-- that lookup. With old_row left null:
+--   - insert of public playlist (is_private=false) → delta=1 (correct)
+--   - insert of private playlist → delta=0 (correct)
+-- The private→public publish path in apps fires this trigger via INSERT of
+-- a new is_current row; go-openaudio's playlist_update.go does in-place UPDATE
+-- so this trigger won't fire on publish today. That gap is tracked separately
+-- (see Stack 4A publish_scheduled_releases / Stack 2 in-block updates).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION handle_playlist() RETURNS TRIGGER AS $$
+declare
+  track_owner_id int := 0;
+  track_item jsonb;
+  subscriber_user_ids integer[];
+  delta int := 0;
+begin
+  insert into aggregate_playlist (playlist_id, is_album) values (new.playlist_id, new.is_album) on conflict do nothing;
+
+  if new.is_private = false then
+    delta := 1;
+  end if;
+
+  if delta != 0 then
+    if new.is_album then
+      update aggregate_user
+      set album_count = album_count + delta
+      where user_id = new.playlist_owner_id;
+    else
+      update aggregate_user
+      set playlist_count = playlist_count + delta
+      where user_id = new.playlist_owner_id;
+    end if;
+  end if;
+
+  begin
+    if new.is_private = false and new.is_delete = false and new.created_at = new.updated_at then
+      select array(
+        select subscriber_id
+          from subscriptions
+          where is_current
+            and not is_delete
+            and user_id = new.playlist_owner_id
+      ) into subscriber_user_ids;
+      if array_length(subscriber_user_ids, 1) > 0 then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+          (
+            new.blocknumber,
+            subscriber_user_ids,
+            new.updated_at,
+            'create',
+            new.playlist_owner_id,
+            'create:playlist_id:' || new.playlist_id,
+            json_build_object('playlist_id', new.playlist_id, 'is_album', new.is_album)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  begin
+    if new.is_delete is false and new.is_private is false then
+      for track_item IN select jsonb_array_elements from jsonb_array_elements(new.playlist_contents->'track_ids')
+      loop
+        if (track_item->>'time')::double precision::int >= extract(epoch from new.updated_at)::int then
+          select owner_id into track_owner_id from tracks where is_current and track_id = (track_item->>'track')::int;
+          if track_owner_id != new.playlist_owner_id then
+            insert into notification
+              (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+            values
+              (
+                new.blocknumber,
+                ARRAY [track_owner_id],
+                new.updated_at,
+                'track_added_to_playlist',
+                track_owner_id,
+                'track_added_to_playlist:playlist_id:' || new.playlist_id || ':track_id:' || (track_item->>'track')::int,
+                json_build_object('track_id', (track_item->>'track')::int, 'playlist_id', new.playlist_id, 'playlist_owner_id', new.playlist_owner_id)
+              )
+            on conflict do nothing;
+          end if;
+        end if;
+      end loop;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+end;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER on_playlist
+  AFTER INSERT ON playlists
+  FOR EACH ROW EXECUTE PROCEDURE handle_playlist();
+EXCEPTION
+  WHEN others THEN NULL;
+END $$;

--- a/pkg/etl/processors/entity_manager/content_triggers_test.go
+++ b/pkg/etl/processors/entity_manager/content_triggers_test.go
@@ -1,0 +1,173 @@
+package entity_manager
+
+import (
+	"context"
+	"strconv"
+	"testing"
+)
+
+// Tests for the content triggers ported in migration 0019:
+// handle_track and handle_playlist. These triggers fire on INSERT (and
+// for tracks, also UPDATE) into the tracks/playlists tables. Go-side
+// entity_manager handlers do the inserts; the triggers should keep
+// aggregate_user track_count/playlist_count/album_count in sync and
+// initialize aggregate_track / aggregate_playlist rows.
+
+func TestTrigger_HandleTrack_InitializesAggregates(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 200)
+	tid := int64(TrackIDOffset + 2000)
+	seedUser(t, pool, uid, "0xtrigtrack", "trigtrack")
+
+	meta := `{"owner_id":3000200,"title":"Trigger Test","genre":"Electronic"}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xtrigtrack", meta))
+
+	// aggregate_track row created
+	var saveCount, repostCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT save_count, repost_count FROM aggregate_track WHERE track_id = $1", tid).Scan(&saveCount, &repostCount); err != nil {
+		t.Fatalf("aggregate_track: %v", err)
+	}
+	// aggregate_user.track_count = 1 (public track)
+	var trackCount, totalTrackCount int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT track_count, total_track_count FROM aggregate_user WHERE user_id = $1", uid).Scan(&trackCount, &totalTrackCount); err != nil {
+		t.Fatalf("aggregate_user: %v", err)
+	}
+	if trackCount != 1 {
+		t.Errorf("aggregate_user.track_count = %d, want 1", trackCount)
+	}
+	if totalTrackCount != 1 {
+		t.Errorf("aggregate_user.total_track_count = %d, want 1", totalTrackCount)
+	}
+}
+
+func TestTrigger_HandleTrack_UnlistedDoesNotIncrementTrackCount(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 210)
+	tid := int64(TrackIDOffset + 2100)
+	seedUser(t, pool, uid, "0xunlisted", "unlistedu")
+
+	meta := `{"owner_id":3000210,"title":"Hidden","genre":"Electronic","is_unlisted":true}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xunlisted", meta))
+
+	var trackCount, totalTrackCount int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT track_count, total_track_count FROM aggregate_user WHERE user_id = $1", uid).Scan(&trackCount, &totalTrackCount); err != nil {
+		t.Fatalf("aggregate_user: %v", err)
+	}
+	if trackCount != 0 {
+		t.Errorf("track_count = %d, want 0 for unlisted track", trackCount)
+	}
+	if totalTrackCount != 1 {
+		t.Errorf("total_track_count = %d, want 1 (counts unlisted)", totalTrackCount)
+	}
+}
+
+func TestTrigger_HandleTrack_RemixCreatesNotification(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	parentOwner := int64(UserIDOffset + 220)
+	remixer := int64(UserIDOffset + 221)
+	parentID := int64(TrackIDOffset + 2200)
+	remixID := int64(TrackIDOffset + 2201)
+	seedUser(t, pool, parentOwner, "0xparent", "parentu")
+	seedUser(t, pool, remixer, "0xremixer", "remixu")
+	seedTrackFull(t, pool, parentID, parentOwner, "Original")
+
+	meta := `{"owner_id":3000221,"title":"Remix","genre":"Electronic","remix_of":{"tracks":[{"parent_track_id":2002200}]}}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, remixer, remixID, "0xremixer", meta))
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM notification WHERE type = 'remix' AND specifier = $1",
+		strconv.FormatInt(remixer, 10)).Scan(&count); err != nil {
+		t.Fatalf("count notifications: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 remix notification, got %d", count)
+	}
+}
+
+func TestTrigger_HandlePlaylist_InitializesAggregates(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 230)
+	pid := int64(PlaylistIDOffset + 3000)
+	seedUser(t, pool, uid, "0xplowner", "plowner")
+
+	meta := `{"playlist_name":"My Playlist","is_album":false,"is_private":false}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xplowner", meta))
+
+	var aggIsAlbum *bool
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_album FROM aggregate_playlist WHERE playlist_id = $1", pid).Scan(&aggIsAlbum); err != nil {
+		t.Fatalf("aggregate_playlist row: %v", err)
+	}
+	if aggIsAlbum == nil || *aggIsAlbum != false {
+		t.Errorf("aggregate_playlist.is_album = %v, want false", aggIsAlbum)
+	}
+
+	var playlistCount, albumCount int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT playlist_count, album_count FROM aggregate_user WHERE user_id = $1", uid).Scan(&playlistCount, &albumCount); err != nil {
+		t.Fatalf("aggregate_user: %v", err)
+	}
+	if playlistCount != 1 {
+		t.Errorf("playlist_count = %d, want 1", playlistCount)
+	}
+	if albumCount != 0 {
+		t.Errorf("album_count = %d, want 0", albumCount)
+	}
+}
+
+func TestTrigger_HandlePlaylist_AlbumIncrementsAlbumCount(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 240)
+	pid := int64(PlaylistIDOffset + 3100)
+	seedUser(t, pool, uid, "0xalbumowner", "albumown")
+
+	meta := `{"playlist_name":"My Album","is_album":true,"is_private":false}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xalbumowner", meta))
+
+	var playlistCount, albumCount int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT playlist_count, album_count FROM aggregate_user WHERE user_id = $1", uid).Scan(&playlistCount, &albumCount); err != nil {
+		t.Fatalf("aggregate_user: %v", err)
+	}
+	if playlistCount != 0 {
+		t.Errorf("playlist_count = %d, want 0", playlistCount)
+	}
+	if albumCount != 1 {
+		t.Errorf("album_count = %d, want 1", albumCount)
+	}
+}
+
+func TestTrigger_HandlePlaylist_PrivateDoesNotIncrement(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 250)
+	pid := int64(PlaylistIDOffset + 3200)
+	seedUser(t, pool, uid, "0xprivate", "privu")
+
+	meta := `{"playlist_name":"Hidden Playlist","is_album":false,"is_private":true}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xprivate", meta))
+
+	var playlistCount int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT playlist_count FROM aggregate_user WHERE user_id = $1", uid).Scan(&playlistCount); err != nil {
+		t.Fatalf("aggregate_user: %v", err)
+	}
+	if playlistCount != 0 {
+		t.Errorf("playlist_count = %d, want 0 for private playlist", playlistCount)
+	}
+}


### PR DESCRIPTION
## Summary

Stack 1C of the trigger-port plan. Migration 0019 adds:

- \`aggregate_user.total_track_count\` column (apps#0143).
- \`handle_user\` — creates \`aggregate_user\` row on user insert. Other triggers (handle_playlist, handle_track, handle_follow) depend on this row existing.
- \`handle_track\` — maintains \`aggregate_track\` + \`aggregate_user.{track_count, total_track_count}\`, plus subscriber-create / remix / remix-contest notifications. Verbatim port; fires on INSERT OR UPDATE.
- \`handle_playlist\` — maintains \`aggregate_playlist\` + \`aggregate_user.{playlist_count, album_count}\`, plus subscriber-create and track-added-to-playlist notifications.

## Deferred

**\`handle_play\`** — apps' trigger fires on a \`plays\` table matching apps' schema, but go-openaudio currently has only \`etl_plays\` (different schema). A follow-up PR will add the apps-shaped \`plays\` table and wire the play processor before the trigger lands.

## Stripped (no reorg support per scoping)

\`handle_playlist\`'s \`revert_blocks\` lookup was removed (go-openaudio doesn't track reverts). With \`old_row\` treated as null:
- INSERT of public playlist (\`is_private=false\`) → delta=1 ✓
- INSERT of private playlist → delta=0 ✓

The private→public publish path in apps fires the trigger via INSERT of a new \`is_current\` row; go-openaudio's \`playlist_update.go\` does in-place UPDATE so this trigger won't fire on publish today. That's tracked in Stack 4A (\`publish_scheduled_releases\`).

## Stack context

Stacked on #239 (1B — social triggers).

- 1A — aggregate tables (#238)
- 1B — social triggers (#239)
- **1C** (this PR) — content triggers (handle_user / handle_track / handle_playlist)
- 1D — secondary triggers (handle_comment / handle_event / handle_share / handle_supporter_rank_ups)

## Test plan

Six DB-backed tests in [content_triggers_test.go](pkg/etl/processors/entity_manager/content_triggers_test.go):

- [x] \`TestTrigger_HandleTrack_InitializesAggregates\` — aggregate_track row + user track counts increment
- [x] \`TestTrigger_HandleTrack_UnlistedDoesNotIncrementTrackCount\` — unlisted track only ticks total_track_count
- [x] \`TestTrigger_HandleTrack_RemixCreatesNotification\` — remix-of triggers a parent-owner notification
- [x] \`TestTrigger_HandlePlaylist_InitializesAggregates\` — aggregate_playlist row + user playlist_count increments
- [x] \`TestTrigger_HandlePlaylist_AlbumIncrementsAlbumCount\` — \`is_album=true\` ticks album_count instead
- [x] \`TestTrigger_HandlePlaylist_PrivateDoesNotIncrement\` — \`is_private=true\` suppresses delta
- [x] All 6 trigger tests + 1B's 6 tests pass together (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)