### PR TITLE
feat(etl): port handle_comment/event/share triggers (parity 1D)

### DIFF
--- a/pkg/etl/db/sql/migrations/0020_secondary_triggers.down.sql
+++ b/pkg/etl/db/sql/migrations/0020_secondary_triggers.down.sql
@@ -1,0 +1,12 @@
+DROP TRIGGER IF EXISTS on_share ON shares;
+DROP TRIGGER IF EXISTS on_event ON events;
+DROP TRIGGER IF EXISTS on_comment ON comments;
+
+DROP FUNCTION IF EXISTS handle_share();
+DROP FUNCTION IF EXISTS handle_event();
+DROP FUNCTION IF EXISTS handle_comment();
+
+ALTER TABLE aggregate_user DROP COLUMN IF EXISTS track_share_count;
+ALTER TABLE aggregate_playlist DROP COLUMN IF EXISTS share_count;
+ALTER TABLE aggregate_track DROP COLUMN IF EXISTS share_count;
+ALTER TABLE aggregate_track DROP COLUMN IF EXISTS comment_count;

--- a/pkg/etl/db/sql/migrations/0020_secondary_triggers.up.sql
+++ b/pkg/etl/db/sql/migrations/0020_secondary_triggers.up.sql
@@ -1,0 +1,186 @@
+-- Add aggregate columns referenced by handle_comment + handle_share.
+-- (apps#0145 added share_count + track_share_count; comment_count came in
+-- a separate apps migration. Ported into one place here.)
+
+ALTER TABLE aggregate_track ADD COLUMN IF NOT EXISTS comment_count int NOT NULL DEFAULT 0;
+ALTER TABLE aggregate_track ADD COLUMN IF NOT EXISTS share_count int DEFAULT 0;
+ALTER TABLE aggregate_playlist ADD COLUMN IF NOT EXISTS share_count int DEFAULT 0;
+ALTER TABLE aggregate_user ADD COLUMN IF NOT EXISTS track_share_count int DEFAULT 0;
+
+-- ============================================================================
+-- handle_comment: maintains aggregate_track.comment_count.
+-- Ported verbatim from apps/packages/discovery-provider/ddl/functions/handle_comment.sql
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION handle_comment() RETURNS TRIGGER AS $$
+begin
+  if new.entity_type = 'Track' then
+    insert into aggregate_track (track_id) values (new.entity_id) on conflict do nothing;
+  end if;
+
+  if new.entity_type = 'Track' then
+    update aggregate_track
+    set comment_count = (
+      select count(*)
+      from comments c
+      where c.is_delete is false
+        and c.is_visible is true
+        and c.entity_type = new.entity_type
+        and c.entity_id = new.entity_id
+    )
+    where track_id = new.entity_id;
+  end if;
+
+  return null;
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER on_comment
+  AFTER INSERT ON comments
+  FOR EACH ROW EXECUTE PROCEDURE handle_comment();
+EXCEPTION
+  WHEN others THEN NULL;
+END $$;
+
+-- ============================================================================
+-- handle_event: creates fan_remix_contest_started notifications when a remix
+-- contest event is created on a public track. Ported verbatim.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION handle_event() RETURNS TRIGGER AS $$
+declare
+  notified_user_id int;
+  owner_user_id int;
+  is_track_public boolean;
+begin
+  if new.event_type = 'remix_contest' and new.is_deleted = false then
+    select owner_id, not is_unlisted into owner_user_id, is_track_public
+    from tracks
+    where is_current and track_id = new.entity_id
+    limit 1;
+
+    if is_track_public then
+      for notified_user_id in
+        select distinct user_id
+        from (
+          select f.follower_user_id as user_id
+          from follows f
+          where f.followee_user_id = new.user_id
+            and f.is_current = true
+            and f.is_delete = false
+          union
+          select s.user_id
+          from saves s
+          where s.save_item_id = new.entity_id
+            and s.save_type = 'track'
+            and s.is_current = true
+            and s.is_delete = false
+        ) as users_to_notify
+      loop
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+          (
+            new.blocknumber,
+            ARRAY[notified_user_id],
+            new.created_at,
+            'fan_remix_contest_started',
+            notified_user_id,
+            'fan_remix_contest_started:' || new.entity_id || ':user:' || new.user_id,
+            json_build_object('entity_user_id', owner_user_id, 'entity_id', new.entity_id)
+          )
+        on conflict do nothing;
+      end loop;
+    end if;
+  end if;
+
+  return null;
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER on_event
+  AFTER INSERT ON events
+  FOR EACH ROW EXECUTE PROCEDURE handle_event();
+EXCEPTION
+  WHEN others THEN NULL;
+END $$;
+
+-- ============================================================================
+-- handle_share: maintains aggregate_track.share_count or aggregate_playlist.share_count,
+-- and aggregate_user.track_share_count for track shares.
+-- Ported verbatim from apps/packages/discovery-provider/ddl/functions/handle_share.sql
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION handle_share() RETURNS TRIGGER AS $$
+begin
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+
+  if new.share_type::text = 'track' then
+    insert into aggregate_track (track_id) values (new.share_item_id) on conflict do nothing;
+  else
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.share_item_id
+      and p.is_current
+    on conflict do nothing;
+  end if;
+
+  if new.share_type::text = 'track' then
+    update aggregate_track
+    set share_count = (
+      select count(*)
+      from shares s
+      where s.share_type = new.share_type
+        and s.share_item_id = new.share_item_id
+    )
+    where track_id = new.share_item_id;
+
+    update aggregate_user
+    set track_share_count = (
+      select count(*)
+      from shares s
+      where s.user_id = new.user_id
+        and s.share_type = new.share_type
+    )
+    where user_id = new.user_id;
+  else
+    update aggregate_playlist
+    set share_count = (
+      select count(*)
+      from shares s
+      where s.share_type = new.share_type
+        and s.share_item_id = new.share_item_id
+    )
+    where playlist_id = new.share_item_id;
+  end if;
+
+  return null;
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER on_share
+  AFTER INSERT ON shares
+  FOR EACH ROW EXECUTE PROCEDURE handle_share();
+EXCEPTION
+  WHEN others THEN NULL;
+END $$;
+
+-- handle_supporter_rank_up intentionally not ported: it depends on
+-- user_bank_txs and supporter_rank_ups tables which are part of the Solana
+-- indexer (out of scope per parity plan).

--- a/pkg/etl/processors/entity_manager/secondary_triggers_test.go
+++ b/pkg/etl/processors/entity_manager/secondary_triggers_test.go
@@ -1,0 +1,105 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+// Tests for handle_comment, handle_event, handle_share triggers ported in
+// migration 0020.
+
+func TestTrigger_HandleComment_TicksCommentCount(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	commenter := int64(UserIDOffset + 300)
+	owner := int64(UserIDOffset + 301)
+	tid := int64(TrackIDOffset + 5000)
+	cid := int64(CommentIDOffset + 100)
+	seedUser(t, pool, commenter, "0xcommenter", "cmtu")
+	seedUser(t, pool, owner, "0xowner", "ownr")
+	seedTrackFull(t, pool, tid, owner, "Commented Song")
+
+	meta := `{"comment_id":4000100,"body":"nice","entity_id":2005000,"entity_type":"Track"}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, commenter, cid, "0xcommenter", meta))
+
+	var commentCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT comment_count FROM aggregate_track WHERE track_id = $1", tid).Scan(&commentCount); err != nil {
+		t.Fatalf("aggregate_track: %v", err)
+	}
+	if commentCount != 1 {
+		t.Errorf("aggregate_track.comment_count = %d, want 1", commentCount)
+	}
+}
+
+func TestTrigger_HandleShare_TicksTrackShareCount(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	sharer := int64(UserIDOffset + 310)
+	owner := int64(UserIDOffset + 311)
+	tid := int64(TrackIDOffset + 5100)
+	seedUser(t, pool, sharer, "0xsharer", "shu")
+	seedUser(t, pool, owner, "0xshareown", "showu")
+	seedTrackFull(t, pool, tid, owner, "Shared Song")
+
+	mustHandle(t, Share(),
+		buildParams(t, pool, EntityTypeTrack, ActionShare, sharer, tid, "0xsharer", `{}`))
+
+	var trackShareCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT share_count FROM aggregate_track WHERE track_id = $1", tid).Scan(&trackShareCount); err != nil {
+		t.Fatalf("aggregate_track: %v", err)
+	}
+	if trackShareCount != 1 {
+		t.Errorf("aggregate_track.share_count = %d, want 1", trackShareCount)
+	}
+
+	var userShareCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT track_share_count FROM aggregate_user WHERE user_id = $1", sharer).Scan(&userShareCount); err != nil {
+		t.Fatalf("aggregate_user: %v", err)
+	}
+	if userShareCount != 1 {
+		t.Errorf("aggregate_user.track_share_count = %d, want 1", userShareCount)
+	}
+}
+
+func TestTrigger_HandleEvent_RemixContestNotifiesFollowers(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	creator := int64(UserIDOffset + 320)
+	follower := int64(UserIDOffset + 321)
+	tid := int64(TrackIDOffset + 5200)
+	eventID := int64(99000)
+
+	seedUser(t, pool, creator, "0xcreator", "creau")
+	seedUser(t, pool, follower, "0xfollA", "follA")
+	seedTrackFull(t, pool, tid, creator, "Remix Parent")
+
+	// follower follows creator
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO follows (follower_user_id, followee_user_id, is_current, is_delete, created_at, txhash, blocknumber)
+		VALUES ($1, $2, true, false, now(), 'tx-fol', 100)
+	`, follower, creator); err != nil {
+		t.Fatalf("seed follow: %v", err)
+	}
+
+	// creator inserts a remix_contest event
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO events (event_id, event_type, user_id, entity_type, entity_id, end_date, is_deleted, created_at, updated_at, blocknumber, txhash, blockhash)
+		VALUES ($1, 'remix_contest', $2, 'Track', $3, now() + interval '7 days', false, now(), now(), 100, 'tx-evt', 'bh-evt')
+	`, eventID, creator, tid); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM notification WHERE type = 'fan_remix_contest_started' AND user_ids @> ARRAY[$1::int]",
+		int(follower)).Scan(&count); err != nil {
+		t.Fatalf("count notifications: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 fan_remix_contest_started notification for follower, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Stack 1D of the trigger-port plan. Migration 0020 adds:

- New aggregate columns: \`aggregate_track.{comment_count,share_count}\`, \`aggregate_playlist.share_count\`, \`aggregate_user.track_share_count\` (apps#0145).
- \`handle_comment\` — maintains \`aggregate_track.comment_count\` from non-deleted, visible comments.
- \`handle_event\` — creates \`fan_remix_contest_started\` notifications for followers + favoriters when a remix_contest event is added on a public track.
- \`handle_share\` — maintains \`aggregate_track.share_count\` or \`aggregate_playlist.share_count\` and \`aggregate_user.track_share_count\`.

## Skipped

\`handle_supporter_rank_up\` is intentionally not ported. It depends on \`user_bank_txs\` and \`supporter_rank_ups\` tables which are part of the Solana indexer (explicitly out of scope per the parity plan).

## Stack context

Stacked on #240 (1C — content triggers).

- 1A — aggregate tables (#238)
- 1B — social triggers (#239)
- 1C — content triggers (#240)
- **1D** (this PR) — secondary triggers
- handle_play deferred until apps-shaped \`plays\` table lands

## Test plan

Three DB-backed tests in [secondary_triggers_test.go](pkg/etl/processors/entity_manager/secondary_triggers_test.go):

- [x] \`TestTrigger_HandleComment_TicksCommentCount\` — comment insert ticks aggregate_track.comment_count
- [x] \`TestTrigger_HandleShare_TicksTrackShareCount\` — share insert ticks track + user share counts
- [x] \`TestTrigger_HandleEvent_RemixContestNotifiesFollowers\` — remix_contest event creates fan_remix_contest_started notification for followers
- [x] All 1B + 1C + 1D trigger tests pass together (no regressions)
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)