### PR TITLE
feat(etl): playlist_tracks junction table + handler population (parity 2A)

### DIFF
--- a/pkg/etl/db/sql/migrations/0021_playlist_tracks.down.sql
+++ b/pkg/etl/db/sql/migrations/0021_playlist_tracks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS playlist_tracks;

--- a/pkg/etl/db/sql/migrations/0021_playlist_tracks.up.sql
+++ b/pkg/etl/db/sql/migrations/0021_playlist_tracks.up.sql
@@ -1,0 +1,17 @@
+-- playlist_tracks: explicit junction table mirroring playlist_contents JSONB.
+-- Schema from apps#0055_playlists_tracks.sql.
+--
+-- handle_playlist_track is intentionally not ported: apps' trigger only does
+-- usdc_purchase notification fan-out (Solana, out of scope). Go-side
+-- entity_manager handlers populate this table directly via updatePlaylistTracks.
+
+CREATE TABLE IF NOT EXISTS playlist_tracks (
+  playlist_id INTEGER NOT NULL,
+  track_id INTEGER NOT NULL,
+  is_removed BOOLEAN NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (playlist_id, track_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_playlist_tracks_track_id ON playlist_tracks USING btree (track_id, created_at);

--- a/pkg/etl/processors/entity_manager/playlist_create.go
+++ b/pkg/etl/processors/entity_manager/playlist_create.go
@@ -108,6 +108,10 @@ func insertPlaylistAndRoute(ctx context.Context, params *Params) error {
 		return err
 	}
 
+	if err := updatePlaylistTracks(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
+		return err
+	}
+
 	// Insert playlist routes if a name is provided.
 	//
 	// Two rows get written on create, both mirroring discovery-provider's

--- a/pkg/etl/processors/entity_manager/playlist_tracks.go
+++ b/pkg/etl/processors/entity_manager/playlist_tracks.go
@@ -1,0 +1,132 @@
+package entity_manager
+
+import (
+	"context"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+)
+
+// extractPlaylistTrackIDs reads track_ids out of a playlist_contents metadata
+// blob. Mirrors apps' playlist.py behavior: accepts either the new array
+// format `[{track:..., time:...}]` or the legacy `{track_ids: [...]}` form.
+// Each entry can use `track` or `track_id` as the field name.
+func extractPlaylistTrackIDs(metadata map[string]any) []int64 {
+	if metadata == nil {
+		return nil
+	}
+	contents, ok := metadata["playlist_contents"]
+	if !ok || contents == nil {
+		return nil
+	}
+
+	var entries []any
+	switch v := contents.(type) {
+	case map[string]any:
+		raw, ok := v["track_ids"]
+		if !ok {
+			return nil
+		}
+		arr, ok := raw.([]any)
+		if !ok {
+			return nil
+		}
+		entries = arr
+	case []any:
+		entries = v
+	default:
+		return nil
+	}
+
+	ids := make([]int64, 0, len(entries))
+	for _, entry := range entries {
+		obj, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := metadataMapInt64(obj, "track_id"); ok {
+			ids = append(ids, id)
+			continue
+		}
+		if id, ok := metadataMapInt64(obj, "track"); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// updatePlaylistTracks materializes the playlist_tracks junction table from
+// the playlist_contents metadata. Mirrors apps' update_playlist_tracks (in
+// playlist.py): rows missing from the new contents are marked is_removed=true,
+// new rows are inserted, and previously removed rows that reappear are
+// recovered (is_removed=false).
+//
+// Side effects on tracks.playlists_containing_track / playlists_previously_containing_track
+// are deferred — they're touched by apps' Python helper but not strictly
+// required for parity of the junction table itself.
+func updatePlaylistTracks(ctx context.Context, dbtx db.DBTX, playlistID int64, metadata map[string]any) error {
+	updatedIDs := extractPlaylistTrackIDs(metadata)
+	updatedSet := make(map[int64]struct{}, len(updatedIDs))
+	for _, id := range updatedIDs {
+		updatedSet[id] = struct{}{}
+	}
+
+	rows, err := dbtx.Query(ctx, `
+		SELECT track_id, is_removed FROM playlist_tracks WHERE playlist_id = $1
+	`, playlistID)
+	if err != nil {
+		return err
+	}
+	existing := make(map[int64]bool)
+	for rows.Next() {
+		var trackID int64
+		var isRemoved bool
+		if err := rows.Scan(&trackID, &isRemoved); err != nil {
+			rows.Close()
+			return err
+		}
+		existing[trackID] = isRemoved
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for trackID, wasRemoved := range existing {
+		if _, stillIn := updatedSet[trackID]; stillIn {
+			if wasRemoved {
+				if _, err := dbtx.Exec(ctx, `
+					UPDATE playlist_tracks
+					SET is_removed = false, updated_at = now()
+					WHERE playlist_id = $1 AND track_id = $2
+				`, playlistID, trackID); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if !wasRemoved {
+			if _, err := dbtx.Exec(ctx, `
+				UPDATE playlist_tracks
+				SET is_removed = true, updated_at = now()
+				WHERE playlist_id = $1 AND track_id = $2
+			`, playlistID, trackID); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, trackID := range updatedIDs {
+		if _, exists := existing[trackID]; exists {
+			continue
+		}
+		if _, err := dbtx.Exec(ctx, `
+			INSERT INTO playlist_tracks (playlist_id, track_id, is_removed)
+			VALUES ($1, $2, false)
+			ON CONFLICT (playlist_id, track_id) DO NOTHING
+		`, playlistID, trackID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/etl/processors/entity_manager/playlist_tracks_test.go
+++ b/pkg/etl/processors/entity_manager/playlist_tracks_test.go
@@ -1,0 +1,112 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractPlaylistTrackIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []int64
+	}{
+		{
+			name: "legacy {track_ids: [{track:..}]} format",
+			raw:  `{"playlist_contents":{"track_ids":[{"track":2000001,"time":100},{"track":2000002,"time":200}]}}`,
+			want: []int64{2000001, 2000002},
+		},
+		{
+			name: "new array format with track_id",
+			raw:  `{"playlist_contents":[{"track_id":2000003,"time":300}]}`,
+			want: []int64{2000003},
+		},
+		{
+			name: "missing playlist_contents",
+			raw:  `{}`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var meta map[string]any
+			_ = json.Unmarshal([]byte(tt.raw), &meta)
+			got := extractPlaylistTrackIDs(meta)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPlaylistCreate_PopulatesPlaylistTracks(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 400)
+	pid := int64(PlaylistIDOffset + 4000)
+	t1 := int64(TrackIDOffset + 6000)
+	t2 := int64(TrackIDOffset + 6001)
+
+	seedUser(t, pool, uid, "0xpltracksu", "pltrxu")
+	seedTrackFull(t, pool, t1, uid, "Track One")
+	seedTrackFull(t, pool, t2, uid, "Track Two")
+
+	meta := `{"playlist_name":"With Tracks","is_album":false,"is_private":false,"playlist_contents":{"track_ids":[{"track":2006000,"time":1700000000},{"track":2006001,"time":1700000100}]}}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xpltracksu", meta))
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = $1 AND is_removed = false",
+		pid).Scan(&count); err != nil {
+		t.Fatalf("count playlist_tracks: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 active playlist_tracks rows, got %d", count)
+	}
+}
+
+func TestPlaylistUpdate_RemovesTrackFromPlaylistTracks(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 410)
+	pid := int64(PlaylistIDOffset + 4100)
+	t1 := int64(TrackIDOffset + 6100)
+	t2 := int64(TrackIDOffset + 6101)
+
+	seedUser(t, pool, uid, "0xpltrxupd", "ptu")
+	seedTrackFull(t, pool, t1, uid, "T1")
+	seedTrackFull(t, pool, t2, uid, "T2")
+
+	createMeta := `{"playlist_name":"Two Tracks","is_album":false,"is_private":false,"playlist_contents":{"track_ids":[{"track":2006100,"time":1700000000},{"track":2006101,"time":1700000100}]}}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xpltrxupd", createMeta))
+
+	updateMeta := `{"playlist_contents":{"track_ids":[{"track":2006100,"time":1700000000}]}}`
+	mustHandle(t, PlaylistUpdate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionUpdate, uid, pid, "0xpltrxupd", updateMeta))
+
+	var t1Removed, t2Removed bool
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_removed FROM playlist_tracks WHERE playlist_id = $1 AND track_id = $2",
+		pid, t1).Scan(&t1Removed); err != nil {
+		t.Fatalf("t1: %v", err)
+	}
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_removed FROM playlist_tracks WHERE playlist_id = $1 AND track_id = $2",
+		pid, t2).Scan(&t2Removed); err != nil {
+		t.Fatalf("t2: %v", err)
+	}
+	if t1Removed {
+		t.Error("t1 should still be active")
+	}
+	if !t2Removed {
+		t.Error("t2 should be marked removed")
+	}
+}

--- a/pkg/etl/processors/entity_manager/playlist_update.go
+++ b/pkg/etl/processors/entity_manager/playlist_update.go
@@ -65,6 +65,12 @@ func updatePlaylist(ctx context.Context, params *Params) error {
 		return err
 	}
 
+	if _, ok := params.Metadata["playlist_contents"]; ok {
+		if err := updatePlaylistTracks(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
+			return err
+		}
+	}
+
 	// Update playlist route if name changed
 	newName := ""
 	if merged.PlaylistName != nil {


### PR DESCRIPTION
## Summary

Stack 2A. Adds the \`playlist_tracks\` junction table (apps#0055) plus Go-side maintenance to keep it in sync with \`playlist_contents\`.

- Migration 0021 creates the table with PK \`(playlist_id, track_id)\` and \`idx_playlist_tracks_track_id\`.
- \`updatePlaylistTracks()\` in [playlist_tracks.go](pkg/etl/processors/entity_manager/playlist_tracks.go) mirrors apps' Python helper: missing tracks → \`is_removed=true\`, new tracks → insert, returning tracks → un-mark removed.
- Wired into \`playlist_create.go\` (always populates) and \`playlist_update.go\` (only when \`playlist_contents\` is in metadata).
- \`extractPlaylistTrackIDs\` accepts both \`{track_ids:[{track}]}\` (legacy) and \`[{track_id}]\` (new) formats.

## Skipped

\`handle_playlist_track\` trigger NOT ported. Its only purpose is fanning out \`track_added_to_purchased_album\` notifications to USDC purchasers — pure Solana, out of scope. Without it, the Go-side helper is sufficient for the junction-table parity.

## Stack context

Stacked on #241 (1D — secondary triggers).

## Test plan

- [x] Unit test \`TestExtractPlaylistTrackIDs\` covers both formats + missing field.
- [x] \`TestPlaylistCreate_PopulatesPlaylistTracks\` — create with 2 tracks → both rows in \`playlist_tracks\` with \`is_removed=false\`.
- [x] \`TestPlaylistUpdate_RemovesTrackFromPlaylistTracks\` — update removing one track → \`is_removed=true\` for it, other stays active.
- [x] \`go build ./...\` clean.
- [x] All previous trigger tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)