### PR TITLE
feat(etl): track/album price history tables and writes (parity 2B)

### DIFF
--- a/pkg/etl/db/sql/migrations/0022_price_history.down.sql
+++ b/pkg/etl/db/sql/migrations/0022_price_history.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS album_price_history;
+DROP TABLE IF EXISTS track_price_history;
+DROP TYPE IF EXISTS usdc_purchase_access_type;

--- a/pkg/etl/db/sql/migrations/0022_price_history.up.sql
+++ b/pkg/etl/db/sql/migrations/0022_price_history.up.sql
@@ -1,0 +1,30 @@
+-- track_price_history + album_price_history: USDC gating audit trail.
+-- Combined schema from apps#0017_track_price_history, #0051_usdc_purchase_access,
+-- and #0058_album_price_history.
+
+DO $$ BEGIN
+  CREATE TYPE usdc_purchase_access_type AS ENUM ('stream', 'download');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS track_price_history (
+  track_id integer NOT NULL,
+  splits jsonb NOT NULL,
+  total_price_cents bigint NOT NULL,
+  blocknumber integer NOT NULL,
+  block_timestamp timestamp WITHOUT TIME ZONE NOT NULL,
+  created_at timestamp WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  access usdc_purchase_access_type NOT NULL DEFAULT 'stream',
+  CONSTRAINT track_price_history_pkey PRIMARY KEY (track_id, block_timestamp)
+);
+
+CREATE TABLE IF NOT EXISTS album_price_history (
+  playlist_id integer NOT NULL,
+  splits jsonb NOT NULL,
+  total_price_cents bigint NOT NULL,
+  blocknumber integer NOT NULL,
+  block_timestamp timestamp WITHOUT TIME ZONE NOT NULL,
+  created_at timestamp WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT album_price_history_pkey PRIMARY KEY (playlist_id, block_timestamp)
+);

--- a/pkg/etl/processors/entity_manager/playlist_create.go
+++ b/pkg/etl/processors/entity_manager/playlist_create.go
@@ -111,6 +111,9 @@ func insertPlaylistAndRoute(ctx context.Context, params *Params) error {
 	if err := updatePlaylistTracks(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
 		return err
 	}
+	if err := updateAlbumPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
+		return err
+	}
 
 	// Insert playlist routes if a name is provided.
 	//

--- a/pkg/etl/processors/entity_manager/playlist_update.go
+++ b/pkg/etl/processors/entity_manager/playlist_update.go
@@ -70,6 +70,9 @@ func updatePlaylist(ctx context.Context, params *Params) error {
 			return err
 		}
 	}
+	if err := updateAlbumPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
+		return err
+	}
 
 	// Update playlist route if name changed
 	newName := ""

--- a/pkg/etl/processors/entity_manager/price_history.go
+++ b/pkg/etl/processors/entity_manager/price_history.go
@@ -1,0 +1,164 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+)
+
+// updateTrackPriceHistory writes a track_price_history row when track metadata
+// includes USDC gating with a price + splits. Mirrors apps' Python helper in
+// track.py (update_track_price_history).
+//
+// access: 'stream' if is_stream_gated, otherwise 'download' if is_download_gated.
+// Only writes when there's no existing row at the same block_timestamp with the
+// same total_price_cents + splits (apps' equality check via .equals()).
+func updateTrackPriceHistory(ctx context.Context, dbtx db.DBTX, trackID int64, blocknumber int64, blockTime time.Time, metadata map[string]any) error {
+	access, conditions := pickPriceConditions(metadata)
+	if conditions == nil {
+		return nil
+	}
+
+	usdc, ok := conditions["usdc_purchase"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	priceCents, ok := metadataMapInt64(usdc, "price")
+	if !ok {
+		return NewValidationError("track %d usdc_purchase missing or non-int price", trackID)
+	}
+	splitsRaw, ok := usdc["splits"]
+	if !ok {
+		return NewValidationError("track %d usdc_purchase missing splits", trackID)
+	}
+	splitsJSON, err := json.Marshal(splitsRaw)
+	if err != nil {
+		return err
+	}
+
+	if same, err := lastTrackPriceMatches(ctx, dbtx, trackID, priceCents, splitsJSON, access); err != nil {
+		return err
+	} else if same {
+		return nil
+	}
+
+	_, err = dbtx.Exec(ctx, `
+		INSERT INTO track_price_history (track_id, splits, total_price_cents, blocknumber, block_timestamp, access)
+		VALUES ($1, $2::jsonb, $3, $4, $5, $6::usdc_purchase_access_type)
+		ON CONFLICT (track_id, block_timestamp) DO NOTHING
+	`, trackID, string(splitsJSON), priceCents, blocknumber, blockTime, access)
+	return err
+}
+
+// updateAlbumPriceHistory writes an album_price_history row when playlist
+// metadata declares USDC stream-gating. Mirrors apps' update_album_price_history.
+func updateAlbumPriceHistory(ctx context.Context, dbtx db.DBTX, playlistID int64, blocknumber int64, blockTime time.Time, metadata map[string]any) error {
+	if metadata == nil {
+		return nil
+	}
+	if !metadataBoolOr(metadata, "is_stream_gated", false) {
+		return nil
+	}
+	conditions, ok := metadata["stream_conditions"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	usdc, ok := conditions["usdc_purchase"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	priceCents, ok := metadataMapInt64(usdc, "price")
+	if !ok {
+		return NewValidationError("playlist %d usdc_purchase missing or non-int price", playlistID)
+	}
+	splitsRaw, ok := usdc["splits"]
+	if !ok {
+		return NewValidationError("playlist %d usdc_purchase missing splits", playlistID)
+	}
+	splitsJSON, err := json.Marshal(splitsRaw)
+	if err != nil {
+		return err
+	}
+
+	if same, err := lastAlbumPriceMatches(ctx, dbtx, playlistID, priceCents, splitsJSON); err != nil {
+		return err
+	} else if same {
+		return nil
+	}
+
+	_, err = dbtx.Exec(ctx, `
+		INSERT INTO album_price_history (playlist_id, splits, total_price_cents, blocknumber, block_timestamp)
+		VALUES ($1, $2::jsonb, $3, $4, $5)
+		ON CONFLICT (playlist_id, block_timestamp) DO NOTHING
+	`, playlistID, string(splitsJSON), priceCents, blocknumber, blockTime)
+	return err
+}
+
+// pickPriceConditions returns ("stream", stream_conditions) when stream-gated,
+// ("download", download_conditions) when download-only-gated, or ("", nil)
+// when not USDC-gated. Mirrors apps' is_stream_gated / is_download_gated logic.
+func pickPriceConditions(metadata map[string]any) (string, map[string]any) {
+	if metadata == nil {
+		return "", nil
+	}
+	streamGated := metadataBoolOr(metadata, "is_stream_gated", false)
+	downloadGated := metadataBoolOr(metadata, "is_download_gated", false)
+	if streamGated {
+		if c, ok := metadata["stream_conditions"].(map[string]any); ok {
+			return "stream", c
+		}
+	}
+	if downloadGated {
+		if c, ok := metadata["download_conditions"].(map[string]any); ok {
+			return "download", c
+		}
+	}
+	return "", nil
+}
+
+func metadataBoolOr(m map[string]any, key string, def bool) bool {
+	v, ok := m[key].(bool)
+	if !ok {
+		return def
+	}
+	return v
+}
+
+// lastTrackPriceMatches reports whether the most recent track_price_history
+// row already records this price/splits/access combination — used to skip
+// duplicate inserts when nothing has changed.
+func lastTrackPriceMatches(ctx context.Context, dbtx db.DBTX, trackID, priceCents int64, splits []byte, access string) (bool, error) {
+	var lastPrice int64
+	var lastSplits []byte
+	var lastAccess string
+	err := dbtx.QueryRow(ctx, `
+		SELECT total_price_cents, splits, access::text
+		FROM track_price_history
+		WHERE track_id = $1
+		ORDER BY block_timestamp DESC
+		LIMIT 1
+	`, trackID).Scan(&lastPrice, &lastSplits, &lastAccess)
+	if err != nil {
+		// no rows yet → not a match, caller should insert
+		return false, nil
+	}
+	return lastPrice == priceCents && string(lastSplits) == string(splits) && lastAccess == access, nil
+}
+
+func lastAlbumPriceMatches(ctx context.Context, dbtx db.DBTX, playlistID, priceCents int64, splits []byte) (bool, error) {
+	var lastPrice int64
+	var lastSplits []byte
+	err := dbtx.QueryRow(ctx, `
+		SELECT total_price_cents, splits
+		FROM album_price_history
+		WHERE playlist_id = $1
+		ORDER BY block_timestamp DESC
+		LIMIT 1
+	`, playlistID).Scan(&lastPrice, &lastSplits)
+	if err != nil {
+		return false, nil
+	}
+	return lastPrice == priceCents && string(lastSplits) == string(splits), nil
+}

--- a/pkg/etl/processors/entity_manager/price_history_test.go
+++ b/pkg/etl/processors/entity_manager/price_history_test.go
@@ -1,0 +1,90 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTrackCreate_WritesTrackPriceHistory(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 500)
+	tid := int64(TrackIDOffset + 7000)
+	seedUser(t, pool, uid, "0xpriced", "pricedu")
+
+	meta := `{
+		"owner_id":3000500,
+		"title":"Premium Track",
+		"genre":"Electronic",
+		"is_stream_gated":true,
+		"is_download_gated":true,
+		"stream_conditions":{"usdc_purchase":{"price":199,"splits":[{"user_id":3000500,"percentage":100}]}},
+		"download_conditions":{"usdc_purchase":{"price":199,"splits":[{"user_id":3000500,"percentage":100}]}}
+	}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xpriced", meta))
+
+	var price int64
+	var access string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT total_price_cents, access::text FROM track_price_history WHERE track_id = $1",
+		tid).Scan(&price, &access); err != nil {
+		t.Fatalf("track_price_history: %v", err)
+	}
+	if price != 199 {
+		t.Errorf("total_price_cents = %d, want 199", price)
+	}
+	if access != "stream" {
+		t.Errorf("access = %q, want stream", access)
+	}
+}
+
+func TestTrackCreate_NoPriceHistoryForFreeTrack(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 510)
+	tid := int64(TrackIDOffset + 7100)
+	seedUser(t, pool, uid, "0xfree", "freeu")
+
+	meta := `{"owner_id":3000510,"title":"Free Track","genre":"Electronic"}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xfree", meta))
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM track_price_history WHERE track_id = $1",
+		tid).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected no price history rows for free track, got %d", count)
+	}
+}
+
+func TestPlaylistCreate_WritesAlbumPriceHistory(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 520)
+	pid := int64(PlaylistIDOffset + 8000)
+	seedUser(t, pool, uid, "0xalbum", "albu")
+
+	meta := `{
+		"playlist_name":"Premium Album",
+		"is_album":true,
+		"is_private":false,
+		"is_stream_gated":true,
+		"stream_conditions":{"usdc_purchase":{"price":499,"splits":[{"user_id":3000520,"percentage":100}]}}
+	}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xalbum", meta))
+
+	var price int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT total_price_cents FROM album_price_history WHERE playlist_id = $1",
+		pid).Scan(&price); err != nil {
+		t.Fatalf("album_price_history: %v", err)
+	}
+	if price != 499 {
+		t.Errorf("total_price_cents = %d, want 499", price)
+	}
+}

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -182,6 +182,9 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 	if err := updateRemixesTable(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
 		return err
 	}
+	if err := updateTrackPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
+		return err
+	}
 
 	slug, titleSlug, collisionID, err := GenerateSlugAndCollisionID(ctx, params.DBTX, params.UserID, params.EntityID, title)
 	if err != nil {

--- a/pkg/etl/processors/entity_manager/track_update.go
+++ b/pkg/etl/processors/entity_manager/track_update.go
@@ -77,6 +77,9 @@ func updateTrack(ctx context.Context, params *Params) error {
 			return err
 		}
 	}
+	if err := updateTrackPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
+		return err
+	}
 
 	if titleChanged {
 		handle, err := getTrackOwnerHandle(ctx, params.DBTX, merged.OwnerID)


### PR DESCRIPTION
## Summary

Stack 2B. Adds the gating-price audit trail tables and wires writes into entity_manager handlers.

Migration 0022:
- \`usdc_purchase_access_type\` enum (\`stream\`, \`download\`).
- \`track_price_history\` (track_id, splits, total_price_cents, blocknumber, block_timestamp, access). PK \`(track_id, block_timestamp)\`.
- \`album_price_history\` (playlist_id, splits, total_price_cents, blocknumber, block_timestamp). PK \`(playlist_id, block_timestamp)\`.

Combined from apps#0017_track_price_history, #0051_usdc_purchase_access, #0058_album_price_history.

[price_history.go](pkg/etl/processors/entity_manager/price_history.go) provides \`updateTrackPriceHistory\` + \`updateAlbumPriceHistory\` mirroring apps' Python helpers:
- \`access = 'stream'\` if \`is_stream_gated\`, else \`'download'\` if \`is_download_gated\`.
- Skip insert when latest row matches new \`(price, splits, access)\` — same dedupe as apps' \`equals()\` check.
- Wired into track_create / track_update / playlist_create / playlist_update.

## Stack context

Stacked on #268 (2A — playlist_tracks; was #242, renumbered after the closed-stack base-branch cleanup).

## Test plan

- [x] \`TestTrackCreate_WritesTrackPriceHistory\` — gated track create writes 199c row with access=stream.
- [x] \`TestTrackCreate_NoPriceHistoryForFreeTrack\` — non-gated track writes nothing.
- [x] \`TestPlaylistCreate_WritesAlbumPriceHistory\` — gated album create writes 499c row.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
