### PR TITLE
feat(etl): enforce immutable field set on track/playlist update (parity 2D)

### DIFF
--- a/pkg/etl/processors/entity_manager/immutable_fields.go
+++ b/pkg/etl/processors/entity_manager/immutable_fields.go
@@ -1,0 +1,58 @@
+package entity_manager
+
+// immutableFields lists metadata keys that cannot be modified by an Update
+// action. Mirrors apps/packages/discovery-provider/src/tasks/metadata.py
+// (immutable_fields, immutable_track_fields, immutable_playlist_fields).
+//
+// On Update, mergeTrackFromMetadata / mergePlaylistFromMetadata strip these
+// keys from the metadata map before merging so they can't override the
+// stored values.
+
+var immutableFields = map[string]struct{}{
+	"blocknumber":        {},
+	"blockhash":          {},
+	"txhash":             {},
+	"created_at":         {},
+	"updated_at":         {},
+	"slot":               {},
+	"metadata_multihash": {},
+	"is_current":         {},
+	"is_delete":          {},
+}
+
+var immutableTrackFields = unionFields(immutableFields, map[string]struct{}{
+	"track_id":     {},
+	"owner_id":     {},
+	"is_available": {},
+	"ddex_app":     {},
+})
+
+var immutablePlaylistFields = unionFields(immutableFields, map[string]struct{}{
+	"playlist_id":       {},
+	"playlist_owner_id": {},
+	"is_album":          {},
+	"ddex_app":          {},
+})
+
+func unionFields(a, b map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		out[k] = struct{}{}
+	}
+	for k := range b {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+// stripImmutableFields removes keys in `immutable` from the metadata map.
+// Returns the same map (mutated in place) for fluent use. Safe on nil.
+func stripImmutableFields(metadata map[string]any, immutable map[string]struct{}) map[string]any {
+	if metadata == nil {
+		return nil
+	}
+	for k := range immutable {
+		delete(metadata, k)
+	}
+	return metadata
+}

--- a/pkg/etl/processors/entity_manager/immutable_fields_test.go
+++ b/pkg/etl/processors/entity_manager/immutable_fields_test.go
@@ -1,0 +1,86 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStripImmutableFields_RemovesKeys(t *testing.T) {
+	meta := map[string]any{
+		"title":      "ok",
+		"created_at": "should-be-stripped",
+		"is_current": false,
+		"track_id":   12345,
+	}
+	stripImmutableFields(meta, immutableTrackFields)
+	if _, ok := meta["created_at"]; ok {
+		t.Error("created_at should be stripped")
+	}
+	if _, ok := meta["is_current"]; ok {
+		t.Error("is_current should be stripped")
+	}
+	if _, ok := meta["track_id"]; ok {
+		t.Error("track_id should be stripped (track-specific immutable)")
+	}
+	if _, ok := meta["title"]; !ok {
+		t.Error("title should remain")
+	}
+}
+
+func TestTrackUpdate_IgnoresImmutableMetadataKeys(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 700)
+	other := int64(UserIDOffset + 701)
+	tid := int64(TrackIDOffset + 9500)
+	seedUser(t, pool, uid, "0xowner", "ownr")
+	seedUser(t, pool, other, "0xother", "ot")
+	seedTrackFull(t, pool, tid, uid, "Original")
+
+	// Try to mutate owner_id (immutable) along with title (mutable).
+	meta := `{"title":"New Title","owner_id":3000701}`
+	mustHandle(t, TrackUpdate(),
+		buildParams(t, pool, EntityTypeTrack, ActionUpdate, uid, tid, "0xowner", meta))
+
+	var ownerID int64
+	var title string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT owner_id, title FROM tracks WHERE track_id = $1 AND is_current = true",
+		tid).Scan(&ownerID, &title); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if ownerID != uid {
+		t.Errorf("owner_id = %d, want %d (immutable)", ownerID, uid)
+	}
+	if title != "New Title" {
+		t.Errorf("title = %q, want New Title (mutable)", title)
+	}
+}
+
+func TestPlaylistUpdate_IgnoresImmutableIsAlbum(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 710)
+	pid := int64(PlaylistIDOffset + 9600)
+	seedUser(t, pool, uid, "0xploner", "plr")
+
+	// Create as non-album.
+	createMeta := `{"playlist_name":"Not An Album","is_album":false,"is_private":false}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xploner", createMeta))
+
+	// Try to flip is_album in update — should be ignored.
+	updateMeta := `{"is_album":true}`
+	mustHandle(t, PlaylistUpdate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionUpdate, uid, pid, "0xploner", updateMeta))
+
+	var isAlbum bool
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_album FROM playlists WHERE playlist_id = $1 AND is_current = true",
+		pid).Scan(&isAlbum); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if isAlbum {
+		t.Error("is_album was changed by update — immutable field not enforced")
+	}
+}

--- a/pkg/etl/processors/entity_manager/playlist_update.go
+++ b/pkg/etl/processors/entity_manager/playlist_update.go
@@ -55,6 +55,7 @@ func updatePlaylist(ctx context.Context, params *Params) error {
 	if err != nil {
 		return err
 	}
+	stripImmutableFields(params.Metadata, immutablePlaylistFields)
 	oldName := ""
 	if base.PlaylistName != nil {
 		oldName = *base.PlaylistName

--- a/pkg/etl/processors/entity_manager/track_update.go
+++ b/pkg/etl/processors/entity_manager/track_update.go
@@ -63,6 +63,7 @@ func updateTrack(ctx context.Context, params *Params) error {
 	if err != nil {
 		return err
 	}
+	stripImmutableFields(params.Metadata, immutableTrackFields)
 	oldTitle := base.Title
 	merged := mergeTrackFromMetadata(params, base)
 


### PR DESCRIPTION
## Summary

Stack 2D. Adds apps' \`immutable_fields\` / \`immutable_track_fields\` / \`immutable_playlist_fields\` sets and applies them in track_update + playlist_update before merging metadata. Without this, a malicious or buggy client could rewrite \`owner_id\`, \`track_id\`, \`is_album\`, etc. via an Update.

Immutable on Update (mirrors apps' [metadata.py](https://github.com/AudiusProject/audius-protocol/blob/main/packages/discovery-provider/src/tasks/metadata.py)):

- **Common**: \`blocknumber\`, \`blockhash\`, \`txhash\`, \`created_at\`, \`updated_at\`, \`slot\`, \`metadata_multihash\`, \`is_current\`, \`is_delete\`
- **Tracks add**: \`track_id\`, \`owner_id\`, \`is_available\`, \`ddex_app\`
- **Playlists add**: \`playlist_id\`, \`playlist_owner_id\`, \`is_album\`, \`ddex_app\`

\`stripImmutableFields()\` deletes these keys from \`params.Metadata\` before \`mergeTrackFromMetadata\` / \`mergePlaylistFromMetadata\` runs.

## Stack context

Stacked on #244 (2C — same-block route audit).

## Test plan

- [x] \`TestStripImmutableFields_RemovesKeys\` — unit test for the helper.
- [x] \`TestTrackUpdate_IgnoresImmutableMetadataKeys\` — Update trying to set \`owner_id\` to a different user leaves it unchanged; \`title\` (mutable) still updates.
- [x] \`TestPlaylistUpdate_IgnoresImmutableIsAlbum\` — \`is_album=true\` in Update metadata is silently ignored after a non-album create.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)