### PR TITLE
test(etl): track_download dedupe regression test (parity 2E)

### DIFF
--- a/pkg/etl/processors/entity_manager/track_download_dedupe_test.go
+++ b/pkg/etl/processors/entity_manager/track_download_dedupe_test.go
@@ -1,0 +1,34 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+// Regression test for track_download dedupe: a replayed download tx
+// must not produce duplicate rows in track_downloads.
+func TestTrackDownload_DedupesByTxHash(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 800)
+	owner := int64(UserIDOffset + 801)
+	tid := int64(TrackIDOffset + 9700)
+	seedUser(t, pool, uid, "0xdler", "dlu")
+	seedUser(t, pool, owner, "0xtrkown", "ow2")
+	seedTrackFull(t, pool, tid, owner, "Downloadable")
+
+	params := buildParams(t, pool, EntityTypeTrack, ActionDownload, uid, tid, "0xdler", `{}`)
+	mustHandle(t, TrackDownload(), params)
+	// Same params (same txhash) replayed — should be a no-op.
+	mustHandle(t, TrackDownload(), params)
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM track_downloads WHERE track_id = $1",
+		tid).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 track_downloads row after replay, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Stack 2E audit. apps' \`download_track\` helper silently returns when a row already exists at \`(parent_track_id, track_id, txhash)\`. The existing go-openaudio handler [track_download.go:49](pkg/etl/processors/entity_manager/track_download.go) already does the same check.

This PR adds a regression test that replays the same download tx and asserts only one row is created. **No code change.**

## Stack context

Stacked on #245 (2D — immutable fields).

## Test plan

- [x] \`TestTrackDownload_DedupesByTxHash\` — same handler params invoked twice, only 1 row in track_downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)