### PR TITLE
feat(etl): scheduled release publisher (parity 4A)

### DIFF
--- a/pkg/etl/config.go
+++ b/pkg/etl/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	EnableMaterializedViewRefresh bool
 	EnablePgNotifyListener        bool
+	EnableScheduledReleases       bool
 
 	// DataTypes controls which entity types the entity manager will index.
 	// If nil (default), all entity types are enabled.
@@ -23,6 +24,7 @@ func DefaultConfig() Config {
 	return Config{
 		EnableMaterializedViewRefresh: true,
 		EnablePgNotifyListener:        true,
+		EnableScheduledReleases:       true,
 		DataTypes:                     nil,
 	}
 }
@@ -70,3 +72,6 @@ func (c *Config) DisableMaterializedViewRefresh() { c.EnableMaterializedViewRefr
 
 // DisablePgNotifyListener disables the PostgreSQL LISTEN-based pubsub (for minimal indexing).
 func (c *Config) DisablePgNotifyListener() { c.EnablePgNotifyListener = false }
+
+// DisableScheduledReleases disables the periodic publish-scheduled-releases task.
+func (c *Config) DisableScheduledReleases() { c.EnableScheduledReleases = false }

--- a/pkg/etl/etl.go
+++ b/pkg/etl/etl.go
@@ -33,7 +33,8 @@ type Indexer struct {
 	blockPubsub *BlockPubsub
 	playPubsub  *PlayPubsub
 
-	mvRefresher *MaterializedViewRefresher
+	mvRefresher       *MaterializedViewRefresher
+	scheduledReleases *ScheduledReleasePublisher
 }
 
 // New creates a new ETL indexer.

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -165,6 +165,10 @@ func (e *Indexer) Run() error {
 	// Initialize materialized view refresher
 	e.mvRefresher = NewMaterializedViewRefresher(e.pool, e.logger)
 
+	// Initialize scheduled release publisher (publishes scheduled tracks/albums
+	// when their release_date passes).
+	e.scheduledReleases = NewScheduledReleasePublisher(e.pool, e.logger)
+
 	// Initialize chain ID from core service
 	err = e.InitializeChainID(context.Background())
 	if err != nil {
@@ -200,6 +204,12 @@ func (e *Indexer) Run() error {
 	if e.config.EnableMaterializedViewRefresh {
 		g.Go(func() error {
 			return e.mvRefresher.Start(gCtx)
+		})
+	}
+
+	if e.config.EnableScheduledReleases {
+		g.Go(func() error {
+			return e.scheduledReleases.Start(gCtx)
 		})
 	}
 

--- a/pkg/etl/scheduled_release_publisher.go
+++ b/pkg/etl/scheduled_release_publisher.go
@@ -1,0 +1,106 @@
+package etl
+
+import (
+	"context"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+	"go.uber.org/zap"
+)
+
+// ScheduledReleasePublisher periodically publishes scheduled tracks and
+// albums whose release_date has passed.
+//
+//   - tracks: is_unlisted=true → false when is_scheduled_release and
+//     release_date < now().
+//   - playlists: is_private=true → false when is_album AND
+//     is_scheduled_release AND release_date < now(). Non-album playlists
+//     are not auto-published.
+type ScheduledReleasePublisher struct {
+	db       db.DBTX
+	logger   *zap.Logger
+	interval time.Duration
+	done     chan bool
+}
+
+// NewScheduledReleasePublisher creates a publisher that runs every minute.
+func NewScheduledReleasePublisher(database db.DBTX, logger *zap.Logger) *ScheduledReleasePublisher {
+	return &ScheduledReleasePublisher{
+		db:       database,
+		logger:   logger.With(zap.String("service", "scheduled_release_publisher")),
+		interval: 60 * time.Second,
+		done:     make(chan bool),
+	}
+}
+
+// Start runs the publish loop. Blocks; intended to run in a goroutine.
+func (p *ScheduledReleasePublisher) Start(ctx context.Context) error {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	p.logger.Info("Starting scheduled release publisher", zap.Duration("interval", p.interval))
+
+	p.publish(ctx)
+
+	for {
+		select {
+		case <-ticker.C:
+			p.publish(ctx)
+		case <-p.done:
+			p.logger.Info("Scheduled release publisher stopped via done channel")
+			return nil
+		case <-ctx.Done():
+			p.logger.Info("Scheduled release publisher stopped via context cancellation")
+			return ctx.Err()
+		}
+	}
+}
+
+// Stop signals the loop to exit.
+func (p *ScheduledReleasePublisher) Stop() {
+	close(p.done)
+	p.logger.Info("Stopped scheduled release publisher")
+}
+
+func (p *ScheduledReleasePublisher) publish(ctx context.Context) {
+	start := time.Now()
+
+	tracksRes, err := p.db.Exec(ctx, `
+		UPDATE tracks
+		SET is_unlisted = false, updated_at = now()
+		WHERE is_unlisted = true
+		  AND is_scheduled_release = true
+		  AND release_date IS NOT NULL
+		  AND release_date < now()
+		  AND is_current = true
+		  AND is_delete = false
+	`)
+	if err != nil {
+		p.logger.Error("publish scheduled tracks failed", zap.Error(err))
+	}
+
+	playlistsRes, err := p.db.Exec(ctx, `
+		UPDATE playlists
+		SET is_private = false, updated_at = now()
+		WHERE is_private = true
+		  AND is_album = true
+		  AND is_scheduled_release = true
+		  AND release_date IS NOT NULL
+		  AND release_date < now()
+		  AND is_current = true
+		  AND is_delete = false
+	`)
+	if err != nil {
+		p.logger.Error("publish scheduled playlists failed", zap.Error(err))
+	}
+
+	tracksCount := tracksRes.RowsAffected()
+	playlistsCount := playlistsRes.RowsAffected()
+
+	if tracksCount > 0 || playlistsCount > 0 {
+		p.logger.Info("published scheduled releases",
+			zap.Int64("tracks", tracksCount),
+			zap.Int64("albums", playlistsCount),
+			zap.Duration("duration", time.Since(start)))
+	}
+}

--- a/pkg/etl/scheduled_release_publisher_test.go
+++ b/pkg/etl/scheduled_release_publisher_test.go
@@ -1,0 +1,126 @@
+package etl
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap"
+)
+
+func setupPublisherDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dbURL := os.Getenv("ETL_TEST_DB_URL")
+	if dbURL == "" {
+		t.Skip("ETL_TEST_DB_URL not set")
+	}
+	logger, _ := zap.NewDevelopment()
+	if err := db.RunMigrations(logger, dbURL, true); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	return pool
+}
+
+func TestScheduledReleasePublisher_PublishesPastDueTrack(t *testing.T) {
+	pool := setupPublisherDB(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO blocks (blockhash, parenthash, is_current, number) VALUES ('blk-pub', '', true, 100)
+		ON CONFLICT (blockhash) DO NOTHING
+	`); err != nil {
+		t.Fatalf("seed block: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (user_id, handle, handle_lc, wallet, is_current, is_verified, is_deactivated, is_available, created_at, updated_at, txhash)
+		VALUES (3000900, 'pubuser', 'pubuser', '0xpub', true, false, false, true, now(), now(), '')
+		ON CONFLICT DO NOTHING
+	`); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	// One past-due scheduled track.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO tracks (track_id, owner_id, is_current, is_delete, is_unlisted, is_scheduled_release, release_date, track_segments, created_at, updated_at, txhash, blocknumber)
+		VALUES (2009000, 3000900, true, false, true, true, now() - interval '1 hour', '[]', now(), now(), 'tx-past', 100)
+	`); err != nil {
+		t.Fatalf("seed past track: %v", err)
+	}
+	// One future scheduled track (should NOT publish).
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO tracks (track_id, owner_id, is_current, is_delete, is_unlisted, is_scheduled_release, release_date, track_segments, created_at, updated_at, txhash, blocknumber)
+		VALUES (2009001, 3000900, true, false, true, true, now() + interval '1 day', '[]', now(), now(), 'tx-future', 100)
+	`); err != nil {
+		t.Fatalf("seed future track: %v", err)
+	}
+
+	logger, _ := zap.NewDevelopment()
+	p := NewScheduledReleasePublisher(pool, logger)
+	p.publish(ctx)
+
+	var pastUnlisted, futureUnlisted bool
+	if err := pool.QueryRow(ctx, "SELECT is_unlisted FROM tracks WHERE track_id = 2009000").Scan(&pastUnlisted); err != nil {
+		t.Fatalf("past: %v", err)
+	}
+	if err := pool.QueryRow(ctx, "SELECT is_unlisted FROM tracks WHERE track_id = 2009001").Scan(&futureUnlisted); err != nil {
+		t.Fatalf("future: %v", err)
+	}
+	if pastUnlisted {
+		t.Error("past-due scheduled track should be published (is_unlisted=false)")
+	}
+	if !futureUnlisted {
+		t.Error("future-scheduled track should still be unlisted")
+	}
+}
+
+func TestScheduledReleasePublisher_PublishesPastDueAlbum(t *testing.T) {
+	pool := setupPublisherDB(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO blocks (blockhash, parenthash, is_current, number) VALUES ('blk-alb', '', true, 100)
+		ON CONFLICT (blockhash) DO NOTHING
+	`); err != nil {
+		t.Fatalf("seed block: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (user_id, handle, handle_lc, wallet, is_current, is_verified, is_deactivated, is_available, created_at, updated_at, txhash)
+		VALUES (3000910, 'pubalbum', 'pubalbum', '0xpubalb', true, false, false, true, now(), now(), '')
+		ON CONFLICT DO NOTHING
+	`); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO playlists (playlist_id, playlist_owner_id, is_album, is_private, is_scheduled_release, release_date, playlist_contents, is_current, is_delete, created_at, updated_at, txhash, blocknumber)
+		VALUES (400900, 3000910, true, true, true, now() - interval '1 hour', '{}', true, false, now(), now(), 'tx-album', 100)
+	`); err != nil {
+		t.Fatalf("seed album: %v", err)
+	}
+
+	// Non-album (regular playlist) — should NOT publish even if past due.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO playlists (playlist_id, playlist_owner_id, is_album, is_private, is_scheduled_release, release_date, playlist_contents, is_current, is_delete, created_at, updated_at, txhash, blocknumber)
+		VALUES (400901, 3000910, false, true, true, now() - interval '1 hour', '{}', true, false, now(), now(), 'tx-pl', 100)
+	`); err != nil {
+		t.Fatalf("seed playlist: %v", err)
+	}
+
+	logger, _ := zap.NewDevelopment()
+	p := NewScheduledReleasePublisher(pool, logger)
+	p.publish(ctx)
+
+	var albumPrivate, playlistPrivate bool
+	_ = pool.QueryRow(ctx, "SELECT is_private FROM playlists WHERE playlist_id = 400900").Scan(&albumPrivate)
+	_ = pool.QueryRow(ctx, "SELECT is_private FROM playlists WHERE playlist_id = 400901").Scan(&playlistPrivate)
+	if albumPrivate {
+		t.Error("past-due scheduled album should be published (is_private=false)")
+	}
+	if !playlistPrivate {
+		t.Error("non-album playlist should NOT be auto-published (only albums)")
+	}
+}


### PR DESCRIPTION
## Summary

Stack 4A. Adds \`ScheduledReleasePublisher\`: a periodic background task (60s interval) that mirrors apps' \`publish_scheduled_releases\` celery task.

- **Tracks**: \`is_unlisted=true\` → \`false\` when \`is_scheduled_release\` and \`release_date < now()\`
- **Playlists**: \`is_private=true\` → \`false\` when \`is_album AND is_scheduled_release AND release_date < now()\` — apps only auto-publishes albums.

Wired into \`Indexer.Start()\` via errgroup alongside the existing MV refresher. Gated by \`Config.EnableScheduledReleases\` (default true; \`DisableScheduledReleases()\` opt-out).

## Note on 3A (skipped)

Stack 3A (\`sort_block_transactions\`) is a no-op for go-openaudio. apps sorts L1 receipts (which arrive unordered); CometBFT delivers transactions in deterministic block order and \`indexer.go\` iterates them as-is. Verified, no commit needed.

## Stack context

Stacked on #246 (2E — track_download dedupe). 3A skipped.

## Test plan

- [x] \`TestScheduledReleasePublisher_PublishesPastDueTrack\` — past-due scheduled track gets published; future-scheduled stays unlisted.
- [x] \`TestScheduledReleasePublisher_PublishesPastDueAlbum\` — past-due album gets published; non-album scheduled playlist stays private.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)