### PR TITLE
feat(etl): port tag_track_user MV and add to refresher (parity 4B)

### DIFF
--- a/pkg/etl/db/sql/migrations/0023_mv_tag_track_user.down.sql
+++ b/pkg/etl/db/sql/migrations/0023_mv_tag_track_user.down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS tag_track_user;

--- a/pkg/etl/db/sql/migrations/0023_mv_tag_track_user.up.sql
+++ b/pkg/etl/db/sql/migrations/0023_mv_tag_track_user.up.sql
@@ -1,0 +1,25 @@
+-- tag_track_user: MV exploding tracks.tags into one row per (tag, track, owner).
+-- Used by tag-search queries. Ported verbatim from apps' schema.
+
+DROP MATERIALIZED VIEW IF EXISTS tag_track_user;
+CREATE MATERIALIZED VIEW tag_track_user AS
+SELECT unnest(t.tags) AS tag,
+       t.track_id,
+       t.owner_id
+FROM (
+  SELECT string_to_array(lower(tracks.tags::text), ','::text) AS tags,
+         tracks.track_id,
+         tracks.owner_id
+  FROM tracks
+  WHERE tracks.tags::text <> ''
+    AND tracks.tags IS NOT NULL
+    AND tracks.is_current IS TRUE
+    AND tracks.is_unlisted IS FALSE
+    AND tracks.stem_of IS NULL
+  ORDER BY tracks.updated_at DESC
+) t
+GROUP BY unnest(t.tags), t.track_id, t.owner_id
+WITH NO DATA;
+
+CREATE INDEX IF NOT EXISTS tag_track_user_tag_idx ON tag_track_user (tag);
+CREATE INDEX IF NOT EXISTS tag_track_user_track_id_idx ON tag_track_user (track_id);

--- a/pkg/etl/materialized_view_refresher.go
+++ b/pkg/etl/materialized_view_refresher.go
@@ -69,6 +69,7 @@ func (r *MaterializedViewRefresher) refreshViews(ctx context.Context) {
 	views := []string{
 		"mv_dashboard_transaction_stats",
 		"mv_dashboard_transaction_types",
+		"tag_track_user",
 	}
 
 	// Refresh views in parallel for better performance


### PR DESCRIPTION
## Summary

Stack 4B. apps' \`tag_track_user\` materialized view explodes \`tracks.tags\` into one row per \`(tag, track_id, owner_id)\` and is used for tag-search queries. It only depends on the \`tracks\` table which we already have.

- Migration 0023 ports the MV definition verbatim from apps' schema (lowercase + comma-split + filter-non-deleted-public-stems) plus indexes on \`tag\` and \`track_id\`.
- [materialized_view_refresher.go](pkg/etl/materialized_view_refresher.go) adds it to the periodic refresh list alongside the two existing dashboard views.

## Other MVs deferred

Other apps MVs depend on tables not yet in go-openaudio:
- \`aggregate_interval_plays\` → \`plays\` (apps schema; we have \`etl_plays\` only)
- \`app_name_metrics_*\` → \`aggregate_daily_app_name_metrics\`
- \`route_metrics_*\` → \`route_metrics\`

These land if/when their underlying tables do. Calling them out in the commit so they're not lost.

## Stack context

Stacked on #247 (4A — scheduled releases).

## Test plan

- [x] Migration applies cleanly on fresh DB.
- [x] \`REFRESH MATERIALIZED VIEW tag_track_user\` succeeds.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)