### PR TITLE
feat(etl): allowed_api_keys + access_authorities normalization (parity 5B)

### DIFF
--- a/pkg/etl/db/sql/migrations/0024_tracks_access_authorities.down.sql
+++ b/pkg/etl/db/sql/migrations/0024_tracks_access_authorities.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracks DROP COLUMN IF EXISTS access_authorities;

--- a/pkg/etl/db/sql/migrations/0024_tracks_access_authorities.up.sql
+++ b/pkg/etl/db/sql/migrations/0024_tracks_access_authorities.up.sql
@@ -1,0 +1,3 @@
+-- Add access_authorities to tracks (apps#13810 / apps#0177).
+
+ALTER TABLE tracks ADD COLUMN IF NOT EXISTS access_authorities text[] DEFAULT NULL;

--- a/pkg/etl/processors/entity_manager/access_authorities.go
+++ b/pkg/etl/processors/entity_manager/access_authorities.go
@@ -1,0 +1,97 @@
+package entity_manager
+
+import (
+	"context"
+	"strings"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+)
+
+// applyAccessNormalization writes any present allowed_api_keys /
+// access_authorities values onto the current tracks row. Called after
+// the main INSERT/UPDATE so it can use UPDATE statements without bloating
+// the giant track INSERT with two more optional columns.
+func applyAccessNormalization(ctx context.Context, dbtx db.DBTX, trackID int64, metadata map[string]any) error {
+	if metadata == nil {
+		return nil
+	}
+	if vals, present, isNull := normalizeAllowedAPIKeys(metadata); present {
+		var arg any
+		if isNull {
+			arg = nil
+		} else {
+			arg = vals
+		}
+		if _, err := dbtx.Exec(ctx, `
+			UPDATE tracks SET allowed_api_keys = $2 WHERE track_id = $1 AND is_current = true
+		`, trackID, arg); err != nil {
+			return err
+		}
+	}
+	if vals, present, isNull := normalizeAccessAuthorities(metadata); present {
+		var arg any
+		if isNull {
+			arg = nil
+		} else {
+			arg = vals
+		}
+		if _, err := dbtx.Exec(ctx, `
+			UPDATE tracks SET access_authorities = $2 WHERE track_id = $1 AND is_current = true
+		`, trackID, arg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeAllowedAPIKeys returns a lowercased copy of metadata.allowed_api_keys.
+// (present=true, isNull=true) → set the column to NULL.
+// (present=false) → key missing, leave the column unchanged.
+func normalizeAllowedAPIKeys(metadata map[string]any) (value []string, present bool, isNull bool) {
+	raw, ok := metadata["allowed_api_keys"]
+	if !ok {
+		return nil, false, false
+	}
+	if raw == nil {
+		return nil, true, true
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, true, false
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		out = append(out, strings.ToLower(s))
+	}
+	return out, true, false
+}
+
+// normalizeAccessAuthorities returns a trimmed-string copy of
+// metadata.access_authorities. Non-list inputs and non-string entries
+// are silently filtered out.
+func normalizeAccessAuthorities(metadata map[string]any) (value []string, present bool, isNull bool) {
+	raw, ok := metadata["access_authorities"]
+	if !ok {
+		return nil, false, false
+	}
+	if raw == nil {
+		return nil, true, true
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, false, false
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		out = append(out, strings.TrimSpace(s))
+	}
+	return out, true, false
+}

--- a/pkg/etl/processors/entity_manager/access_authorities_test.go
+++ b/pkg/etl/processors/entity_manager/access_authorities_test.go
@@ -1,0 +1,66 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeAllowedAPIKeys_LowercasesValues(t *testing.T) {
+	meta := map[string]any{}
+	_ = json.Unmarshal([]byte(`{"allowed_api_keys":["KEY-A","Key-B","key-c"]}`), &meta)
+	vals, present, isNull := normalizeAllowedAPIKeys(meta)
+	if !present || isNull {
+		t.Fatal("expected present, non-null")
+	}
+	want := []string{"key-a", "key-b", "key-c"}
+	if len(vals) != len(want) {
+		t.Fatalf("got %v, want %v", vals, want)
+	}
+	for i, v := range vals {
+		if v != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, v, want[i])
+		}
+	}
+}
+
+func TestNormalizeAccessAuthorities_TrimsValues(t *testing.T) {
+	meta := map[string]any{}
+	_ = json.Unmarshal([]byte(`{"access_authorities":["  0xabc  ", "0xdef "]}`), &meta)
+	vals, present, isNull := normalizeAccessAuthorities(meta)
+	if !present || isNull {
+		t.Fatal("expected present, non-null")
+	}
+	want := []string{"0xabc", "0xdef"}
+	for i, v := range vals {
+		if v != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, v, want[i])
+		}
+	}
+}
+
+func TestTrackCreate_AppliesAccessNormalization(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 900)
+	tid := int64(TrackIDOffset + 9900)
+	seedUser(t, pool, uid, "0xacc", "accu")
+
+	meta := `{"owner_id":3000900,"title":"Access Track","genre":"Electronic","allowed_api_keys":["UPPER-KEY"],"access_authorities":["  0xLOWER  "]}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xacc", meta))
+
+	var apiKeys []string
+	var auth []string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT allowed_api_keys, access_authorities FROM tracks WHERE track_id = $1 AND is_current = true",
+		tid).Scan(&apiKeys, &auth); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(apiKeys) != 1 || apiKeys[0] != "upper-key" {
+		t.Errorf("allowed_api_keys = %v, want [upper-key]", apiKeys)
+	}
+	if len(auth) != 1 || auth[0] != "0xLOWER" {
+		t.Errorf("access_authorities = %v, want [0xLOWER]", auth)
+	}
+}

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -185,6 +185,9 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 	if err := updateTrackPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
 		return err
 	}
+	if err := applyAccessNormalization(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
+		return err
+	}
 
 	slug, titleSlug, collisionID, err := GenerateSlugAndCollisionID(ctx, params.DBTX, params.UserID, params.EntityID, title)
 	if err != nil {

--- a/pkg/etl/processors/entity_manager/track_update.go
+++ b/pkg/etl/processors/entity_manager/track_update.go
@@ -81,6 +81,9 @@ func updateTrack(ctx context.Context, params *Params) error {
 	if err := updateTrackPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
 		return err
 	}
+	if err := applyAccessNormalization(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
+		return err
+	}
 
 	if titleChanged {
 		handle, err := getTrackOwnerHandle(ctx, params.DBTX, merged.OwnerID)


### PR DESCRIPTION
## Summary

Stack 5B. Adds apps#13810 / apps#0177's \`access_authorities\` column and normalizes both \`allowed_api_keys\` and \`access_authorities\` on track create + update, matching apps' \`track.py\`:

- \`allowed_api_keys\`: each entry lowercased.
- \`access_authorities\`: each entry whitespace-trimmed.
- Explicit \`null\` in metadata sets the column to NULL.
- Non-string list entries silently filtered out (\`isinstance(addr, str)\`).

\`applyAccessNormalization\` runs after the main track INSERT/UPDATE with targeted column UPDATEs — avoids bloating the existing 30-column INSERT statement.

## Stack context

Stacked on #269 (5A — hashid track_ids; was #249, renumbered after the closed-stack base-branch cleanup).

## Test plan

- [x] \`TestNormalizeAllowedAPIKeys_LowercasesValues\` — \`KEY-A → key-a\`.
- [x] \`TestNormalizeAccessAuthorities_TrimsValues\` — \`"  0xabc  " → "0xabc"\`.
- [x] \`TestTrackCreate_AppliesAccessNormalization\` — DB-backed end-to-end.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
