### PR TITLE
fix(etl): comment threading guards (parity 5C)

### DIFF
--- a/pkg/etl/processors/entity_manager/comment_create.go
+++ b/pkg/etl/processors/entity_manager/comment_create.go
@@ -52,8 +52,8 @@ func (h *commentCreateHandler) Handle(ctx context.Context, params *Params) error
 		}
 	}
 
-	// Insert thread relationship if this is a reply
-	if parentID, ok := params.MetadataInt64("parent_comment_id"); ok && parentID > 0 {
+	// Insert thread relationship if this is a reply.
+	if parentID, ok := getCommentParentID(params); ok {
 		_, err := params.DBTX.Exec(ctx, `
 			INSERT INTO comment_threads (parent_comment_id, comment_id)
 			VALUES ($1, $2)
@@ -65,6 +65,19 @@ func (h *commentCreateHandler) Handle(ctx context.Context, params *Params) error
 	}
 
 	return nil
+}
+
+// getCommentParentID returns the parent comment id from metadata, accepting
+// either parent_comment_id (preferred) or parent_id (alt). Clients may send
+// either; both are treated as the same field.
+func getCommentParentID(params *Params) (int64, bool) {
+	if id, ok := params.MetadataInt64("parent_comment_id"); ok && id > 0 {
+		return id, true
+	}
+	if id, ok := params.MetadataInt64("parent_id"); ok && id > 0 {
+		return id, true
+	}
+	return 0, false
 }
 
 func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) error {
@@ -118,14 +131,44 @@ func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) er
 		return NewValidationError("comment body exceeds %d character limit", CharacterLimitCommentBody)
 	}
 
-	// Validate parent_comment_id if provided
-	if parentID, ok := params.MetadataInt64("parent_comment_id"); ok && parentID > 0 {
+	// Validate parent_comment_id (or parent_id) if provided.
+	if parentID, ok := getCommentParentID(params); ok && isCreate {
 		pExists, err := commentExists(ctx, params.DBTX, parentID)
 		if err != nil {
 			return err
 		}
 		if !pExists {
 			return NewValidationError("parent comment %d does not exist", parentID)
+		}
+
+		// Parent must be on the same entity (track/fanclub) as this child.
+		var parentEntityType string
+		var parentEntityID int64
+		err = params.DBTX.QueryRow(ctx,
+			"SELECT entity_type, entity_id FROM comments WHERE comment_id = $1",
+			parentID).Scan(&parentEntityType, &parentEntityID)
+		if err != nil {
+			return err
+		}
+		childEntityType := et
+		if childEntityType == "" {
+			childEntityType = EntityTypeTrack
+		}
+		if parentEntityType != childEntityType || parentEntityID != entityID {
+			return NewValidationError("parent comment %d does not belong to %s %d",
+				parentID, childEntityType, entityID)
+		}
+
+		// Reject duplicate (parent, child) pair.
+		var dup bool
+		err = params.DBTX.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM comment_threads WHERE parent_comment_id = $1 AND comment_id = $2)",
+			parentID, params.EntityID).Scan(&dup)
+		if err != nil {
+			return err
+		}
+		if dup {
+			return NewValidationError("comment_thread (%d, %d) already exists", parentID, params.EntityID)
 		}
 	}
 

--- a/pkg/etl/processors/entity_manager/comment_threading_test.go
+++ b/pkg/etl/processors/entity_manager/comment_threading_test.go
@@ -1,0 +1,65 @@
+package entity_manager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCommentCreate_AcceptsParentIDAltKey(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 1100)
+	owner := int64(UserIDOffset + 1101)
+	tid := int64(TrackIDOffset + 11000)
+	parentCID := int64(CommentIDOffset + 1000)
+	childCID := int64(CommentIDOffset + 1001)
+	seedUser(t, pool, uid, "0xcm1", "cm1u")
+	seedUser(t, pool, owner, "0xcm2", "cm2u")
+	seedTrackFull(t, pool, tid, owner, "Threaded")
+
+	// Insert parent comment via the handler.
+	parentMeta := `{"comment_id":4001000,"body":"top-level","entity_id":2011000,"entity_type":"Track"}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, uid, parentCID, "0xcm1", parentMeta))
+
+	// Reply using parent_id (alt key) instead of parent_comment_id.
+	childMeta := `{"comment_id":4001001,"body":"reply","entity_id":2011000,"entity_type":"Track","parent_id":4001000}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, uid, childCID, "0xcm1", childMeta))
+
+	var threadCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM comment_threads WHERE parent_comment_id = $1 AND comment_id = $2",
+		parentCID, childCID).Scan(&threadCount); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if threadCount != 1 {
+		t.Errorf("expected 1 comment_threads row, got %d", threadCount)
+	}
+}
+
+func TestCommentCreate_RejectsParentOnDifferentEntity(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 1110)
+	owner := int64(UserIDOffset + 1111)
+	tidA := int64(TrackIDOffset + 11100)
+	tidB := int64(TrackIDOffset + 11101)
+	parentCID := int64(CommentIDOffset + 1100)
+	childCID := int64(CommentIDOffset + 1101)
+
+	seedUser(t, pool, uid, "0xcma", "cmau")
+	seedUser(t, pool, owner, "0xcmb", "cmbu")
+	seedTrackFull(t, pool, tidA, owner, "TrackA")
+	seedTrackFull(t, pool, tidB, owner, "TrackB")
+
+	parentMeta := `{"comment_id":4001100,"body":"on TrackA","entity_id":2011100,"entity_type":"Track"}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, uid, parentCID, "0xcma", parentMeta))
+
+	// Reply attempting to reference parent on TrackA but child claims to be on TrackB.
+	childMeta := `{"comment_id":4001101,"body":"reply","entity_id":2011101,"entity_type":"Track","parent_comment_id":4001100}`
+	mustReject(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, uid, childCID, "0xcma", childMeta),
+		"does not belong to Track")
+}


### PR DESCRIPTION
## Summary

Stack 5C audit + fixes. apps' \`comment.py\` validates three cases that go-openaudio was missing for thread inserts:

1. **Accept \`parent_id\` as alternative metadata key.** apps treats \`parent_comment_id\` and \`parent_id\` interchangeably (the API client may send either). go-openaudio was only checking \`parent_comment_id\`, so a \`parent_id\`-only reply silently skipped parent validation.
2. **Validate parent comment is on the same entity** (track/fanclub) as the child. apps checks \`parent_c.entity_type\` and \`parent_c.entity_id\` align with the new comment.
3. **Reject duplicate \`(parent_comment_id, comment_id)\` thread pair explicitly** rather than relying on \`ON CONFLICT DO NOTHING\` to swallow it (matches apps' \`existing_records\` check).

\`getCommentParentID()\` centralizes the \`parent_comment_id\`-or-\`parent_id\` lookup.

## Stack context

Stacked on #250 (5B — access_authorities normalization).

## Test plan

- [x] \`TestCommentCreate_AcceptsParentIDAltKey\` — \`parent_id\` (alt key) works end-to-end.
- [x] \`TestCommentCreate_RejectsParentOnDifferentEntity\` — child on TrackB cannot reply to a comment on TrackA.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)