### PR TITLE
feat(etl): index oauth_redirect_uris on developer app create/update (parity 5E)

### DIFF
--- a/pkg/etl/db/sql/migrations/0025_oauth_redirect_uris.down.sql
+++ b/pkg/etl/db/sql/migrations/0025_oauth_redirect_uris.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_redirect_uris;

--- a/pkg/etl/db/sql/migrations/0025_oauth_redirect_uris.up.sql
+++ b/pkg/etl/db/sql/migrations/0025_oauth_redirect_uris.up.sql
@@ -1,0 +1,14 @@
+-- oauth_redirect_uris: per-developer-app redirect URI list for OAuth.
+-- Schema matches api/'s sql/01_schema.sql; IF NOT EXISTS makes this a
+-- no-op against api/'s DB, while still creating the table for any
+-- standalone consumer.
+
+CREATE TABLE IF NOT EXISTS oauth_redirect_uris (
+  id serial NOT NULL,
+  client_id character varying(255) NOT NULL,
+  redirect_uri text NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT oauth_redirect_uris_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_oauth_redirect_uris_client_id ON oauth_redirect_uris (client_id);

--- a/pkg/etl/processors/entity_manager/developer_app_create.go
+++ b/pkg/etl/processors/entity_manager/developer_app_create.go
@@ -92,7 +92,17 @@ func insertDeveloperApp(ctx context.Context, params *Params) error {
 		params.TxHash,
 		params.BlockNumber,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Index redirect_uris if provided.
+	if uris, present, _ := extractRedirectURIs(params.Metadata); present && len(uris) > 0 {
+		if err := replaceRedirectURIs(ctx, params.DBTX, address, uris); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // DeveloperAppCreate returns the DeveloperApp Create handler.

--- a/pkg/etl/processors/entity_manager/developer_app_update.go
+++ b/pkg/etl/processors/entity_manager/developer_app_update.go
@@ -102,7 +102,18 @@ func updateDeveloperApp(ctx context.Context, params *Params) error {
 		params.TxHash,
 		params.BlockNumber,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Re-index redirect_uris when present in metadata: delete all existing
+	// for client_id, then insert the new set.
+	if uris, present, _ := extractRedirectURIs(params.Metadata); present {
+		if err := replaceRedirectURIs(ctx, params.DBTX, address, uris); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func getDeveloperAppOwner(ctx context.Context, dbtx db.DBTX, address string) (int64, error) {

--- a/pkg/etl/processors/entity_manager/oauth_redirect_uris.go
+++ b/pkg/etl/processors/entity_manager/oauth_redirect_uris.go
@@ -1,0 +1,63 @@
+package entity_manager
+
+import (
+	"context"
+
+	"github.com/OpenAudio/go-openaudio/etl/db"
+)
+
+// MaxRedirectURIs caps how many redirect URIs a single developer app may register.
+const MaxRedirectURIs = 50
+
+// MaxRedirectURILength caps each individual URI string length.
+const MaxRedirectURILength = 2000
+
+// extractRedirectURIs reads the metadata's redirect_uris field, dropping
+// invalid entries (non-string, over-length, or non-list inputs) and capping
+// the list at MaxRedirectURIs. Returns isNull=true for explicit null in
+// metadata; present=false when the key is missing entirely.
+func extractRedirectURIs(metadata map[string]any) (uris []string, present bool, isNull bool) {
+	raw, ok := metadata["redirect_uris"]
+	if !ok {
+		return nil, false, false
+	}
+	if raw == nil {
+		return nil, true, true
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, false, false
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		s, ok := v.(string)
+		if !ok {
+			return nil, false, false
+		}
+		if len(s) > MaxRedirectURILength {
+			return nil, false, false
+		}
+		out = append(out, s)
+	}
+	if len(out) > MaxRedirectURIs {
+		out = out[:MaxRedirectURIs]
+	}
+	return out, true, false
+}
+
+// replaceRedirectURIs sets the redirect URI list for a developer app:
+// clears existing rows for the client_id and inserts the new set.
+func replaceRedirectURIs(ctx context.Context, dbtx db.DBTX, clientID string, uris []string) error {
+	if _, err := dbtx.Exec(ctx, "DELETE FROM oauth_redirect_uris WHERE client_id = $1", clientID); err != nil {
+		return err
+	}
+	for _, uri := range uris {
+		if _, err := dbtx.Exec(ctx,
+			"INSERT INTO oauth_redirect_uris (client_id, redirect_uri) VALUES ($1, $2)",
+			clientID, uri,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/etl/processors/entity_manager/oauth_redirect_uris_test.go
+++ b/pkg/etl/processors/entity_manager/oauth_redirect_uris_test.go
@@ -1,0 +1,102 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExtractRedirectURIs(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		want      []string
+		isPresent bool
+		isNull    bool
+	}{
+		{name: "happy path", raw: `{"redirect_uris":["https://a","https://b"]}`, want: []string{"https://a", "https://b"}, isPresent: true},
+		{name: "missing", raw: `{}`, isPresent: false},
+		{name: "explicit null", raw: `{"redirect_uris":null}`, isPresent: true, isNull: true},
+		{name: "non-list dropped", raw: `{"redirect_uris":"oops"}`, isPresent: false},
+		{name: "non-string entry skipped", raw: `{"redirect_uris":["ok",1]}`, isPresent: false},
+		{name: "over-length URI rejects whole list", raw: `{"redirect_uris":["` + strings.Repeat("x", MaxRedirectURILength+1) + `"]}`, isPresent: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var meta map[string]any
+			_ = json.Unmarshal([]byte(tt.raw), &meta)
+			uris, present, isNull := extractRedirectURIs(meta)
+			if present != tt.isPresent {
+				t.Errorf("present = %v, want %v", present, tt.isPresent)
+			}
+			if isNull != tt.isNull {
+				t.Errorf("isNull = %v, want %v", isNull, tt.isNull)
+			}
+			if len(uris) != len(tt.want) {
+				t.Fatalf("uris = %v, want %v", uris, tt.want)
+			}
+			for i := range uris {
+				if uris[i] != tt.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, uris[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeveloperAppCreate_IndexesRedirectURIs(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 1200)
+	seedUser(t, pool, uid, "0xappOwner", "appownr")
+
+	addr := "0xdeadbeef00000000000000000000000000000001"
+	meta := `{"name":"My App","address":"` + addr + `","redirect_uris":["https://a.example","https://b.example"]}`
+	mustHandle(t, DeveloperAppCreate(),
+		buildParams(t, pool, EntityTypeDeveloperApp, ActionCreate, uid, 0, "0xappOwner", meta))
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM oauth_redirect_uris WHERE client_id = $1",
+		addr).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 redirect URI rows, got %d", count)
+	}
+}
+
+func TestReplaceRedirectURIs_DeletesAndInserts(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	addr := "0xdeadbeef00000000000000000000000000000002"
+
+	if err := replaceRedirectURIs(context.Background(), pool, addr, []string{"https://old1", "https://old2", "https://old3"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := replaceRedirectURIs(context.Background(), pool, addr, []string{"https://new"}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM oauth_redirect_uris WHERE client_id = $1",
+		addr).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row after replace, got %d", count)
+	}
+
+	var uri string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT redirect_uri FROM oauth_redirect_uris WHERE client_id = $1",
+		addr).Scan(&uri); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if uri != "https://new" {
+		t.Errorf("uri = %q, want https://new", uri)
+	}
+}


### PR DESCRIPTION
## Summary

Stack 5E. Picks up [apps#13863](https://github.com/AudiusProject/audius-protocol/pull/13863). Adds the \`oauth_redirect_uris\` table from apps' SQLAlchemy model and wires \`redirect_uris\` indexing into developer_app create/update handlers.

Migration 0025:
- \`oauth_redirect_uris\` (id serial PK, client_id varchar(255), redirect_uri text, created_at) with index on client_id.

\`extractRedirectURIs()\` validates the \`metadata.redirect_uris\` field per apps:
- must be a list
- each entry must be a string under \`MAX_REDIRECT_URI_LENGTH\` (2000)
- list capped at \`MAX_REDIRECT_URIS\` (50)
- explicit \`null\` → "clear all"
- missing key → "no change"

\`replaceRedirectURIs()\` implements apps' delete-then-insert pattern.

Wired into \`developer_app_create\` (writes if non-empty list) and \`developer_app_update\` (writes when key is present, including the explicit-null clear case).

## Note: pre-existing developer_app_update bug

\`developer_app_update\` has a pre-existing bug — its INSERT-of-a-new-row pattern violates \`UNIQUE(address)\` constraint (the schema has both \`PRIMARY KEY (address, txhash)\` AND \`UNIQUE (address)\` which are incompatible with versioning). **Out of scope for this PR.** The update test covers \`replaceRedirectURIs\` directly via the helper rather than going through the broken handler path.

## Stack context

Stacked on #251 (5C — comment threading). Last PR in the parity stack.

## Test plan

- [x] \`TestExtractRedirectURIs\` (6 sub-cases) — happy path, missing, null, type checks, length cap.
- [x] \`TestDeveloperAppCreate_IndexesRedirectURIs\` — DB-backed end-to-end through the create handler.
- [x] \`TestReplaceRedirectURIs_DeletesAndInserts\` — helper deletes prior rows and inserts new.
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)