### PR TITLE
fix: state sync snapshot reliability (catch-up snapshot + UNLOGGED restore)

### DIFF
--- a/pkg/core/server/abci.go
+++ b/pkg/core/server/abci.go
@@ -91,12 +91,13 @@ func (s *Server) startABCI(ctx context.Context) error {
 
 	s.logger.Info("got latest block", zap.Bool("ss_enabled", s.config.StateSync.Enable), zap.Bool("already_synced", alreadySynced), zap.Int("rpc_servers", len(s.config.StateSync.RPCServers)))
 
-	// Check if we already have downloaded the snapshot
-	skipCometStateSync := false
+	// Restore in-progress state sync tracking from stored metadata (e.g. after a restart
+	// mid-download). CometBFT will re-offer the snapshot and ApplySnapshotChunk will reuse
+	// any chunks already on disk, so we never need to bypass CometBFT's state sync — doing
+	// so would leave CometBFT's state.db at height 0 and cause a handshake mismatch.
 	if s.config.StateSync.Enable && !alreadySynced {
 		offeredSnapshot, err := s.GetOfferedSnapshot()
 		if err == nil && offeredSnapshot != nil {
-			// Restore accepted snapshot tracking from stored metadata (for hot reload recovery)
 			s.snapshotMutex.Lock()
 			s.acceptedSnapshotHeight = offeredSnapshot.Height
 			s.acceptedSnapshotHash = make([]byte, len(offeredSnapshot.Hash))
@@ -107,39 +108,25 @@ func (s *Server) startABCI(ctx context.Context) error {
 				zap.Uint64("height", offeredSnapshot.Height),
 				zap.String("hash", hex.EncodeToString(offeredSnapshot.Hash)))
 
-			if s.haveAllChunks(offeredSnapshot.Height, int(offeredSnapshot.Chunks)) {
-				s.logger.Info("all chunks already downloaded, reconstructing directly and skipping CometBFT state sync",
+			// Restore partial download progress to the console display
+			downloadedChunks, err := s.countReconstructionChunks(int64(offeredSnapshot.Height))
+			if err == nil && downloadedChunks > 0 {
+				s.logger.Info("resuming state sync: chunks already on disk will be reused",
 					zap.Uint64("height", offeredSnapshot.Height),
-					zap.Uint32("chunks", offeredSnapshot.Chunks))
+					zap.Int64("downloadedChunks", downloadedChunks),
+					zap.Uint32("totalChunks", offeredSnapshot.Chunks))
 
-				if err := s.ReassemblePgDump(int64(offeredSnapshot.Height)); err == nil {
-					if err := s.RestoreDatabase(int64(offeredSnapshot.Height)); err == nil {
-						s.logger.Info("state sync completed from existing chunks")
-						s.clearStateSyncInfo()
-						skipCometStateSync = true
-					}
-				}
-			} else {
-				// We have partial progress, restore it in state sync info
-				downloadedChunks, err := s.countReconstructionChunks(int64(offeredSnapshot.Height))
-				if err == nil && downloadedChunks > 0 {
-					s.logger.Info("restoring partial state sync progress",
-						zap.Uint64("height", offeredSnapshot.Height),
-						zap.Int64("downloadedChunks", downloadedChunks),
-						zap.Uint32("totalChunks", offeredSnapshot.Chunks))
-
-					s.updateStateSyncInfo(func(info *v1.GetStatusResponse_SyncInfo_StateSyncInfo) *v1.GetStatusResponse_SyncInfo_StateSyncInfo {
-						info = s.ensureStateSyncInfo(info, offeredSnapshot.Height, offeredSnapshot.Hash, offeredSnapshot.Chunks)
-						info.Phase = v1.GetStatusResponse_SyncInfo_StateSyncInfo_PHASE_DOWNLOADING_CHUNKS
-						info.DownloadedChunks = downloadedChunks
-						return info
-					})
-				}
+				s.updateStateSyncInfo(func(info *v1.GetStatusResponse_SyncInfo_StateSyncInfo) *v1.GetStatusResponse_SyncInfo_StateSyncInfo {
+					info = s.ensureStateSyncInfo(info, offeredSnapshot.Height, offeredSnapshot.Hash, offeredSnapshot.Chunks)
+					info.Phase = v1.GetStatusResponse_SyncInfo_StateSyncInfo_PHASE_DOWNLOADING_CHUNKS
+					info.DownloadedChunks = downloadedChunks
+					return info
+				})
 			}
 		}
 	}
 
-	if s.config.StateSync.Enable && !alreadySynced && !skipCometStateSync {
+	if s.config.StateSync.Enable && !alreadySynced {
 		rpcServers := s.config.StateSync.RPCServers
 		s.logger.Info("state sync enabled", zap.Any("rpcservers", rpcServers))
 

--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
@@ -151,6 +152,56 @@ func (s *Server) startSnapshotCreator(ctx context.Context) error {
 		logger.Info("ServeSnapshots is not enabled, skipping snapshot creation")
 		s.CompleteProcess(ProcessStateSnapshotCreator)
 		return nil
+	}
+
+	// Wait for block sync to complete before creating snapshots.
+	// Snapshots taken while catching up would be stale, and createSnapshot
+	// already skips CatchingUp=true — this makes the wait explicit.
+	s.SleepingProcessWithMetadata(ProcessStateSnapshotCreator, "Waiting for block sync to complete")
+	for {
+		status, err := s.rpc.Status(context.Background())
+		if err == nil && !status.SyncInfo.CatchingUp {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			s.CompleteProcess(ProcessStateSnapshotCreator)
+			return ctx.Err()
+		case <-time.After(30 * time.Second):
+		}
+	}
+
+	// Create an immediate snapshot if all snapshot intervals were missed during
+	// block sync catch-up (e.g. after a node restart). This ensures other nodes
+	// can always state sync without waiting up to BlockInterval blocks.
+	//
+	// Round down to the nearest interval boundary so the snapshot height matches
+	// the expected interval grid (e.g. 24200000, 24100000) and the postgres state
+	// is guaranteed to have processed past that height.
+	{
+		status, err := s.rpc.Status(context.Background())
+		snapshots, _ := s.getStoredSnapshots()
+		if err == nil {
+			latestHeight := status.SyncInfo.LatestBlockHeight
+			blockInterval := s.config.StateSync.BlockInterval
+			snapshotHeight := latestHeight - (latestHeight % blockInterval)
+			newestSnapshot := int64(0)
+			if len(snapshots) > 0 {
+				newestSnapshot = int64(snapshots[len(snapshots)-1].Height)
+			}
+			if snapshotHeight > newestSnapshot {
+				logger.Info("creating catch-up snapshot after block sync",
+					zap.Int64("height", snapshotHeight),
+					zap.Int64("latestHeight", latestHeight),
+					zap.Int64("lastSnapshot", newestSnapshot))
+				if err := s.createSnapshot(logger, snapshotHeight); err != nil {
+					logger.Error("error creating catch-up snapshot", zap.Error(err))
+				}
+				if err := s.pruneSnapshots(logger); err != nil {
+					logger.Error("error pruning snapshots after catch-up", zap.Error(err))
+				}
+			}
+		}
 	}
 
 	node := s.node
@@ -757,7 +808,6 @@ func (s *Server) RestoreDatabase(height int64) error {
 	// Truncate all tables before loading dump data. Migrations pre-populate some tables
 	// (e.g. core_db_migrations) which cause COPY to fail with duplicate key errors.
 	// Collect names first so the connection isn't held open (busy) during TRUNCATE.
-	setMessage("Clearing existing table data")
 	s.logger.Info("pg_restore: truncating tables to clear migration-created data")
 	if db, err := s.pool.Acquire(context.Background()); err == nil {
 		rows, err := db.Query(context.Background(),
@@ -780,7 +830,6 @@ func (s *Server) RestoreDatabase(height int64) error {
 		db.Release()
 	}
 
-	setMessage("Preparing tables for bulk load")
 	s.logger.Info("pg_restore: setting tables to UNLOGGED to suppress WAL during data load")
 	if err := alterPersistence("UNLOGGED"); err != nil {
 		return fmt.Errorf("set unlogged: %w", err)

--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -662,33 +662,109 @@ func (s *Server) ReassemblePgDump(height int64) error {
 	return nil
 }
 
-// RestoreDatabase restores the PostgreSQL database using the reassembled pg_dump binary file
+// RestoreDatabase restores the PostgreSQL database using the reassembled pg_dump binary file.
+// It splits the restore into three phases with tables set to UNLOGGED during the data phase
+// to avoid WAL generation on large tables (e.g. core_transactions) which causes OOM.
 func (s *Server) RestoreDatabase(height int64) error {
 	tmpDir := filepath.Join(s.config.RootDir, tmpReconstructionDir)
 	heightDir := getHeightDir(tmpDir, height)
 	dumpPath := getPgDumpPath(heightDir)
 
-	cmd := exec.Command("pg_restore",
-		"--dbname="+s.config.PSQLConn,
-		"--clean",
-		"--if-exists",
-		"--no-owner",
-		"--no-privileges",
-		dumpPath)
+	pgRestore := func(section string) error {
+		args := []string{
+			"--dbname=" + s.config.PSQLConn,
+			"--no-owner",
+			"--no-privileges",
+		}
+		if section != "" {
+			args = append(args, "--section="+section)
+		}
+		args = append(args, dumpPath)
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+		var stdout, stderr bytes.Buffer
+		cmd := exec.Command("pg_restore", args...)
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
 
-	err := cmd.Run()
-	if err != nil {
-		s.logger.Error("pg_restore failed",
-			zap.Error(err),
-			zap.String("stderr", stderr.String()),
-			zap.String("stdout", stdout.String()),
-		)
-		return fmt.Errorf("error restoring database: %w", err)
+		err := cmd.Run()
+		if err != nil {
+			s.logger.Error("pg_restore failed",
+				zap.String("section", section),
+				zap.Error(err),
+				zap.String("stderr", stderr.String()),
+			)
+			return fmt.Errorf("pg_restore --%s failed: %w", section, err)
+		}
+		return nil
 	}
+
+	alterPersistence := func(persistence string) error {
+		db, err := s.pool.Acquire(context.Background())
+		if err != nil {
+			return fmt.Errorf("acquire connection: %w", err)
+		}
+		defer db.Release()
+
+		rows, err := db.Query(context.Background(),
+			"SELECT tablename FROM pg_tables WHERE schemaname='public'")
+		if err != nil {
+			return fmt.Errorf("list tables: %w", err)
+		}
+		defer rows.Close()
+
+		var tables []string
+		for rows.Next() {
+			var t string
+			if err := rows.Scan(&t); err != nil {
+				return err
+			}
+			tables = append(tables, t)
+		}
+
+		for _, table := range tables {
+			if _, err := db.Exec(context.Background(),
+				"ALTER TABLE "+table+" SET "+persistence); err != nil {
+				s.logger.Warn("failed to alter table persistence",
+					zap.String("table", table),
+					zap.String("persistence", persistence),
+					zap.Error(err))
+			}
+		}
+		return nil
+	}
+
+	// Tune postgres for bulk load: skip WAL fsync, allow large WAL before checkpoint.
+	// These are reset automatically when postgres restarts normally.
+	if db, err := s.pool.Acquire(context.Background()); err == nil {
+		db.Exec(context.Background(), "ALTER SYSTEM SET synchronous_commit = off")
+		db.Exec(context.Background(), "ALTER SYSTEM SET max_wal_size = '8GB'")
+		db.Exec(context.Background(), "ALTER SYSTEM SET checkpoint_timeout = '1h'")
+		db.Exec(context.Background(), "SELECT pg_reload_conf()")
+		db.Release()
+	}
+
+	s.logger.Info("pg_restore: restoring schema (pre-data)")
+	// pre-data errors (missing tables from schema drift) are non-fatal
+	_ = pgRestore("pre-data")
+
+	s.logger.Info("pg_restore: setting tables to UNLOGGED to suppress WAL during data load")
+	if err := alterPersistence("UNLOGGED"); err != nil {
+		return fmt.Errorf("set unlogged: %w", err)
+	}
+
+	s.logger.Info("pg_restore: restoring data")
+	if err := pgRestore("data"); err != nil {
+		return err
+	}
+
+	s.logger.Info("pg_restore: setting tables back to LOGGED")
+	if err := alterPersistence("LOGGED"); err != nil {
+		return fmt.Errorf("set logged: %w", err)
+	}
+
+	s.logger.Info("pg_restore: restoring indexes and constraints (post-data)")
+	// post-data errors (duplicate indexes etc.) are non-fatal
+	_ = pgRestore("post-data")
 
 	return nil
 }

--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -706,7 +706,7 @@ func (s *Server) RestoreDatabase(height int64) error {
 		defer db.Release()
 
 		rows, err := db.Query(context.Background(),
-			"SELECT tablename FROM pg_tables WHERE schemaname='public'")
+			"SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename")
 		if err != nil {
 			return fmt.Errorf("list tables: %w", err)
 		}
@@ -733,13 +733,20 @@ func (s *Server) RestoreDatabase(height int64) error {
 		return nil
 	}
 
-	// Tune postgres for bulk load: skip WAL fsync, allow large WAL before checkpoint.
-	// These are reset automatically when postgres restarts normally.
+	// Tune postgres for bulk load. These are reset automatically when postgres restarts normally.
 	if db, err := s.pool.Acquire(context.Background()); err == nil {
-		db.Exec(context.Background(), "ALTER SYSTEM SET synchronous_commit = off")
-		db.Exec(context.Background(), "ALTER SYSTEM SET max_wal_size = '8GB'")
-		db.Exec(context.Background(), "ALTER SYSTEM SET checkpoint_timeout = '1h'")
-		db.Exec(context.Background(), "SELECT pg_reload_conf()")
+		for _, sql := range []string{
+			"ALTER SYSTEM SET synchronous_commit = off",
+			"ALTER SYSTEM SET max_wal_size = '8GB'",
+			"ALTER SYSTEM SET checkpoint_timeout = '1h'",
+			"SELECT pg_reload_conf()",
+		} {
+			if _, err := db.Exec(context.Background(), sql); err != nil {
+				s.logger.Warn("pg_restore: failed to apply tuning setting", zap.String("sql", sql), zap.Error(err))
+			} else {
+				s.logger.Info("pg_restore: applied setting", zap.String("sql", sql))
+			}
+		}
 		db.Release()
 	}
 
@@ -747,6 +754,28 @@ func (s *Server) RestoreDatabase(height int64) error {
 	// pre-data errors (missing tables from schema drift) are non-fatal
 	_ = pgRestore("pre-data")
 
+	// Truncate all tables before loading dump data. Migrations pre-populate some tables
+	// (e.g. core_db_migrations) which cause COPY to fail with duplicate key errors.
+	setMessage("Clearing existing table data")
+	s.logger.Info("pg_restore: truncating tables to clear migration-created data")
+	if db, err := s.pool.Acquire(context.Background()); err == nil {
+		rows, err := db.Query(context.Background(),
+			"SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename")
+		if err == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var t string
+				if err := rows.Scan(&t); err == nil {
+					if _, err := db.Exec(context.Background(), "TRUNCATE TABLE "+t+" CASCADE"); err != nil {
+						s.logger.Warn("pg_restore: failed to truncate table", zap.String("table", t), zap.Error(err))
+					}
+				}
+			}
+		}
+		db.Release()
+	}
+
+	setMessage("Preparing tables for bulk load")
 	s.logger.Info("pg_restore: setting tables to UNLOGGED to suppress WAL during data load")
 	if err := alterPersistence("UNLOGGED"); err != nil {
 		return fmt.Errorf("set unlogged: %w", err)

--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -756,20 +756,25 @@ func (s *Server) RestoreDatabase(height int64) error {
 
 	// Truncate all tables before loading dump data. Migrations pre-populate some tables
 	// (e.g. core_db_migrations) which cause COPY to fail with duplicate key errors.
+	// Collect names first so the connection isn't held open (busy) during TRUNCATE.
 	setMessage("Clearing existing table data")
 	s.logger.Info("pg_restore: truncating tables to clear migration-created data")
 	if db, err := s.pool.Acquire(context.Background()); err == nil {
 		rows, err := db.Query(context.Background(),
 			"SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename")
+		var tables []string
 		if err == nil {
-			defer rows.Close()
 			for rows.Next() {
 				var t string
-				if err := rows.Scan(&t); err == nil {
-					if _, err := db.Exec(context.Background(), "TRUNCATE TABLE "+t+" CASCADE"); err != nil {
-						s.logger.Warn("pg_restore: failed to truncate table", zap.String("table", t), zap.Error(err))
-					}
+				if rows.Scan(&t) == nil {
+					tables = append(tables, t)
 				}
+			}
+			rows.Close()
+		}
+		for _, t := range tables {
+			if _, err := db.Exec(context.Background(), "TRUNCATE TABLE "+t+" CASCADE"); err != nil {
+				s.logger.Warn("pg_restore: failed to truncate table", zap.String("table", t), zap.Error(err))
 			}
 		}
 		db.Release()


### PR DESCRIPTION
## Problem

Two interrelated state sync reliability issues:

1. **No fresh snapshots after node restart** — When a node restarts and block-syncs to the current head, `createSnapshot` returns early for every interval that fires while `CatchingUp=true`. Both creatornode.audius.co and creatornode2.audius.co hit this: after their recent restarts they missed every snapshot interval between ~23.7M and ~24.2M blocks (~8h gap). Nodes needing to state sync had no usable recent snapshot.

2. **OOM during pg_restore** — `pg_restore` on large tables (`core_transactions`, 19M+ rows) generates ~4.4GB of WAL per checkpoint cycle, causing OOM even with `synchronous_commit=off` and `wal_level=minimal`. Migrations also pre-populate some tables before `pg_restore` runs, causing COPY to fail with duplicate key errors.

## Changes

**`pkg/core/server/state_sync.go`**
- After block sync completes (`CatchingUp=false`), immediately create a snapshot if the latest existing snapshot is more than `BlockInterval` blocks old. Prevents the 8-16h gap where no fresh snapshots exist after a restart.
- Split `RestoreDatabase` into three phases: pre-data (schema), data, post-data (indexes). During the data phase, all tables are set to `UNLOGGED` (suppresses WAL completely), then converted back to `LOGGED` before index build.
- Truncate all public tables before the data phase so migration-created rows don't cause duplicate key errors.
- Collect table names into a slice before running TRUNCATEs to avoid pgx `conn busy` error (can't call `Exec` while `rows.Next()` is iterating on same connection).

**`pkg/core/server/abci.go`**
- Remove broken "direct restore path" that skipped CometBFT state sync when all chunks were already on disk. This left `state.db` at height 0 while ABCI returned the snapshot height, causing a handshake mismatch on every subsequent start. CometBFT's native `ApplySnapshotChunk` already reuses on-disk chunks and correctly updates `state.db`.

## Scope

Intentionally minimal — only the 4 commits that fix snapshot creation and restore reliability. Does not include: trust height fix, console display changes, CI changes, or rollback entrypoint changes (those are in separate PRs).

## Deploy plan

1. Merge and deploy to **creatornode.audius.co** and **creatornode2.audius.co** — on restart, each will immediately create a fresh snapshot at the current block height instead of waiting up to 100k blocks (~37h).
2. Once a fresh snapshot appears, wipe and restart **creatornode3.audius.co** to state sync against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)