### PR TITLE
fix: tighten state-sync defaults (keep=2, blockInterval=100000)

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -204,7 +204,7 @@ func ReadConfig() (*Config, error) {
 	cfg.StateSync = &StateSyncConfig{
 		ServeSnapshots: GetEnvWithDefault("stateSyncServeSnapshots", "false") == "true",
 		Enable:         GetEnvWithDefault("stateSyncEnable", "true") == "true",
-		Keep:           getEnvIntWithDefault("stateSyncKeep", 6),
+		Keep:           getEnvIntWithDefault("stateSyncKeep", 2),
 		BlockInterval:  int64(getEnvIntWithDefault("stateSyncBlockInterval", 100)),
 		ChunkFetchers:  int32(getEnvIntWithDefault("stateSyncChunkFetchers", 10)),
 		RPCServers:     strings.Split(GetEnvWithDefault("stateSyncRPCServers", ssRpcServers), ","),

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -205,7 +205,7 @@ func ReadConfig() (*Config, error) {
 		ServeSnapshots: GetEnvWithDefault("stateSyncServeSnapshots", "false") == "true",
 		Enable:         GetEnvWithDefault("stateSyncEnable", "true") == "true",
 		Keep:           getEnvIntWithDefault("stateSyncKeep", 2),
-		BlockInterval:  int64(getEnvIntWithDefault("stateSyncBlockInterval", 100)),
+		BlockInterval:  int64(getEnvIntWithDefault("stateSyncBlockInterval", 100000)),
 		ChunkFetchers:  int32(getEnvIntWithDefault("stateSyncChunkFetchers", 10)),
 		RPCServers:     strings.Split(GetEnvWithDefault("stateSyncRPCServers", ssRpcServers), ","),
 	}


### PR DESCRIPTION
## Summary
Two related default changes in `pkg/core/config/config.go` to bring the state-sync defaults in line with what production validators actually use:

- **`stateSyncKeep`: `6` → `2`** — each snapshot is currently ~30–45 GB. With `Keep=6` a snapshot-serving node accumulates ~180 GB+ of snapshots on top of chain data and Postgres. This exhausted the 1 TB disk on `creatornode2.audius.co` today (the only prod node with `stateSyncServeSnapshots=true`), which put Postgres into a checkpoint PANIC / recovery loop until snapshots were manually deleted. Two snapshots is enough to serve an incoming state-syncer (newest) plus one fallback (in case the newest is mid-creation).

- **`stateSyncBlockInterval`: `100` → `100000`** — a 100-block interval would create a new snapshot roughly every minute on mainnet, which is far too aggressive both on disk and CPU. Prod already overrides this to `100000` (the height boundaries seen in `/data/bolt/snapshots_*/height_002420****` etc.); align the default with what validators actually use.

Operators who want different values can still override via the `stateSyncKeep` / `stateSyncBlockInterval` env vars.

## Test plan
- [ ] CI green
- [ ] After rollout on `creatornode2.audius.co`, confirm only the most recent 2 snapshot directories exist under `/data/bolt/snapshots_<chainID>/` after the next snapshot creation cycle.
- [ ] Confirm new nodes coming up without env overrides take snapshots at 100k-block boundaries (heights ending in `_00000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)