### PR TITLE
chore: re-enable edge tag push on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
 
   tag-edge:
-    if: false # temporarily disabled: edge tag pushes trigger auto-upgrade restarts which break snapshot creation (see PR #226)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-test-push
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
State sync reliability fixes are merged (PR #253, #254, #256) and creator-3 has successfully completed state sync. Re-enabling the `:edge` auto-upgrade tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)