### PR TITLE
feat: blob storage streaming redirect for images

### DIFF
--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -308,13 +308,34 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		return nil
 	} else {
 		// non audio (images)
+		go ss.recordMetric(ServeImage)
+
+		// Presigned URL redirect: send client directly to storage backend.
+		// Skip when a download filename was requested so the Content-Disposition
+		// header set above is preserved.
+		if ss.Config.BlobStorageStreaming && filenameForDownload == "" {
+			signedURL, err := foundIn.SignedURL(ctx, key, &gcblob.SignedURLOptions{
+				Expiry: presignedURLDefaultExpiry,
+				Method: http.MethodGet,
+			})
+			if err != nil {
+				ss.logger.Error("presigned URL generation failed for image",
+					zap.String("cid", cid), zap.Error(err))
+				return c.JSON(http.StatusInternalServerError, map[string]string{
+					"error": "blob storage streaming is enabled but presigned URL generation failed",
+				})
+			}
+			blob.Close()
+			blob = nil // prevent double-close in defer
+			return c.Redirect(http.StatusTemporaryRedirect, signedURL)
+		}
+
 		// images: cache 30 days
 		c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=2592000, immutable")
 		blobData, err := io.ReadAll(blob)
 		if err != nil {
 			return err
 		}
-		go ss.recordMetric(ServeImage)
 		return c.Blob(200, blob.ContentType(), blobData)
 	}
 


### PR DESCRIPTION
## Summary
- Extends \`OPENAUDIO_BLOB_STORAGE_STREAMING\` so non-audio blobs (artwork, profile pics, playlist art) also redirect to a presigned GCS URL instead of streaming bytes through the node
- Uses \`presignedURLDefaultExpiry\` (2h) since images have no track duration
- Skips the redirect when \`?filename=...\` is set so \`Content-Disposition\` is preserved, mirroring the audio path's \`id3\`/\`filename\` carve-outs
- Records the \`ServeImage\` metric on both the redirect and direct-serve branches

## Test plan
- [ ] Deploy to a node with \`OPENAUDIO_BLOB_STORAGE_STREAMING=true\` (e.g. creator-3)
- [ ] Fetch an artwork CID and confirm a \`307\` redirect to a signed \`storage.googleapis.com\` URL
- [ ] Fetch \`?filename=foo.jpg\` and confirm it streams from the node with the \`Content-Disposition\` header
- [ ] Confirm audio behavior is unchanged