### PR TITLE
Version v1.2.13: reward authority rotation primitive (RewardPool)

### DIFF
--- a/pkg/version/.version.json
+++ b/pkg/version/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.2.12",
+  "version": "1.2.13",
   "service": "validator"
 }


### PR DESCRIPTION
## Summary

Ships as **v1.2.13** (`.version.json` bumped in this PR). Releases the `RewardPool` cometbft primitive merged in #254, which unblocks the artist-coin attestation kill switch added in v1.2.11 (#215).

## What's in v1.2.13

PR #254 — Reward authority rotation primitive (RewardPool):

- **Schema** (migration `00034_reward_pools.sql`): new `core_reward_pools` table keyed by the Solana RM pubkey; `core_rewards.rewards_manager_pubkey` FK with reads aliased as `claim_authorities` via LEFT JOIN. `launchpad_authority_rm` seed table maps each per-mint claim authority eth address → its Solana RM, backfilling existing reward rows to real-RM-bound pools. The legacy `core_rewards.claim_authorities` column is dropped.
- **Cometbft txs**: body+signature envelope; new `CreateRewardPool` and `SetRewardPoolAuthorities` actions. `CreateReward` now requires an existing pool; signer must be in the pool's authorities. `CreateRewardPool` additionally requires an **ed25519 `rm_owner_signature`** over the body bytes, produced by the RM's keypair — defeats pool-creation frontrunning by an observer who watches Solana RM init events but lacks the launchpad's deterministic secret.
- **Wire compat**: legacy reward bytes are rejected at CheckTx/ProcessProposal but accepted at FinalizeBlock for block-sync replay of historical state.
- **Validator endpoints**: `GetRewardAttestation` restored from the #215 kill switch; auth check uses the pool's current authorities so rotation immediately revokes attestation rights. `GetRewardSenderAttestation` / `GetDeleteRewardSenderAttestation` gate per-RM (pool members for pool-managed RMs; validator/AAO trust set only for the configured AUDIO RM; everything else is refused).
- **AUDIO denylist**: `validateCreateRewardPool` refuses the configured AUDIO RM, so AUDIO attestation authority remains on the network-wide trust set.

## What changed

- `pkg/version/.version.json`: `1.2.12` → `1.2.13`.

## Implications for rollout

This release pairs with corresponding API-repo work (deferred from PR #254) that lands `CreateRewardPool` calls before `CreateReward` for new launchpad mints. Until that ships, new mints will fail at `validateCreateReward`'s pool-existence check. Existing mints work via the migration backfill.

The wire-compat layer keeps the chain replayable for any node bootstrapping from genesis. PR #232 (separate, post-network-restart cleanup) strips it later.

## Test plan

- [ ] CI green
- [ ] Local: migration applies cleanly to a fresh DB and to a snapshot of staging
- [ ] After merge: trigger `Create Release` workflow with `version=v1.2.13`
- [ ] Roll v1.2.13 to `edge` and verify the AUDIO denylist is active in the chosen environment (`AudioRewardsManagerPubkey()` returns the expected RM)
- [ ] Verify a `CreateRewardPool` integration test against devnet round-trips: pool created → reward created against pool → authority rotated via `SetRewardPoolAuthorities` → rotated-out authority can no longer attest

🤖 Generated with [Claude Code](https://claude.com/claude-code)