### PR TITLE
feat: redirect-on-miss + replication backoff (peering egress)

### DIFF
--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -178,6 +178,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		RepairEnabled:            repairEnabled,
 		RepairInterval:           repairInterval,
 		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
+		RedirectOnMiss:            os.Getenv("OPENAUDIO_REDIRECT_ON_MISS") == "true",
 	}
 
 	ss, err := server.New(lc, logger, config, posChannel, core, ethService)

--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -178,7 +178,6 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		RepairEnabled:            repairEnabled,
 		RepairInterval:           repairInterval,
 		BlobStorageStreaming:      os.Getenv("OPENAUDIO_BLOB_STORAGE_STREAMING") == "true",
-		RedirectOnMiss:            os.Getenv("OPENAUDIO_REDIRECT_ON_MISS") == "true",
 	}
 
 	ss, err := server.New(lc, logger, config, posChannel, core, ethService)

--- a/pkg/mediorum/server/replicate_worker.go
+++ b/pkg/mediorum/server/replicate_worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/server/signature"
 	"github.com/bdragon300/tusgo"
+	"github.com/erni27/imcache"
 	"go.uber.org/zap"
 )
 
@@ -348,8 +349,15 @@ func (ss *MediorumServer) findMissedReplications() {
 
 	for _, upload := range uploads {
 		if len(upload.Mirrors) < ss.Config.ReplicationFactor {
+			// Backoff so we don't re-queue the same upload every cycle while
+			// it stays under-replicated (e.g. its source blob is gone or
+			// peers keep rejecting it). After the cache TTL we'll try again.
+			if _, attempted := ss.replicationAttempts.Get(upload.ID); attempted {
+				continue
+			}
 			select {
 			case ss.replicationWork <- upload:
+				ss.replicationAttempts.Set(upload.ID, struct{}{}, imcache.WithDefaultExpiration())
 				ss.logger.Info("queued upload for replication", zap.String("uploadID", upload.ID))
 			default:
 				// Channel full, skip for now

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -182,6 +182,25 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 				return c.String(404, "blob not found")
 			}
 
+			// Redirect-on-miss: send the user straight to a peer that has
+			// the blob, and kick off a backgrounded pull (with backoff) so
+			// we eventually hold blobs that are rendezvous-ours. Avoids the
+			// doubled-egress cost of pulling-then-serving inline with the
+			// user request.
+			if ss.Config.RedirectOnMiss {
+				host := ss.findNodeToServeBlob(ctx, cid)
+				if host == "" {
+					return c.String(404, "blob not found")
+				}
+				ss.maybeBackgroundPull(cid)
+
+				dest := ss.replaceHost(c, host)
+				query := dest.Query()
+				query.Add("allow_unhealthy", "true") // we confirmed the node has it
+				dest.RawQuery = query.Encode()
+				return c.Redirect(302, dest.String())
+			}
+
 			// Try to pull the file first
 			_, pullErr := ss.findAndPullBlob(ctx, cid, nil)
 			if pullErr == nil {
@@ -389,6 +408,33 @@ func (ss *MediorumServer) findNodeToServeBlob(_ context.Context, key string) str
 	}
 
 	return ""
+}
+
+// maybeBackgroundPull starts an async pull of cid into our local bucket so
+// we eventually hold blobs we're rendezvous-supposed-to-hold, without doing
+// the pull inline with the user request. Skips if the CID isn't ours (no
+// reason to acquire it), if disk is full, or if we already attempted a pull
+// for this CID within the backoff window.
+func (ss *MediorumServer) maybeBackgroundPull(cid string) {
+	_, isMine := ss.rendezvousAllHosts(cid)
+	if !isMine {
+		return
+	}
+	if _, found := ss.bgPullBackoff.Get(cid); found {
+		return
+	}
+	if !ss.diskHasSpaceForCID(cid, nil) {
+		return
+	}
+	ss.bgPullBackoff.Set(cid, struct{}{}, imcache.WithDefaultExpiration())
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		if _, err := ss.findAndPullBlob(ctx, cid, nil); err != nil {
+			ss.logger.Debug("background pull failed", zap.String("cid", cid), zap.Error(err))
+		}
+	}()
 }
 
 // findAndPullBlob locates a CID on the network and pulls it into the local

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -174,7 +172,10 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 
 	blob, foundIn, err := ss.readBlob(ctx, key)
 
-	// If our bucket doesn't have the file, try to pull it first
+	// Cache miss: redirect the client to a peer that has the blob and
+	// fire a backgrounded pull (with backoff) so we eventually hold blobs
+	// that are rendezvous-ours. Avoids the doubled-egress cost of
+	// pulling-then-serving inline with the user request.
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			// don't redirect if the client only wants to know if we have it (ie localOnly query param is true)
@@ -182,64 +183,17 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 				return c.String(404, "blob not found")
 			}
 
-			// Redirect-on-miss: send the user straight to a peer that has
-			// the blob, and kick off a backgrounded pull (with backoff) so
-			// we eventually hold blobs that are rendezvous-ours. Avoids the
-			// doubled-egress cost of pulling-then-serving inline with the
-			// user request.
-			if ss.Config.RedirectOnMiss {
-				host := ss.findNodeToServeBlob(ctx, cid)
-				if host == "" {
-					return c.String(404, "blob not found")
-				}
-				ss.maybeBackgroundPull(cid)
-
-				dest := ss.replaceHost(c, host)
-				query := dest.Query()
-				query.Add("allow_unhealthy", "true") // we confirmed the node has it
-				dest.RawQuery = query.Encode()
-				return c.Redirect(302, dest.String())
+			host := ss.findNodeToServeBlob(ctx, cid)
+			if host == "" {
+				return c.String(404, "blob not found")
 			}
+			ss.maybeBackgroundPull(cid)
 
-			// Try to pull the file first
-			_, pullErr := ss.findAndPullBlob(ctx, cid, nil)
-			if pullErr == nil {
-				// Successfully pulled, try reading again
-				blob, foundIn, err = ss.readBlob(ctx, key)
-				if err == nil {
-					// Successfully read after pull, continue with normal serving
-				} else {
-					// Still can't read after pull, fall through to proxy/redirect
-					ss.logger.Warn("failed to read blob after pull", zap.String("cid", cid), zap.Error(err))
-				}
-			} else {
-				// Pull failed - check if it's due to disk space
-				if !ss.diskHasSpaceForCID(cid, nil) {
-					// Disk is full, proxy the request instead of erroring
-					ss.logger.Info("disk full, proxying blob request", zap.String("cid", cid), zap.Error(pullErr))
-					host := ss.findNodeToServeBlob(ctx, cid)
-					if host == "" {
-						return c.String(404, "blob not found")
-					}
-					return ss.proxyBlobRequest(c, host, cid)
-				}
-				// Pull failed for other reasons, fall through to redirect
-				ss.logger.Debug("failed to pull blob, will redirect", zap.String("cid", cid), zap.Error(pullErr))
-			}
-
-			// If we still don't have the blob, redirect to a node that has it
-			if blob == nil {
-				host := ss.findNodeToServeBlob(ctx, cid)
-				if host == "" {
-					return c.String(404, "blob not found")
-				}
-
-				dest := ss.replaceHost(c, host)
-				query := dest.Query()
-				query.Add("allow_unhealthy", "true") // we confirmed the node has it, so allow it to serve it even if unhealthy
-				dest.RawQuery = query.Encode()
-				return c.Redirect(302, dest.String())
-			}
+			dest := ss.replaceHost(c, host)
+			query := dest.Query()
+			query.Add("allow_unhealthy", "true") // we confirmed the node has it
+			dest.RawQuery = query.Encode()
+			return c.Redirect(302, dest.String())
 		} else {
 			return err
 		}
@@ -512,39 +466,6 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 	})
 
 	ss.logger.Info("play logged", zap.String("user_id", userId), zap.String("track_id", trackID))
-}
-
-// proxyBlobRequest proxies a blob request to another node when we don't have disk space to pull it
-func (ss *MediorumServer) proxyBlobRequest(c echo.Context, targetHost, cid string) error {
-	// Build the target URL
-	targetURL, err := url.Parse(targetHost)
-	if err != nil {
-		return c.String(500, "invalid target host")
-	}
-	targetURL.Scheme = ss.getScheme()
-	targetURL.Path = c.Request().URL.Path
-	targetURL.RawQuery = c.Request().URL.RawQuery
-
-	// Add allow_unhealthy query param
-	query := targetURL.Query()
-	query.Add("allow_unhealthy", "true")
-	targetURL.RawQuery = query.Encode()
-
-	// Create reverse proxy
-	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-
-	// Modify the request for proxying
-	originalURL := c.Request().URL
-	c.Request().URL = targetURL
-	c.Request().Host = targetURL.Host
-
-	// Proxy the request
-	proxy.ServeHTTP(c.Response(), c.Request())
-
-	// Restore original URL (though response is already sent)
-	c.Request().URL = originalURL
-
-	return nil
 }
 
 // checks signature from discovery node

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -82,7 +82,6 @@ type MediorumConfig struct {
 
 	ProgrammableDistributionEnabled bool
 	BlobStorageStreaming             bool
-	RedirectOnMiss                   bool
 
 	// should have a basedir type of thing
 	// by default will put db + blobs there

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -82,6 +82,7 @@ type MediorumConfig struct {
 
 	ProgrammableDistributionEnabled bool
 	BlobStorageStreaming             bool
+	RedirectOnMiss                   bool
 
 	// should have a basedir type of thing
 	// by default will put db + blobs there
@@ -140,6 +141,8 @@ type MediorumServer struct {
 	trackAccessInfoCache  *imcache.Cache[string, trackAccessInfo]
 	attrCache             *imcache.Cache[string, *blob.Attributes]
 	knownPresent          *imcache.Cache[string, int64]
+	bgPullBackoff         *imcache.Cache[string, struct{}]
+	replicationAttempts   *imcache.Cache[string, struct{}]
 	failsPeerReachability bool
 
 	StartedAt time.Time
@@ -394,6 +397,8 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		trackAccessInfoCache: imcache.New(imcache.WithMaxEntriesLimitOption[string, trackAccessInfo](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, trackAccessInfo](5*time.Minute)),
 		attrCache:            imcache.New(imcache.WithMaxEntriesLimitOption[string, *blob.Attributes](10_000, imcache.EvictionPolicyLRU)),
 		knownPresent:         imcache.New(imcache.WithMaxEntriesLimitOption[string, int64](500_000, imcache.EvictionPolicyLRU)),
+		bgPullBackoff:        imcache.New(imcache.WithMaxEntriesLimitOption[string, struct{}](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, struct{}](time.Hour)),
+		replicationAttempts:  imcache.New(imcache.WithMaxEntriesLimitOption[string, struct{}](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, struct{}](time.Hour)),
 
 		StartedAt: time.Now().UTC(),
 		Config:    config,


### PR DESCRIPTION
Reduces inter-node peering egress, which on creator-3 was running ~10x the user-facing audio traffic (one CID = 458 MB outbound to peers in a 20-min log window).

## Summary
**1. Redirect-on-miss in \`serveBlob\`** (now the default — no flag)

A cache miss in \`serveBlob\` no longer pulls the full blob from a peer before serving the user. Instead, the user is 302'd straight to a peer that has the blob, and a backgrounded \`findAndPullBlob\` is fired so the node still eventually holds blobs it's rendezvous-supposed-to hold. Cuts the inbound peer-pull leg on every cold read.

The background pull has a per-CID 1h backoff (\`bgPullBackoff\` imcache, 50k LRU) so repeated requests for the same missing CID don't each spawn a fresh pull. It also short-circuits when \`!isMine\` (no point acquiring a blob we won't be asked to hold) and when disk is full.

Dead code removed alongside the flag: the synchronous pull-on-miss block, the disk-full \`proxyBlobRequest\` fallback (now obsolete since redirect-on-miss handles cold misses without touching local disk), the post-pull re-read.

**2. Replication-attempt backoff in \`findMissedReplications\`**

The 5-min replication scan now skips uploads it queued within the last hour (\`replicationAttempts\` imcache). On creator-3 the scan was re-queuing 100+ orphaned uploads every tick — their source blobs are gone, so the worker immediately fails with \`storage: object doesn't exist\`. Backoff stops the noise without changing recovery behavior (after the TTL it tries again).

## Test plan
- [x] \`go build ./pkg/mediorum/...\` clean
- [ ] After deploy: \`/internal/blobs/*\` outbound bytes drop materially on the deployed node
- [ ] A missing CID on the node produces a 302 (not a pull-and-serve)
- [ ] The node still acquires blobs via the background pull within a few minutes of being asked for them (check bucket contents)
- [ ] No duplicate-pull within the 1h backoff window (no repeated \"background pull failed\" lines for the same CID inside an hour)