### PR TITLE
fix(integration-tests): stabilize flaky devnet startup in CI

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -167,7 +167,7 @@ services:
 
   test-integration:
     image: ${OPENAUDIO_TEST_HARNESS_IMAGE:-openaudio/go-openaudio:harness}
-    command: go test -v -count=1 -timeout=90s ./pkg/integration_tests/...
+    command: go test -v -count=1 -timeout=300s ./pkg/integration_tests/...
     volumes:
       - ./cmd:/app/cmd
       - ./pkg:/app/pkg
@@ -182,13 +182,13 @@ services:
       - 'node4.oap.devnet:host-gateway'
     depends_on:
       openaudio-1:
-        condition: service_started
+        condition: service_healthy
       openaudio-2:
-        condition: service_started
+        condition: service_healthy
       openaudio-3:
-        condition: service_started
+        condition: service_healthy
       openaudio-4:
-        condition: service_started
+        condition: service_healthy
       eth-ganache:
         condition: service_healthy
       nginx:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -167,7 +167,7 @@ services:
 
   test-integration:
     image: ${OPENAUDIO_TEST_HARNESS_IMAGE:-openaudio/go-openaudio:harness}
-    command: go test -v -count=1 -timeout=300s ./pkg/integration_tests/...
+    command: go test -v -count=1 -timeout=600s ./pkg/integration_tests/...
     volumes:
       - ./cmd:/app/cmd
       - ./pkg:/app/pkg

--- a/pkg/integration_tests/utils/nodes.go
+++ b/pkg/integration_tests/utils/nodes.go
@@ -71,7 +71,7 @@ func EnsureProtocol(endpoint string) string {
 }
 
 func WaitForDevnetHealthy(timeout ...time.Duration) error {
-	timeoutDuration := 60 * time.Second
+	timeoutDuration := 120 * time.Second
 	if len(timeout) > 0 {
 		timeoutDuration = timeout[0]
 	}

--- a/pkg/integration_tests/utils/nodes.go
+++ b/pkg/integration_tests/utils/nodes.go
@@ -71,7 +71,7 @@ func EnsureProtocol(endpoint string) string {
 }
 
 func WaitForDevnetHealthy(timeout ...time.Duration) error {
-	timeoutDuration := 120 * time.Second
+	timeoutDuration := 300 * time.Second
 	if len(timeout) > 0 {
 		timeoutDuration = timeout[0]
 	}
@@ -94,67 +94,70 @@ func WaitForDevnetHealthy(timeout ...time.Duration) error {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	client := NewTestHTTPClient()
+	// Use a short per-request timeout so a single slow/hung node cannot
+	// exhaust the overall readiness budget on one iteration.
+	pollClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: 5 * time.Second,
+	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return errors.New("timed out waiting for devnet to be ready")
-		case <-ticker.C:
-			// Check core services are ready
-			allReady := true
-			for _, n := range nodes {
-				status, err := n.Core.GetStatus(context.Background(), connect.NewRequest(&corev1.GetStatusRequest{}))
-				if err != nil {
-					allReady = false
-					break
-				} else if !status.Msg.Ready {
-					allReady = false
-					break
-				}
+	checkReady := func() bool {
+		for _, n := range nodes {
+			reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+			status, err := n.Core.GetStatus(reqCtx, connect.NewRequest(&corev1.GetStatusRequest{}))
+			reqCancel()
+			if err != nil || status.Msg == nil || !status.Msg.Ready {
+				return false
 			}
-			if !allReady {
-				continue
+		}
+
+		for _, addr := range nodeAddresses {
+			baseURL := addr
+			if !strings.HasPrefix(baseURL, "https://") && !strings.HasPrefix(baseURL, "http://") {
+				baseURL = "https://" + baseURL
+			} else if strings.HasPrefix(baseURL, "http://") {
+				baseURL = strings.Replace(baseURL, "http://", "https://", 1)
 			}
 
-			// Check mediorum services have wallets registered
-			allMediorumReady := true
+			reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+			req, err := http.NewRequestWithContext(reqCtx, "GET", baseURL+"/health-check", nil)
+			if err != nil {
+				reqCancel()
+				return false
+			}
+			resp, err := pollClient.Do(req)
+			reqCancel()
+			if err != nil {
+				return false
+			}
+
 			var healthResponse struct {
 				Storage struct {
 					WalletIsRegistered bool `json:"wallet_is_registered"`
 				} `json:"storage"`
 			}
-
-			for _, addr := range nodeAddresses {
-				// Ensure https:// protocol
-				baseURL := addr
-				if !strings.HasPrefix(baseURL, "https://") && !strings.HasPrefix(baseURL, "http://") {
-					baseURL = "https://" + baseURL
-				} else if strings.HasPrefix(baseURL, "http://") {
-					baseURL = strings.Replace(baseURL, "http://", "https://", 1)
-				}
-
-				req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/health-check", nil)
-				if err != nil {
-					allMediorumReady = false
-					break
-				}
-
-				resp, err := client.Do(req)
-				if err != nil {
-					allMediorumReady = false
-					break
-				}
-
-				if resp.StatusCode != 200 || json.NewDecoder(resp.Body).Decode(&healthResponse) != nil || !healthResponse.Storage.WalletIsRegistered {
-					resp.Body.Close()
-					allMediorumReady = false
-					break
-				}
-				resp.Body.Close()
+			ok := resp.StatusCode == 200 &&
+				json.NewDecoder(resp.Body).Decode(&healthResponse) == nil &&
+				healthResponse.Storage.WalletIsRegistered
+			resp.Body.Close()
+			if !ok {
+				return false
 			}
+		}
+		return true
+	}
 
-			if allReady && allMediorumReady {
+	if checkReady() {
+		return nil
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("timed out waiting for devnet to be ready")
+		case <-ticker.C:
+			if checkReady() {
 				return nil
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes the flaky integration-test run seen in [actions/runs/25826369209](https://github.com/OpenAudio/go-openaudio/actions/runs/25826369209/job/75880429999), where `TestBlockCreation` timed out waiting for the devnet and then the suite itself died at the 90s overall `go test` timeout while `TestEntityManager` was still in flight.

- Wait for `openaudio-1..4` to be `service_healthy` (not just `service_started`) before the test harness runs `go test`, so tests don't begin before any node is serving traffic.
- Raise the suite-level `go test -timeout` from `90s` to `300s` — the previous value was tighter than a single readiness probe and turned one slow boot into a suite-wide failure.
- Raise `WaitForDevnetHealthy` default from `60s` to `120s` to cover slower mediorum wallet registration on cold CI runners (HTTP healthcheck can pass before the wallet is registered).

## Test plan

- [ ] CI integration-tests job passes on this PR
- [ ] Re-run a few times to confirm reduced flake rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)