### PR TITLE
fix(etl): normalize empty playlist_contents on update (apps#14306 parity)

### DIFF
--- a/pkg/etl/processors/entity_manager/empty_playlist_contents_test.go
+++ b/pkg/etl/processors/entity_manager/empty_playlist_contents_test.go
@@ -1,0 +1,159 @@
+package entity_manager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// Regression: removing the last track from a playlist via an Update should
+// empty the playlist on reload (both the JSONB column and the playlist_tracks
+// junction). The handler's key-exists check (`_, ok :=`) correctly
+// distinguishes an empty list from a missing key; these tests lock that in.
+
+func TestPlaylistUpdate_EmptyArrayMarksAllTracksRemoved(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 1300)
+	pid := int64(PlaylistIDOffset + 12000)
+	t1 := int64(TrackIDOffset + 13000)
+	seedUser(t, pool, uid, "0xemptyowner", "emptyu")
+	seedTrackFull(t, pool, t1, uid, "Lone Track")
+
+	createMeta := `{"playlist_name":"Single","is_album":false,"is_private":false,"playlist_contents":{"track_ids":[{"track":2013000,"time":1700000000}]}}`
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xemptyowner", createMeta))
+
+	// Sanity: one row, not removed.
+	var beforeCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = $1 AND is_removed = false",
+		pid).Scan(&beforeCount); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if beforeCount != 1 {
+		t.Fatalf("expected 1 active row before update, got %d", beforeCount)
+	}
+
+	// SDK-style empty list at the new array form.
+	updateMeta := `{"playlist_contents":[]}`
+	mustHandle(t, PlaylistUpdate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionUpdate, uid, pid, "0xemptyowner", updateMeta))
+
+	var activeAfter int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = $1 AND is_removed = false",
+		pid).Scan(&activeAfter); err != nil {
+		t.Fatalf("count after: %v", err)
+	}
+	if activeAfter != 0 {
+		t.Errorf("after empty-array update, expected 0 active playlist_tracks rows, got %d", activeAfter)
+	}
+
+	// Legacy dict form `{track_ids: []}` should behave the same.
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid+1, "0xemptyowner",
+			`{"playlist_name":"Single2","is_album":false,"is_private":false,"playlist_contents":{"track_ids":[{"track":2013000,"time":1700000000}]}}`))
+
+	mustHandle(t, PlaylistUpdate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionUpdate, uid, pid+1, "0xemptyowner",
+			`{"playlist_contents":{"track_ids":[]}}`))
+
+	var legacyActive int
+	_ = pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = $1 AND is_removed = false",
+		pid+1).Scan(&legacyActive)
+	if legacyActive != 0 {
+		t.Errorf("legacy {track_ids:[]} form: expected 0 active rows, got %d", legacyActive)
+	}
+}
+
+func TestPlaylistUpdate_EmptyArrayWritesJSONBColumn(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	uid := int64(UserIDOffset + 1310)
+	pid := int64(PlaylistIDOffset + 12100)
+	t1 := int64(TrackIDOffset + 13100)
+	seedUser(t, pool, uid, "0xjsonbu", "jsonbu")
+	seedTrackFull(t, pool, t1, uid, "Track")
+
+	mustHandle(t, PlaylistCreate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionCreate, uid, pid, "0xjsonbu",
+			`{"playlist_name":"P","is_album":false,"is_private":false,"playlist_contents":{"track_ids":[{"track":2013100,"time":1}]}}`))
+
+	mustHandle(t, PlaylistUpdate(),
+		buildParams(t, pool, EntityTypePlaylist, ActionUpdate, uid, pid, "0xjsonbu",
+			`{"playlist_contents":[]}`))
+
+	var contentsRaw []byte
+	if err := pool.QueryRow(context.Background(),
+		"SELECT playlist_contents::text FROM playlists WHERE playlist_id = $1 AND is_current = true",
+		pid).Scan(&contentsRaw); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	// The persisted JSONB shape is always `{"track_ids":[...]}` regardless of
+	// the SDK's input shape (bare array or legacy dict). Lock that in here.
+	contentsStr := string(contentsRaw)
+	if !isEffectivelyEmpty(contentsStr) {
+		t.Errorf("playlist_contents = %q, want empty representation", contentsStr)
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(contentsRaw, &asMap); err != nil {
+		t.Fatalf("playlist_contents not a JSON object: %v (raw=%q)", err, contentsStr)
+	}
+	if _, ok := asMap["track_ids"]; !ok {
+		t.Errorf("expected normalized {track_ids:[]} form, got %q", contentsStr)
+	}
+}
+
+func TestNormalizePlaylistContentsJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "missing key", raw: `{}`, want: `{"track_ids":[]}`},
+		{name: "explicit null", raw: `{"playlist_contents":null}`, want: `{"track_ids":[]}`},
+		{name: "bare empty array (new SDK shape)", raw: `{"playlist_contents":[]}`, want: `{"track_ids":[]}`},
+		{name: "legacy empty dict", raw: `{"playlist_contents":{"track_ids":[]}}`, want: `{"track_ids":[]}`},
+		{name: "bare array with entries", raw: `{"playlist_contents":[{"track":1,"time":2}]}`, want: `{"track_ids":[{"time":2,"track":1}]}`},
+		{name: "legacy dict with entries", raw: `{"playlist_contents":{"track_ids":[{"track":3,"time":4}]}}`, want: `{"track_ids":[{"time":4,"track":3}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var meta map[string]any
+			_ = json.Unmarshal([]byte(tt.raw), &meta)
+			got := string(normalizePlaylistContentsJSON(meta))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// isEffectivelyEmpty returns true for JSONB values that represent "no tracks":
+// "[]", "{}", or {"track_ids": []}.
+func isEffectivelyEmpty(s string) bool {
+	switch s {
+	case "[]", "{}":
+		return true
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal([]byte(s), &asMap); err == nil {
+		if v, ok := asMap["track_ids"]; ok {
+			if arr, ok := v.([]any); ok {
+				return len(arr) == 0
+			}
+		}
+		// Any other top-level keys but no track_ids → also empty.
+		if len(asMap) == 0 {
+			return true
+		}
+	}
+	var asArr []any
+	if err := json.Unmarshal([]byte(s), &asArr); err == nil {
+		return len(asArr) == 0
+	}
+	return false
+}

--- a/pkg/etl/processors/entity_manager/playlist_row.go
+++ b/pkg/etl/processors/entity_manager/playlist_row.go
@@ -123,11 +123,12 @@ func mergePlaylistFromMetadata(p *Params, base *playlistRow) *playlistRow {
 		out.IsScheduledRelease = v
 	}
 
-	if v, ok := p.MetadataJSON("playlist_contents"); ok {
-		out.PlaylistContents = marshalJSONOrNil(v)
-		if len(out.PlaylistContents) == 0 {
-			out.PlaylistContents = []byte("{}")
-		}
+	// playlist_contents: present when the metadata key exists, including the
+	// SDK-sent empty list `[]`. Normalize to `{"track_ids":[...]}` regardless
+	// of whether the SDK sent the legacy dict or the new bare-array shape so
+	// downstream readers see one schema.
+	if _, ok := p.Metadata["playlist_contents"]; ok {
+		out.PlaylistContents = normalizePlaylistContentsJSON(p.Metadata)
 	}
 	if v, ok := p.MetadataJSON("stream_conditions"); ok {
 		out.StreamConditions = marshalJSONOrNil(v)
@@ -242,13 +243,49 @@ func insertPlaylistRow(ctx context.Context, dbtx db.DBTX, r *playlistRow, isDele
 }
 
 func metadataPlaylistContentsJSON(p *Params) []byte {
-	v, ok := p.MetadataJSON("playlist_contents")
-	if !ok || v == nil {
-		return []byte("{}")
+	if p == nil || p.Metadata == nil {
+		return []byte(`{"track_ids":[]}`)
 	}
-	b, err := json.Marshal(v)
+	if _, ok := p.Metadata["playlist_contents"]; !ok {
+		return []byte(`{"track_ids":[]}`)
+	}
+	return normalizePlaylistContentsJSON(p.Metadata)
+}
+
+// normalizePlaylistContentsJSON returns the JSONB payload to persist to
+// playlists.playlist_contents — always `{"track_ids": [...]}` regardless
+// of input shape.
+//
+// Accepts:
+//   - bare array form (new SDK):  [{"track":..,"time":..}, ...]  or  []
+//   - dict form (legacy):         {"track_ids": [...]}
+//   - explicit null / missing key: empty list
+//
+// Inner entries pass through as-is; only the outer wrapper is normalized.
+// The hashid-decode + dedupe + index-time logic lives at the junction-table
+// layer (updatePlaylistTracks).
+func normalizePlaylistContentsJSON(metadata map[string]any) []byte {
+	raw, ok := metadata["playlist_contents"]
+	if !ok || raw == nil {
+		return []byte(`{"track_ids":[]}`)
+	}
+	var entries []any
+	switch v := raw.(type) {
+	case []any:
+		entries = v
+	case map[string]any:
+		if t, ok := v["track_ids"]; ok {
+			if arr, ok := t.([]any); ok {
+				entries = arr
+			}
+		}
+	}
+	if entries == nil {
+		entries = []any{}
+	}
+	out, err := json.Marshal(map[string]any{"track_ids": entries})
 	if err != nil {
-		return []byte("{}")
+		return []byte(`{"track_ids":[]}`)
 	}
-	return b
+	return out
 }


### PR DESCRIPTION
## Summary

Picks up the backend behavior change from [apps#14306](https://github.com/AudiusProject/audius-protocol/pull/14306) ("allow removing the last track from a playlist").

### apps' bug

In Python, `if not playlist_metadata.get("playlist_contents")` is true for an empty list. So when the SDK sent `{"playlist_contents": []}` (user removing the last track from a playlist), apps' `populate_playlist_record_metadata` silently skipped the JSONB update. The UI showed the track removed (optimistic update), but a reload restored it because the persisted state was unchanged.

apps' fix swaps `if not ...` for `if ... is None`, so the empty list goes through `process_playlist_contents` like any other value.

### go-openaudio status

go-openaudio's `mergePlaylistFromMetadata` already uses a `_, ok :=` key-exists check, not a truthiness check — so **the underlying bug does not reproduce here**. Verified via `TestPlaylistUpdate_EmptyArrayMarksAllTracksRemoved`: the `playlist_tracks` junction correctly marks all rows `is_removed=true`.

### Adjacent gap found and fixed

apps' `process_playlist_contents` always normalizes its output to the dict form `{"track_ids": [...]}` regardless of input shape. go-openaudio was persisting whatever shape the SDK sent (bare `[]` or legacy dict), which downstream readers wouldn't expect.

This PR adds `normalizePlaylistContentsJSON`:

```
{}                                              → {"track_ids":[]}
{"playlist_contents": null}                     → {"track_ids":[]}
{"playlist_contents": []}                       → {"track_ids":[]}
{"playlist_contents": {"track_ids": []}}        → {"track_ids":[]}
{"playlist_contents": [{...}]}                  → {"track_ids":[{...}]}
{"playlist_contents": {"track_ids": [{...}]}}   → {"track_ids":[{...}]}
```

Wired into both create (`metadataPlaylistContentsJSON`) and update (`mergePlaylistFromMetadata`).

## Stack context

Stacked on #252 (5E — oauth_redirect_uris). Follow-up after the main parity stack.

## Test plan

- [x] `TestNormalizePlaylistContentsJSON` — 6 sub-cases covering all input shapes.
- [x] `TestPlaylistUpdate_EmptyArrayMarksAllTracksRemoved` — both bare `[]` (new SDK) and legacy `{track_ids:[]}` paths correctly clear the junction.
- [x] `TestPlaylistUpdate_EmptyArrayWritesJSONBColumn` — asserts the persisted JSONB is a JSON object with a `track_ids` key (apps' canonical form).
- [x] All previously-passing playlist tests still pass (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)