### PR TITLE
feat(core/db): drop unused core indexes

### DIFF
--- a/pkg/core/db/sql/migrations/00035_drop_unused_core_indexes.sql
+++ b/pkg/core/db/sql/migrations/00035_drop_unused_core_indexes.sql
@@ -1,0 +1,15 @@
+-- +migrate Up notransaction
+DROP INDEX CONCURRENTLY IF EXISTS idx_core_blocks_hash;
+DROP INDEX CONCURRENTLY IF EXISTS idx_core_tx_stats_time_type;
+DROP INDEX CONCURRENTLY IF EXISTS idx_core_blocks_chain_id;
+DROP INDEX CONCURRENTLY IF EXISTS idx_core_blocks_proposer;
+
+-- +migrate Down notransaction
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_core_blocks_hash
+  ON core_blocks(hash);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_core_tx_stats_time_type
+  ON core_tx_stats(created_at, tx_type);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_core_blocks_chain_id
+  ON core_blocks(chain_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_core_blocks_proposer
+  ON core_blocks(proposer);


### PR DESCRIPTION
## Summary

- Drop four unused core indexes with `DROP INDEX CONCURRENTLY`.
- Keep the migration reversible with concurrent `CREATE INDEX` statements.
- Intentionally leave `idx_uploads_transcode_cid_320` in place because the current `serve_blob` path queries `transcode_results ->> '320'` and production stats showed real scans.

## Evidence

This follows the same cleanup campaign as #205 and #217. On 2026-05-18 I canaried these four drops on one mainnet validator, then rolled them across a 20-validator fleet after confirming zero production scans for the candidates and no code-side query path that depends on them.

Dropped indexes:

- `idx_core_blocks_hash`
- `idx_core_tx_stats_time_type`
- `idx_core_blocks_chain_id`
- `idx_core_blocks_proposer`

Operational verification after rollout:

- canary validator remained healthy after the DDL
- all 20 validators reported the four indexes absent
- full fleet health check passed after rollout
- observed reclaim was about 5-6 GB per validator

## Tests

- `go test ./pkg/core/...`
