### PR TITLE
fix(mediorum): atomic metric increments

### DIFF
--- a/pkg/mediorum/server/metric_recording_test.go
+++ b/pkg/mediorum/server/metric_recording_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordMetricConcurrentIncrements(t *testing.T) {
+	ss := testNetwork[0]
+	action := fmt.Sprintf("test_record_metric_%d", time.Now().UnixNano())
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	firstOfMonth := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, ss.crud.DB.Where("action = ?", action).Delete(&DailyMetrics{}).Error)
+	require.NoError(t, ss.crud.DB.Where("action = ?", action).Delete(&MonthlyMetrics{}).Error)
+
+	const writers = 64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			ss.recordMetric(action)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var daily DailyMetrics
+	require.NoError(t, ss.crud.DB.First(&daily, "timestamp = ? AND action = ?", today, action).Error)
+	assert.EqualValues(t, writers, daily.Count)
+
+	var monthly MonthlyMetrics
+	require.NoError(t, ss.crud.DB.First(&monthly, "timestamp = ? AND action = ?", firstOfMonth, action).Error)
+	assert.EqualValues(t, writers, monthly.Count)
+}

--- a/pkg/mediorum/server/serve_blob.go
+++ b/pkg/mediorum/server/serve_blob.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 	gcblob "gocloud.dev/blob"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
 
@@ -27,7 +28,7 @@ import (
 )
 
 const (
-	presignedURLDefaultExpiry = 2 * time.Hour  // fallback when duration unknown
+	presignedURLDefaultExpiry = 2 * time.Hour   // fallback when duration unknown
 	presignedURLMinExpiry     = 5 * time.Minute // floor for very short tracks
 	presignedURLBufferRatio   = 1.1             // 10% buffer over track duration
 )
@@ -304,44 +305,30 @@ func (ss *MediorumServer) recordMetric(action string) {
 	firstOfMonth := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
 
 	// Increment daily metric
-	err := ss.crud.DB.Transaction(func(tx *gorm.DB) error {
-		var metric DailyMetrics
-		if err := tx.FirstOrCreate(&metric, DailyMetrics{
-			Timestamp: today,
-			Action:    action,
-		}).Error; err != nil {
-			return err
-		}
-		metric.Count += 1
-		if err := tx.Save(&metric).Error; err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	if err != nil {
+	if err := ss.crud.DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "timestamp"}, {Name: "action"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"count": gorm.Expr("daily_metrics.count + EXCLUDED.count"),
+		}),
+	}).Create(&DailyMetrics{
+		Timestamp: today,
+		Action:    action,
+		Count:     1,
+	}).Error; err != nil {
 		ss.logger.Error("unable to increment daily metric", zap.Error(err), zap.String("action", action))
 	}
 
 	// Increment monthly metric
-	err = ss.crud.DB.Transaction(func(tx *gorm.DB) error {
-		var metric MonthlyMetrics
-		if err := tx.FirstOrCreate(&metric, MonthlyMetrics{
-			Timestamp: firstOfMonth,
-			Action:    action,
-		}).Error; err != nil {
-			return err
-		}
-		metric.Count += 1
-		if err := tx.Save(&metric).Error; err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	if err != nil {
+	if err := ss.crud.DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "timestamp"}, {Name: "action"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"count": gorm.Expr("monthly_metrics.count + EXCLUDED.count"),
+		}),
+	}).Create(&MonthlyMetrics{
+		Timestamp: firstOfMonth,
+		Action:    action,
+		Count:     1,
+	}).Error; err != nil {
 		ss.logger.Error("unable to increment monthly metric", zap.Error(err), zap.String("action", action))
 	}
 }


### PR DESCRIPTION
recordMetric reads daily_metrics / monthly_metrics with FirstOrCreate, mutates count in Go, and writes back with Save. Under concurrent calls on the same (timestamp, action) row, two goroutines observe the same count and the later write overwrites the earlier — increments are lost.

Replace the read-modify-write with a single INSERT … ON CONFLICT upsert using each table's composite PK, incrementing in SQL via gorm.Expr. The pattern is already used in crudr/crudr.go and server/upload_client.go.

## Test plan

- [x] `go test -race -count=10 -run TestRecordMetricConcurrentIncrements ./pkg/mediorum/server/` — spawns 64 concurrent writers on one (timestamp, action) row; the previous code persists ~12 daily / ~16 monthly increments out of 64, the fix persists exactly 64.
- [x] `go test -count=1 ./pkg/mediorum/...`