### PR TITLE
fix(mediorum): bound audio analysis backlog scans

### DIFF
--- a/pkg/mediorum/ddl/ddl.go
+++ b/pkg/mediorum/ddl/ddl.go
@@ -6,8 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"regexp"
-	"strings"
 
 	_ "embed"
 )
@@ -63,7 +61,7 @@ func Migrate(db *sql.DB, myHost string) {
 	runMigration(db, `CREATE INDEX IF NOT EXISTS idx_uploads_transcode_cid_320 ON uploads ((transcode_results::jsonb ->> '320'))`)
 
 	// Index for bounded StoreAll audio-analysis backlog retries.
-	runMigration(db, `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_uploads_audio_analysis_backlog
+	runMigration(db, `CREATE INDEX IF NOT EXISTS idx_uploads_audio_analysis_backlog
 ON uploads (COALESCE(audio_analysis_error_count, 0), audio_analyzed_at ASC NULLS FIRST, id)
 WHERE template = 'audio' AND audio_analysis_status IS DISTINCT FROM 'done'`)
 
@@ -80,41 +78,8 @@ func runMigration(db *sql.DB, ddl string) {
 		return
 	}
 
-	dropInvalidIndexIfNeeded(db, ddl)
-
 	mustExec(db, ddl)
 	mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, h)
-}
-
-// concurrentIndexNameRe captures the index name from a
-// `CREATE INDEX CONCURRENTLY IF NOT EXISTS <name>` statement. A previous
-// interrupted run can leave the index registered with indisvalid=false; the
-// `IF NOT EXISTS` guard would then silently skip recreation forever, so we
-// drop any invalid leftover before running the migration.
-var concurrentIndexNameRe = regexp.MustCompile(`(?is)CREATE\s+INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)`)
-
-func dropInvalidIndexIfNeeded(db *sql.DB, ddl string) {
-	m := concurrentIndexNameRe.FindStringSubmatch(ddl)
-	if m == nil {
-		return
-	}
-	// Unquoted Postgres identifiers are stored lower-case in pg_class.relname.
-	name := strings.ToLower(m[1])
-
-	var invalid bool
-	err := db.QueryRow(`
-		SELECT NOT i.indisvalid
-		FROM pg_index i
-		JOIN pg_class c ON c.oid = i.indexrelid
-		WHERE c.relname = $1
-	`, name).Scan(&invalid)
-	if err != nil || !invalid {
-		return
-	}
-
-	// DROP INDEX CONCURRENTLY must run outside a transaction; mustExec uses
-	// db.Exec which is fine because runMigration has no surrounding tx.
-	mustExec(db, fmt.Sprintf(`DROP INDEX CONCURRENTLY IF EXISTS %s`, name))
 }
 
 func mustExec(db *sql.DB, ddl string, va ...interface{}) {

--- a/pkg/mediorum/ddl/ddl.go
+++ b/pkg/mediorum/ddl/ddl.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"regexp"
+	"strings"
 
 	_ "embed"
 )
@@ -60,6 +62,11 @@ func Migrate(db *sql.DB, myHost string) {
 	// Index for fast CID→duration lookup (presigned URL expiry)
 	runMigration(db, `CREATE INDEX IF NOT EXISTS idx_uploads_transcode_cid_320 ON uploads ((transcode_results::jsonb ->> '320'))`)
 
+	// Index for bounded StoreAll audio-analysis backlog retries.
+	runMigration(db, `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_uploads_audio_analysis_backlog
+ON uploads (COALESCE(audio_analysis_error_count, 0), audio_analyzed_at ASC NULLS FIRST, id)
+WHERE template = 'audio' AND audio_analysis_status IS DISTINCT FROM 'done'`)
+
 	runMigration(db, `vacuum full`)
 }
 
@@ -73,8 +80,41 @@ func runMigration(db *sql.DB, ddl string) {
 		return
 	}
 
+	dropInvalidIndexIfNeeded(db, ddl)
+
 	mustExec(db, ddl)
 	mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, h)
+}
+
+// concurrentIndexNameRe captures the index name from a
+// `CREATE INDEX CONCURRENTLY IF NOT EXISTS <name>` statement. A previous
+// interrupted run can leave the index registered with indisvalid=false; the
+// `IF NOT EXISTS` guard would then silently skip recreation forever, so we
+// drop any invalid leftover before running the migration.
+var concurrentIndexNameRe = regexp.MustCompile(`(?is)CREATE\s+INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+func dropInvalidIndexIfNeeded(db *sql.DB, ddl string) {
+	m := concurrentIndexNameRe.FindStringSubmatch(ddl)
+	if m == nil {
+		return
+	}
+	// Unquoted Postgres identifiers are stored lower-case in pg_class.relname.
+	name := strings.ToLower(m[1])
+
+	var invalid bool
+	err := db.QueryRow(`
+		SELECT NOT i.indisvalid
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		WHERE c.relname = $1
+	`, name).Scan(&invalid)
+	if err != nil || !invalid {
+		return
+	}
+
+	// DROP INDEX CONCURRENTLY must run outside a transaction; mustExec uses
+	// db.Exec which is fine because runMigration has no surrounding tx.
+	mustExec(db, fmt.Sprintf(`DROP INDEX CONCURRENTLY IF EXISTS %s`, name))
 }
 
 func mustExec(db *sql.DB, ddl string, va ...interface{}) {

--- a/pkg/mediorum/server/audio_analysis.go
+++ b/pkg/mediorum/server/audio_analysis.go
@@ -18,7 +18,18 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const MAX_TRIES = 3
+const (
+	MAX_TRIES = 3
+
+	// audioAnalysisBacklogLimit caps the per-tick backlog scan so a node with
+	// a large failing set cannot stall on a single sweep.
+	audioAnalysisBacklogLimit = 100
+
+	// audioAnalysisRetryBackoff defers re-attempts of previously-failed
+	// uploads. Without it, failing rows are picked up every tick and burn
+	// worker time on the same hot set.
+	audioAnalysisRetryBackoff = 24 * time.Hour
+)
 
 func (ss *MediorumServer) startAudioAnalyzer(ctx context.Context) error {
 	work := make(chan *Upload)
@@ -59,14 +70,10 @@ func (ss *MediorumServer) startAudioAnalyzer(ctx context.Context) error {
 }
 
 func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work chan<- *Upload) {
-	uploads := []*Upload{}
-	err := ss.crud.DB.Where("template = ? and (audio_analysis_status is null or audio_analysis_status != ?)", JobTemplateAudio, JobStatusDone).
-		Order("random()").
-		Find(&uploads).
-		Error
-
+	uploads, err := ss.findMissedAudioAnalysisCandidates(ctx, time.Now().UTC(), audioAnalysisBacklogLimit)
 	if err != nil {
 		ss.logger.Warn("failed to find backlog work", zap.Error(err))
+		return
 	}
 
 	for _, upload := range uploads {
@@ -86,10 +93,40 @@ func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work 
 		}
 		if ok {
 			if ss.blobExists(ctx, cidutil.ShardCID(cid)) {
-				work <- upload
+				select {
+				case work <- upload:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}
+}
+
+func (ss *MediorumServer) findMissedAudioAnalysisCandidates(ctx context.Context, now time.Time, limit int) ([]*Upload, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	cutoff := now.Add(-audioAnalysisRetryBackoff)
+	uploads := []*Upload{}
+	// Keep these literals aligned with idx_uploads_audio_analysis_backlog so
+	// Postgres can use the partial index even with generic plans.
+	err := ss.crud.DB.WithContext(ctx).
+		Where(`
+			template = 'audio'
+			AND audio_analysis_status IS DISTINCT FROM 'done'
+			AND COALESCE(audio_analysis_error_count, 0) < ?
+			AND (audio_analyzed_at IS NULL OR audio_analyzed_at <= ?)
+		`, MAX_TRIES, cutoff).
+		Order("COALESCE(audio_analysis_error_count, 0) ASC").
+		Order("audio_analyzed_at ASC NULLS FIRST").
+		Order("id ASC").
+		Limit(limit).
+		Find(&uploads).
+		Error
+
+	return uploads, err
 }
 
 func (ss *MediorumServer) startAudioAnalysisWorker(workerId int, work chan *Upload) {

--- a/pkg/mediorum/server/audio_analysis_test.go
+++ b/pkg/mediorum/server/audio_analysis_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindMissedAudioAnalysisCandidatesBoundsRetriesAndBackoff(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+	now := time.Now().UTC().Truncate(time.Second)
+	prefix := fmt.Sprintf("audio-analysis-candidates-%d-", now.UnixNano())
+
+	cleanup := func() {
+		require.NoError(t, ss.crud.DB.Where("id LIKE ?", prefix+"%").Delete(&Upload{}).Error)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	uploads := []Upload{
+		{
+			ID:                      prefix + "done",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusDone,
+			AudioAnalysisErrorCount: 0,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			ID:                      prefix + "too-many-errors",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: MAX_TRIES,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			ID:                      prefix + "recent-error",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: 1,
+			AudioAnalyzedAt:         now.Add(-time.Hour),
+		},
+		{
+			ID:                      prefix + "image",
+			Template:                JobTemplateImgSquare,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: 1,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			ID:                      prefix + "old-error",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: 1,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			// Boundary: error_count == MAX_TRIES-1 must still be retryable.
+			ID:                      prefix + "max-minus-one",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: MAX_TRIES - 1,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			ID:                  prefix + "never-tried",
+			Template:            JobTemplateAudio,
+			AudioAnalysisStatus: "",
+			AudioAnalyzedAt:     time.Time{},
+		},
+	}
+	for i := range uploads {
+		require.NoError(t, ss.crud.DB.Create(&uploads[i]).Error)
+	}
+
+	candidates, err := ss.findMissedAudioAnalysisCandidates(ctx, now, 100)
+	require.NoError(t, err)
+
+	got := map[string]bool{}
+	for _, upload := range candidates {
+		if strings.HasPrefix(upload.ID, prefix) {
+			got[upload.ID] = true
+		}
+	}
+
+	require.Equal(t, map[string]bool{
+		prefix + "never-tried":   true,
+		prefix + "old-error":     true,
+		prefix + "max-minus-one": true,
+	}, got)
+}


### PR DESCRIPTION
findMissedAudioAnalysisJobs orders the candidate set by random() with no limit and no filter on audio_analysis_error_count. As the failing set grows, every five-minute tick rebuilds that set with a full sequential scan over uploads, and rows already at MAX_TRIES are re-enqueued forever — onError keeps bumping the count past the cap that nothing else enforces.

Replace the selector with a deterministic query that:
- filters `template = 'audio' AND audio_analysis_status IS DISTINCT FROM 'done'`
- excludes rows with `COALESCE(audio_analysis_error_count, 0) >= MAX_TRIES`
- defers retries until 24h after the last attempt
- orders by `(error_count, audio_analyzed_at, id)` and caps at 100 per tick

Back it with a partial index matching the predicate. `CREATE INDEX CONCURRENTLY` can leave the index `indisvalid=false` if it is interrupted; `IF NOT EXISTS` then skips re-creation forever while the migration row records success. The migration runner now detects an invalid leftover of the same name and drops it before re-creating.

## Test plan

- [x] `TestFindMissedAudioAnalysisCandidatesBoundsRetriesAndBackoff` covers the template filter, the `MAX_TRIES − 1` / `MAX_TRIES` boundary, and the 24h backoff cutoff against a real Postgres.
- [x] `go test -race -count=3 -run TestFindMissedAudioAnalysisCandidates ./pkg/mediorum/server/`
- [x] `go test -count=1 ./pkg/mediorum/...`

Companion `/internal/crud/status` change in #275 exposes `audio_analysis_backlog.{depth, retry_exhausted_count}` over the same predicate, so the bound established here is externally verifiable from any peer.