### PR TITLE
feat(mediorum): peer-observable /internal/crud/status

### DIFF
--- a/pkg/mediorum/crudr/status.go
+++ b/pkg/mediorum/crudr/status.go
@@ -1,0 +1,113 @@
+package crudr
+
+import (
+	"context"
+)
+
+type TableStatus struct {
+	EstimatedRows int64 `json:"estimated_rows"`
+	HeapBytes     int64 `json:"heap_bytes"`
+	IndexBytes    int64 `json:"index_bytes"`
+	TotalBytes    int64 `json:"total_bytes"`
+}
+
+type CursorStatus struct {
+	Count            int64  `json:"count"`
+	MinLastULID      string `json:"min_last_ulid"`
+	MaxLastULID      string `json:"max_last_ulid"`
+	NullOrEmptyCount int64  `json:"null_or_empty_count"`
+}
+
+type Status struct {
+	MinAvailableULID string                 `json:"min_available_ulid"`
+	MaxULID          string                 `json:"max_ulid"`
+	Tables           map[string]TableStatus `json:"tables"`
+	Cursors          CursorStatus           `json:"cursors"`
+}
+
+type tableStatusRow struct {
+	Name          string `gorm:"column:name"`
+	EstimatedRows int64  `gorm:"column:estimated_rows"`
+	HeapBytes     int64  `gorm:"column:heap_bytes"`
+	IndexBytes    int64  `gorm:"column:index_bytes"`
+	TotalBytes    int64  `gorm:"column:total_bytes"`
+}
+
+type opBoundsRow struct {
+	MinULID string `gorm:"column:min_ulid"`
+	MaxULID string `gorm:"column:max_ulid"`
+}
+
+type cursorStatusRow struct {
+	Count            int64  `gorm:"column:count"`
+	MinLastULID      string `gorm:"column:min_last_ulid"`
+	MaxLastULID      string `gorm:"column:max_last_ulid"`
+	NullOrEmptyCount int64  `gorm:"column:null_or_empty_count"`
+}
+
+func (c *Crudr) Status(ctx context.Context, tableNames []string) (*Status, error) {
+	status := &Status{
+		Tables: map[string]TableStatus{},
+	}
+
+	var bounds opBoundsRow
+	if err := c.DB.WithContext(ctx).Raw(`
+		SELECT
+			coalesce((SELECT ulid FROM ops ORDER BY ulid ASC LIMIT 1), '') AS min_ulid,
+			coalesce((SELECT ulid FROM ops ORDER BY ulid DESC LIMIT 1), '') AS max_ulid
+	`).Scan(&bounds).Error; err != nil {
+		return nil, err
+	}
+	status.MinAvailableULID = bounds.MinULID
+	status.MaxULID = bounds.MaxULID
+
+	var cursor cursorStatusRow
+	if err := c.DB.WithContext(ctx).Raw(`
+		SELECT
+			count(*)::bigint AS count,
+			coalesce(min(nullif(last_ulid, '')), '') AS min_last_ulid,
+			coalesce(max(nullif(last_ulid, '')), '') AS max_last_ulid,
+			count(*) FILTER (WHERE last_ulid IS NULL OR last_ulid = '')::bigint AS null_or_empty_count
+		FROM cursors
+	`).Scan(&cursor).Error; err != nil {
+		return nil, err
+	}
+	status.Cursors = CursorStatus{
+		Count:            cursor.Count,
+		MinLastULID:      cursor.MinLastULID,
+		MaxLastULID:      cursor.MaxLastULID,
+		NullOrEmptyCount: cursor.NullOrEmptyCount,
+	}
+
+	if len(tableNames) == 0 {
+		return status, nil
+	}
+
+	var rows []tableStatusRow
+	if err := c.DB.WithContext(ctx).Raw(`
+		SELECT c.relname AS name,
+		       GREATEST(c.reltuples::bigint, 0) AS estimated_rows,
+		       pg_relation_size(c.oid) AS heap_bytes,
+		       pg_indexes_size(c.oid) AS index_bytes,
+		       pg_total_relation_size(c.oid) AS total_bytes
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+		  AND c.relkind IN ('r', 'p')
+		  AND c.relname IN ?
+		ORDER BY c.relname
+	`, tableNames).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		status.Tables[row.Name] = TableStatus{
+			EstimatedRows: row.EstimatedRows,
+			HeapBytes:     row.HeapBytes,
+			IndexBytes:    row.IndexBytes,
+			TotalBytes:    row.TotalBytes,
+		}
+	}
+
+	return status, nil
+}

--- a/pkg/mediorum/crudr/status_test.go
+++ b/pkg/mediorum/crudr/status_test.go
@@ -1,0 +1,84 @@
+package crudr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OpenAudio/go-openaudio/pkg/lifecycle"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestStatusReportsHistoryBoundsAndCursorSafety(t *testing.T) {
+	db := SetupTestDB()
+	require.NoError(t, db.AutoMigrate(TestBlobThing{}))
+
+	z := zap.NewNop()
+	c := New("host1", nil, nil, db, lifecycle.NewLifecycle(context.Background(), "crudr status test", z), z, nil).
+		RegisterModels(&TestBlobThing{})
+	require.NoError(t, db.Exec("TRUNCATE ops, cursors, test_blob_things").Error)
+
+	require.NoError(t, c.Create(TestBlobThing{Host: "server1", Key: "dd1"}))
+	require.NoError(t, c.Create(TestBlobThing{Host: "server1", Key: "dd2"}))
+	require.NoError(t, c.DB.Create(&Cursor{Host: "peer-empty", LastULID: ""}).Error)
+	require.NoError(t, c.DB.Create(&Cursor{Host: "peer-old", LastULID: "01GW5C4Y87PH83C66AHB0VDBN4"}).Error)
+	require.NoError(t, c.DB.Create(&Cursor{Host: "peer-new", LastULID: "01KRXB1K24BAFDYCGR07KDHTQ5"}).Error)
+
+	status, err := c.Status(context.Background(), []string{"ops", "test_blob_things", "cursors"})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, status.MinAvailableULID)
+	require.NotEmpty(t, status.MaxULID)
+	require.LessOrEqual(t, status.MinAvailableULID, status.MaxULID)
+
+	require.Equal(t, int64(3), status.Cursors.Count)
+	require.Equal(t, int64(1), status.Cursors.NullOrEmptyCount)
+	require.Equal(t, "01GW5C4Y87PH83C66AHB0VDBN4", status.Cursors.MinLastULID)
+	require.Equal(t, "01KRXB1K24BAFDYCGR07KDHTQ5", status.Cursors.MaxLastULID)
+
+	require.Contains(t, status.Tables, "ops")
+	require.Contains(t, status.Tables, "test_blob_things")
+	require.Contains(t, status.Tables, "cursors")
+	require.GreaterOrEqual(t, status.Tables["ops"].TotalBytes, int64(0))
+}
+
+func TestStatusReportsEmptyAvailableHistory(t *testing.T) {
+	db := SetupTestDB()
+
+	z := zap.NewNop()
+	c := New("host1", nil, nil, db, lifecycle.NewLifecycle(context.Background(), "crudr empty status test", z), z, nil)
+	require.NoError(t, db.Exec("TRUNCATE ops, cursors").Error)
+
+	status, err := c.Status(context.Background(), []string{"ops", "cursors"})
+	require.NoError(t, err)
+
+	require.Empty(t, status.MinAvailableULID)
+	require.Empty(t, status.MaxULID)
+	require.Equal(t, int64(0), status.Cursors.Count)
+	require.Equal(t, int64(0), status.Cursors.NullOrEmptyCount)
+	require.Contains(t, status.Tables, "ops")
+}
+
+func TestStatusClampsNegativeReltuples(t *testing.T) {
+	// Newly-created Postgres tables have pg_class.reltuples = -1 until ANALYZE
+	// runs. The status query must clamp that to 0 instead of leaking a
+	// sentinel value to peers.
+	db := SetupTestDB()
+
+	z := zap.NewNop()
+	c := New("host1", nil, nil, db, lifecycle.NewLifecycle(context.Background(), "crudr reltuples test", z), z, nil)
+
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS status_reltuples_probe (id bigint)`).Error)
+	t.Cleanup(func() {
+		require.NoError(t, db.Exec(`DROP TABLE IF EXISTS status_reltuples_probe`).Error)
+	})
+	// Force the sentinel to make the test deterministic even on databases that
+	// have already ANALYZEd the relation.
+	require.NoError(t, db.Exec(`UPDATE pg_class SET reltuples = -1 WHERE relname = 'status_reltuples_probe'`).Error)
+
+	status, err := c.Status(context.Background(), []string{"status_reltuples_probe"})
+	require.NoError(t, err)
+	probe, ok := status.Tables["status_reltuples_probe"]
+	require.True(t, ok)
+	require.Equal(t, int64(0), probe.EstimatedRows)
+}

--- a/pkg/mediorum/server/serve_crud.go
+++ b/pkg/mediorum/server/serve_crud.go
@@ -17,6 +17,35 @@ import (
 
 const PullLimit = 10000
 
+var crudStatusTables = []string{
+	"ops",
+	"uploads",
+	"storage_and_db_sizes",
+	"qm_audio_analyses",
+	"audio_previews",
+	"cursors",
+}
+
+// audioAnalysisStatusRetryBackoff is the cutoff this endpoint uses to decide
+// whether a previously-failed audio upload still counts toward the live
+// backlog or has cooled into the retry-eligible window. It mirrors the
+// contract of the bounded audio-analysis selector; defined locally because
+// the status endpoint is a read-only observer that should not couple to the
+// analyzer's scheduling internals.
+const audioAnalysisStatusRetryBackoff = 24 * time.Hour
+
+type audioAnalysisBacklogRow struct {
+	Depth               int64 `gorm:"column:depth"`
+	RetryExhaustedCount int64 `gorm:"column:retry_exhausted_count"`
+}
+
+type audioAnalysisBacklogStatus struct {
+	Depth               int64 `json:"depth"`
+	RetryExhaustedCount int64 `json:"retry_exhausted_count"`
+	MaxTries            int   `json:"max_tries"`
+	RetryBackoffSeconds int64 `json:"retry_backoff_seconds"`
+}
+
 func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	ss.crudSweepMutex.Lock()
 	defer ss.crudSweepMutex.Unlock()
@@ -54,6 +83,65 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 
 	c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=300")
 	return c.JSON(200, filteredOps)
+}
+
+func (ss *MediorumServer) serveCrudStatus(c echo.Context) error {
+	ctx, cancel := context.WithTimeout(c.Request().Context(), 5*time.Second)
+	defer cancel()
+
+	status, err := ss.crud.Status(ctx, crudStatusTables)
+	if err != nil {
+		return c.String(http.StatusInternalServerError, fmt.Sprintf("Failed to query crud status: %v", err))
+	}
+
+	backlog, err := ss.queryAudioAnalysisBacklogStatus(ctx, time.Now().UTC())
+	if err != nil {
+		return c.String(http.StatusInternalServerError, fmt.Sprintf("Failed to query audio analysis backlog: %v", err))
+	}
+
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+	return c.JSON(http.StatusOK, struct {
+		*crudr.Status
+		PullLimit            int                        `json:"pull_limit"`
+		AudioAnalysisBacklog audioAnalysisBacklogStatus `json:"audio_analysis_backlog"`
+	}{
+		Status:               status,
+		PullLimit:            PullLimit,
+		AudioAnalysisBacklog: backlog,
+	})
+}
+
+// queryAudioAnalysisBacklogStatus returns the live audio-analysis queue depth
+// (rows still eligible to run) and the dead-letter count (rows at or above the
+// retry cap). A single aggregate scan keeps the cost bounded; the predicate
+// matches the bounded backlog selector exactly so the two numbers describe
+// the same population the analyzer reasons about. The query is correct on a
+// stock schema; when the matching partial index is present it is also cheap.
+func (ss *MediorumServer) queryAudioAnalysisBacklogStatus(ctx context.Context, now time.Time) (audioAnalysisBacklogStatus, error) {
+	cutoff := now.Add(-audioAnalysisStatusRetryBackoff)
+	var row audioAnalysisBacklogRow
+	err := ss.crud.DB.WithContext(ctx).Raw(`
+		SELECT
+			count(*) FILTER (
+				WHERE COALESCE(audio_analysis_error_count, 0) < ?
+				  AND (audio_analyzed_at IS NULL OR audio_analyzed_at <= ?)
+			)::bigint AS depth,
+			count(*) FILTER (
+				WHERE COALESCE(audio_analysis_error_count, 0) >= ?
+			)::bigint AS retry_exhausted_count
+		FROM uploads
+		WHERE template = 'audio'
+		  AND audio_analysis_status IS DISTINCT FROM 'done'
+	`, MAX_TRIES, cutoff, MAX_TRIES).Scan(&row).Error
+	if err != nil {
+		return audioAnalysisBacklogStatus{}, err
+	}
+	return audioAnalysisBacklogStatus{
+		Depth:               row.Depth,
+		RetryExhaustedCount: row.RetryExhaustedCount,
+		MaxTries:            MAX_TRIES,
+		RetryBackoffSeconds: int64(audioAnalysisStatusRetryBackoff / time.Second),
+	}, nil
 }
 
 func (ss *MediorumServer) serveCrudPush(c echo.Context) error {

--- a/pkg/mediorum/server/serve_crud_test.go
+++ b/pkg/mediorum/server/serve_crud_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/mediorum/crudr"
+	"github.com/OpenAudio/go-openaudio/pkg/mediorum/server/signature"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeCrudStatus(t *testing.T) {
+	statusServer := testNetwork[0]
+	requestingPeer := testNetwork[1]
+
+	req, err := signature.SignedGet(
+		context.Background(),
+		statusServer.Config.Self.Host+"/internal/crud/status",
+		requestingPeer.Config.privateKey,
+		requestingPeer.Config.Self.Host,
+	)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+
+	var payload struct {
+		crudr.Status
+		PullLimit int `json:"pull_limit"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+
+	require.Equal(t, PullLimit, payload.PullLimit)
+	require.Contains(t, payload.Tables, "ops")
+	require.Contains(t, payload.Tables, "uploads")
+	require.Contains(t, payload.Tables, "qm_audio_analyses")
+	require.GreaterOrEqual(t, payload.Cursors.Count, int64(0))
+}
+
+func TestQueryAudioAnalysisBacklogStatusPartitionsDepthAndExhausted(t *testing.T) {
+	ctx := context.Background()
+	ss := testNetwork[0]
+	now := time.Now().UTC().Truncate(time.Second)
+	prefix := fmt.Sprintf("audio-backlog-status-%d-", now.UnixNano())
+
+	cleanup := func() {
+		require.NoError(t, ss.crud.DB.Where("id LIKE ?", prefix+"%").Delete(&Upload{}).Error)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Baselines captured before seeding so the test is robust to leftover
+	// rows from earlier tests running against the same shared database.
+	baseline, err := ss.queryAudioAnalysisBacklogStatus(ctx, now)
+	require.NoError(t, err)
+
+	fixtures := []Upload{
+		{
+			// Eligible: never analysed.
+			ID:       prefix + "never-tried",
+			Template: JobTemplateAudio,
+		},
+		{
+			// Eligible: failed once, past the backoff window.
+			ID:                      prefix + "old-error",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: 1,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			// Not depth, not exhausted: still inside backoff window.
+			ID:                      prefix + "recent-error",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: 1,
+			AudioAnalyzedAt:         now.Add(-time.Hour),
+		},
+		{
+			// Exhausted: at the cap.
+			ID:                      prefix + "exhausted",
+			Template:                JobTemplateAudio,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: MAX_TRIES,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+		{
+			// Excluded: already done.
+			ID:                  prefix + "done",
+			Template:            JobTemplateAudio,
+			AudioAnalysisStatus: JobStatusDone,
+		},
+		{
+			// Excluded: not an audio upload.
+			ID:                      prefix + "image",
+			Template:                JobTemplateImgSquare,
+			AudioAnalysisStatus:     JobStatusError,
+			AudioAnalysisErrorCount: 1,
+			AudioAnalyzedAt:         now.Add(-48 * time.Hour),
+		},
+	}
+	for i := range fixtures {
+		require.NoError(t, ss.crud.DB.Create(&fixtures[i]).Error)
+	}
+
+	got, err := ss.queryAudioAnalysisBacklogStatus(ctx, now)
+	require.NoError(t, err)
+
+	require.Equal(t, baseline.Depth+2, got.Depth)
+	require.Equal(t, baseline.RetryExhaustedCount+1, got.RetryExhaustedCount)
+	require.Equal(t, MAX_TRIES, got.MaxTries)
+	require.Equal(t, int64((24 * time.Hour).Seconds()), got.RetryBackoffSeconds)
+}
+
+func TestServeCrudStatusIncludesAudioAnalysisBacklog(t *testing.T) {
+	statusServer := testNetwork[0]
+	requestingPeer := testNetwork[1]
+
+	req, err := signature.SignedGet(
+		context.Background(),
+		statusServer.Config.Self.Host+"/internal/crud/status",
+		requestingPeer.Config.privateKey,
+		requestingPeer.Config.Self.Host,
+	)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload struct {
+		AudioAnalysisBacklog struct {
+			Depth               int64 `json:"depth"`
+			RetryExhaustedCount int64 `json:"retry_exhausted_count"`
+			MaxTries            int   `json:"max_tries"`
+			RetryBackoffSeconds int64 `json:"retry_backoff_seconds"`
+		} `json:"audio_analysis_backlog"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+
+	require.Equal(t, MAX_TRIES, payload.AudioAnalysisBacklog.MaxTries)
+	require.Equal(t, int64((24 * time.Hour).Seconds()), payload.AudioAnalysisBacklog.RetryBackoffSeconds)
+	require.GreaterOrEqual(t, payload.AudioAnalysisBacklog.Depth, int64(0))
+	require.GreaterOrEqual(t, payload.AudioAnalysisBacklog.RetryExhaustedCount, int64(0))
+}
+
+func TestServeCrudStatusRequiresPeerAuth(t *testing.T) {
+	statusServer := testNetwork[0]
+
+	resp, err := http.Get(statusServer.Config.Self.Host + "/internal/crud/status")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -496,6 +496,7 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 	internalApi := routes.Group("/internal")
 
 	// internal: crud
+	internalApi.GET("/crud/status", ss.serveCrudStatus, middleware.BasicAuth(ss.checkBasicAuth))
 	internalApi.GET("/crud/sweep", ss.serveCrudSweep)
 	internalApi.POST("/crud/push", ss.serveCrudPush, middleware.BasicAuth(ss.checkBasicAuth))
 


### PR DESCRIPTION
A peer cannot today observe another peer's CRUD replication state without scraping the full sweep stream. Add `GET /internal/crud/status`, gated by the same signed-peer middleware as the other `/internal/crud` routes:

- `min_available_ulid` / `max_ulid` — bounds of the locally-retained ops history, so a caller can tell whether its `last_ulid` is still recoverable from this peer.
- `cursors.{count, min_last_ulid, max_last_ulid, null_or_empty_count}` — distribution of peer cursors; a partitioned or stuck cursor is visible from the outside.
- `tables` — `pg_class`-derived `{estimated_rows, heap_bytes, index_bytes, total_bytes}` for the CRUD-managed set. `reltuples` is clamped with `GREATEST(reltuples, 0)` so a freshly-created table does not return the `-1` sentinel.
- `audio_analysis_backlog.{depth, retry_exhausted_count, max_tries, retry_backoff_seconds}` — rows still eligible to run vs rows at or above the cap. Computed in one aggregate scan with FILTER clauses.

Response carries `Cache-Control: no-store` and embeds `PullLimit` so callers can size sweeps against the same constant.

## Test plan

- [x] `TestStatusReportsHistoryBoundsAndCursorSafety`
- [x] `TestStatusReportsEmptyAvailableHistory`
- [x] `TestStatusClampsNegativeReltuples` (forces `-1` via `pg_class` update)
- [x] `TestServeCrudStatus` end-to-end through signed peer auth
- [x] `TestServeCrudStatusRequiresPeerAuth` (401 path)
- [x] `TestQueryAudioAnalysisBacklog` covers the `MAX_TRIES` / backoff partition
- [x] `go test -count=3 ./pkg/mediorum/crudr/ ./pkg/mediorum/server/`

The bounded backlog selector in #274 produces the population this endpoint reports on; the endpoint is also correct on the stock schema without that change.