### PR TITLE
fix(mediorum): suppress no-op uploads ops on replication retries

### DIFF
--- a/pkg/mediorum/server/replicate_worker.go
+++ b/pkg/mediorum/server/replicate_worker.go
@@ -231,31 +231,40 @@ func (ss *MediorumServer) replicateToHosts(ctx context.Context, upload *Upload, 
 		}
 	}
 
+	// No replications succeeded — skip the DB read and the crudr broadcast.
+	// The replication worker re-queues an under-replicated upload every cache
+	// TTL (1h); without this fast-exit, each retry where every reachable peer
+	// fails would write a fresh uploads op with byte-identical mirrors and
+	// fan that op out to every peer in the network, dominating the
+	// uploads-update op rate.
+	if len(newSuccessHosts) == 0 {
+		return nil
+	}
+
 	// Update upload record with successful mirrors using crudr for broadcast
 	var dbUpload Upload
 	if err := ss.crud.DB.Where("id = ?", upload.ID).First(&dbUpload).Error; err != nil {
 		return fmt.Errorf("failed to get upload from DB: %w", err)
 	}
 
-	// Start with existing mirrors and add new ones
-	var allMirrors []string
-	if isTranscoded {
-		allMirrors = append([]string{}, dbUpload.TranscodedMirrors...)
-	} else {
-		allMirrors = append([]string{}, dbUpload.Mirrors...)
+	// Start with existing mirrors and merge in successful hosts.
+	merged, changed := mergeReplicationMirrors(isTranscoded, &dbUpload, newSuccessHosts)
+	if !changed {
+		// A concurrent worker has already recorded every host we just
+		// replicated to. The merged list equals what's already in the DB,
+		// so emitting a crud op now would broadcast a row with byte-
+		// identical content to every peer for no semantic gain.
+		ss.logger.Debug("replication produced no new mirrors; suppressing crud broadcast",
+			zap.String("uploadID", upload.ID),
+			zap.String("cid", cid),
+			zap.Strings("newSuccessHosts", newSuccessHosts),
+		)
+		return nil
 	}
-
-	// Add newly successful hosts if not already present
-	for _, host := range newSuccessHosts {
-		if !slices.Contains(allMirrors, host) {
-			allMirrors = append(allMirrors, host)
-		}
-	}
-
 	if isTranscoded {
-		dbUpload.TranscodedMirrors = allMirrors
+		dbUpload.TranscodedMirrors = merged
 	} else {
-		dbUpload.Mirrors = allMirrors
+		dbUpload.Mirrors = merged
 	}
 
 	if err := ss.crud.Update(&dbUpload); err != nil {
@@ -271,10 +280,33 @@ func (ss *MediorumServer) replicateToHosts(ctx context.Context, upload *Upload, 
 		zap.String("uploadID", upload.ID),
 		zap.String("cid", cid),
 		zap.String("field", fieldName),
-		zap.Strings(fieldName, allMirrors),
+		zap.Strings(fieldName, merged),
 	)
 
 	return nil
+}
+
+// mergeReplicationMirrors merges newSuccessHosts into the upload's existing
+// mirror list (transcoded vs original chosen by isTranscoded) in stable
+// order, de-duplicating against hosts already present. Returns the merged
+// list and whether the merge actually added anything; callers use the bool
+// to decide whether to broadcast a crud op or suppress a no-op write.
+func mergeReplicationMirrors(isTranscoded bool, upload *Upload, newSuccessHosts []string) ([]string, bool) {
+	var existing []string
+	if isTranscoded {
+		existing = upload.TranscodedMirrors
+	} else {
+		existing = upload.Mirrors
+	}
+	merged := append([]string{}, existing...)
+	changed := false
+	for _, host := range newSuccessHosts {
+		if !slices.Contains(merged, host) {
+			merged = append(merged, host)
+			changed = true
+		}
+	}
+	return merged, changed
 }
 
 func (ss *MediorumServer) replicateToHost(host string, cid string, reader io.Reader, fileSize int64, placementHosts []string) error {

--- a/pkg/mediorum/server/replicate_worker_test.go
+++ b/pkg/mediorum/server/replicate_worker_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeReplicationMirrors_AddsNewHostsInStableOrder(t *testing.T) {
+	upload := &Upload{Mirrors: []string{"a", "b"}}
+	merged, changed := mergeReplicationMirrors(false, upload, []string{"c", "d"})
+	assert.True(t, changed)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, merged)
+}
+
+func TestMergeReplicationMirrors_TranscodedSelectsRightField(t *testing.T) {
+	upload := &Upload{
+		Mirrors:           []string{"orig-a"},
+		TranscodedMirrors: []string{"t-a"},
+	}
+	merged, changed := mergeReplicationMirrors(true, upload, []string{"t-b"})
+	assert.True(t, changed)
+	assert.Equal(t, []string{"t-a", "t-b"}, merged)
+}
+
+func TestMergeReplicationMirrors_NoNewHostsReturnsUnchanged(t *testing.T) {
+	upload := &Upload{Mirrors: []string{"a", "b"}}
+	merged, changed := mergeReplicationMirrors(false, upload, nil)
+	assert.False(t, changed, "empty newSuccessHosts must report unchanged")
+	assert.Equal(t, []string{"a", "b"}, merged)
+}
+
+func TestMergeReplicationMirrors_AllDuplicatesReturnsUnchanged(t *testing.T) {
+	upload := &Upload{Mirrors: []string{"a", "b", "c"}}
+	merged, changed := mergeReplicationMirrors(false, upload, []string{"a", "c"})
+	assert.False(t, changed,
+		"every newSuccessHost already in existing must report unchanged "+
+			"(this is the suppression path that prevents uploads-update churn)")
+	assert.Equal(t, []string{"a", "b", "c"}, merged)
+}
+
+func TestMergeReplicationMirrors_PartialOverlapReportsChanged(t *testing.T) {
+	upload := &Upload{Mirrors: []string{"a", "b"}}
+	merged, changed := mergeReplicationMirrors(false, upload, []string{"b", "c"})
+	assert.True(t, changed, "at least one new host means changed=true")
+	assert.Equal(t, []string{"a", "b", "c"}, merged)
+}
+
+func TestMergeReplicationMirrors_EmptyExistingAddsAll(t *testing.T) {
+	upload := &Upload{Mirrors: nil}
+	merged, changed := mergeReplicationMirrors(false, upload, []string{"a", "b"})
+	assert.True(t, changed)
+	assert.Equal(t, []string{"a", "b"}, merged)
+}
+
+func TestMergeReplicationMirrors_DoesNotMutateUploadFields(t *testing.T) {
+	upload := &Upload{Mirrors: []string{"a"}}
+	originalLen := len(upload.Mirrors)
+	merged, _ := mergeReplicationMirrors(false, upload, []string{"b"})
+	merged[0] = "MUTATED"
+	assert.Equal(t, originalLen, len(upload.Mirrors),
+		"merge result must not alias upload.Mirrors (callers may inspect or "+
+			"reassign it independently)")
+	assert.Equal(t, "a", upload.Mirrors[0])
+}
+
+func TestMergeReplicationMirrors_DedupsWithinNewHostsList(t *testing.T) {
+	upload := &Upload{Mirrors: []string{"a"}}
+	// A buggy caller could pass the same host twice in newSuccessHosts;
+	// the merge must not produce duplicates.
+	merged, changed := mergeReplicationMirrors(false, upload, []string{"b", "b"})
+	assert.True(t, changed)
+	assert.Equal(t, []string{"a", "b"}, merged)
+}


### PR DESCRIPTION
replicateToHosts unconditionally calls crud.Update after every
replication attempt, even when the merged mirror list is byte-identical
to what is already stored. The replication worker re-queues an
under-replicated upload every cache TTL (1h by default), so a chronically-
failing upload emits a fresh uploads-update op every hour. Each op is
then broadcast to every peer in the network for replay, dominating the
steady-state uploads-update op rate.

Add two suppression points:

1. When newSuccessHosts is empty (every replication attempt failed),
   skip the DB read and the crud.Update entirely.
2. When newSuccessHosts is non-empty but every host is already present
   in the merged mirror list (a concurrent worker recorded these
   successes), skip the crud.Update. Local DB state is current;
   emitting an op with byte-identical content writes a row to ops on
   every peer for no semantic gain.

The merge logic is extracted into mergeReplicationMirrors so the
suppression decision is pure and unit-testable. A debug log fires when
the second suppression path triggers, so an operator investigating
"replication succeeded but no op fired" has a trace.

## Wire compatibility

No protocol change. The suppressed ops were redundant under the
existing OnConflict{UpdateAll: true} apply semantics — peers already
upserted incoming ops idempotently. Old binaries continue to emit the
redundant ops; new binaries don't. Heterogeneous fleets converge to
the same row state.

## Tests

go test -count=10 ./pkg/mediorum/server/ (80 runs, all green):

- mergeReplicationMirrors stable-order append
- transcoded vs original field selection
- empty newSuccessHosts -> unchanged
- all-duplicates newSuccessHosts -> unchanged (suppression path)
- partial overlap -> changed
- empty existing -> changed
- result slice not aliased to upload fields
- dedup within newSuccessHosts

