### PR TITLE
feat(mediorum): read-repair on failed PoS challenge

### DIFF
--- a/pkg/mediorum/server/pos.go
+++ b/pkg/mediorum/server/pos.go
@@ -55,14 +55,11 @@ func (ss *MediorumServer) startPoSHandler(ctx context.Context) error {
 				if err != nil {
 					ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: false, Error: err.Error()})
 					ss.logger.Error("Failed to get storage proof", zap.String("cid", cid), zap.Error(err))
-					if host, pullErr := ss.findAndPullBlob(ctx, cid, replicaSet); pullErr == nil {
-						ss.logger.Info("PoS read-repair succeeded", zap.String("cid", cid), zap.String("host", host))
-					} else {
-						ss.logger.Warn("PoS read-repair failed", zap.String("cid", cid), zap.Error(pullErr))
-					}
-					continue
+					// kick off async read-repair; respond with empty proof so caller doesn't time out
+					ss.maybeBackgroundPull(cid)
+				} else {
+					ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: true})
 				}
-				ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: true})
 			}
 			response := pos.PoSResponse{
 				CID:      cid,

--- a/pkg/mediorum/server/pos.go
+++ b/pkg/mediorum/server/pos.go
@@ -55,11 +55,10 @@ func (ss *MediorumServer) startPoSHandler(ctx context.Context) error {
 				if err != nil {
 					ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: false, Error: err.Error()})
 					ss.logger.Error("Failed to get storage proof", zap.String("cid", cid), zap.Error(err))
-					// kick off async read-repair; respond with empty proof so caller doesn't time out
 					ss.maybeBackgroundPull(cid)
-				} else {
-					ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: true})
+					continue
 				}
+				ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: true})
 			}
 			response := pos.PoSResponse{
 				CID:      cid,

--- a/pkg/mediorum/server/pos.go
+++ b/pkg/mediorum/server/pos.go
@@ -55,6 +55,11 @@ func (ss *MediorumServer) startPoSHandler(ctx context.Context) error {
 				if err != nil {
 					ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: false, Error: err.Error()})
 					ss.logger.Error("Failed to get storage proof", zap.String("cid", cid), zap.Error(err))
+					if host, pullErr := ss.findAndPullBlob(ctx, cid, replicaSet); pullErr == nil {
+						ss.logger.Info("PoS read-repair succeeded", zap.String("cid", cid), zap.String("host", host))
+					} else {
+						ss.logger.Warn("PoS read-repair failed", zap.String("cid", cid), zap.Error(pullErr))
+					}
 					continue
 				}
 				ss.metrics.recordPoS(PoSResult{At: time.Now().UTC(), CID: cid, OK: true})


### PR DESCRIPTION
## Summary
- On `getStorageProof` failure inside `startPoSHandler`, call `maybeBackgroundPull(cid)` before the existing `continue`.
- `maybeBackgroundPull` ([serve_blob.go](pkg/mediorum/server/serve_blob.go#L378)) is the existing async read-repair primitive — it runs the pull in a goroutine, dedupes via `bgPullBackoff` (LRU, 1hr TTL), gates on `isMine` and `diskHasSpaceForCID`, and emits `readPullAttempts` / `readPullSuccesses` metrics.
- Response semantics are unchanged: the failure branch still `continue`s (no `PoSResponse` sent), so `InsertStorageProofPeers` recording for this height is unaffected.
- Closes the gap where a missing blob would only get recovered when the next periodic repair cycle (default 1hr) ran.

## Test plan
- [ ] Unit: existing PoS handler still records success/failure metrics as before.
- [ ] Devnet: kill a blob on one replica, wait for a PoS challenge to fail on that node, confirm `readPullAttempts` increments and the blob is back in the local bucket on next read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)