### PR TITLE
fix(etl): restore 0017 stub so golang-migrate can step past version 17

### DIFF
--- a/pkg/etl/db/sql/migrations/0017_aggregate_tables.down.sql
+++ b/pkg/etl/db/sql/migrations/0017_aggregate_tables.down.sql
@@ -1,0 +1,1 @@
+-- No-op stub. See 0017_aggregate_tables.up.sql.

--- a/pkg/etl/db/sql/migrations/0017_aggregate_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0017_aggregate_tables.up.sql
@@ -1,0 +1,12 @@
+-- No-op stub.
+--
+-- Migration 0017 originally created aggregate_user / aggregate_track /
+-- aggregate_playlist / aggregate_plays / aggregate_monthly_plays /
+-- milestones (#238). #267 reverted that work — those tables are owned by
+-- api/'s pg_migrate.sh, not pkg/etl.
+--
+-- We keep an empty 0017 file so golang-migrate can step past version 17
+-- on production DBs that already recorded it. Deleting the file outright
+-- causes Up() to fail with "no migration found for version 17: read down
+-- for version 17 sql/migrations: file does not exist", which blocks every
+-- newer migration (0021, 0022, …) and leaves the ETL DB stuck.


### PR DESCRIPTION
## Summary

- Production explorer (`explorer.openaudio.org`) is down — every DB-touching route (`/`, `/transactions`, `/blocks`, `/validators`, `/fragments/*`) returns `{"message":"Internal Server Error"}`.
- Root cause from `kubectl -n explorer logs audiusd-0`:

  ```
  error running migrations: error running up migrations:
    no migration found for version 17:
    read down for version 17 sql/migrations: file does not exist
  ```

- #267 reverted #238 by **deleting** `0017_aggregate_tables.{up,down}.sql`. The explorer prod DB already recorded `etl_db_migrations.version = 17` from when #238 was deployed, so on every restart `golang-migrate`'s `Up()` aborts before it can apply 0021/0022. ETL `Run()` exits before `e.db = db.New(pool)` ([`pkg/etl/indexer.go:51-69`](https://github.com/OpenAudio/go-openaudio/blob/main/pkg/etl/indexer.go#L51-L69)), so `ex.etl.GetDB()` stays nil and every explorer handler nil-panics on its first DB call (stack trace lands on `reads.sql.go:145` from `explorer.go:1144`).
- Fix: re-add `0017_aggregate_tables.{up,down}.sql` as comment-only files. The postgres driver short-circuits whitespace-only statements in `runStatement`, so:
  - **Prod DB** (`version=17` already): `Up()` finds the file, steps to 21, 22 without re-running the empty SQL.
  - **Fresh DB**: 0017 applies as a no-op; the aggregate / milestone tables stay owned by `api/`'s `pg_migrate.sh`, matching #267's architectural intent.

## Test plan

- [ ] Deploy to `explorer` namespace and confirm `audiusd-0` logs show `Applied N successful migrations!` followed by ETL indexer startup (no more `service will restart` retries).
- [ ] `curl https://explorer.openaudio.org/` returns 200 with HTML, not `{"message":"Internal Server Error"}`.
- [ ] Spot-check `/transactions`, `/blocks`, `/validators`, `/fragments/tps`.
- [ ] Confirm fresh devnet (`make up`) still comes up clean — 0017 should be recorded but apply no SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)