### PR TITLE
ci: complete release-please pipeline with tag-driven publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, mainnet-alpha-beta ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, mainnet-alpha-beta ]
+    branches: [ main ]
 
 jobs:
   build-test-push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, mainnet-alpha-beta ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, mainnet-alpha-beta ]
 
 jobs:
   build-test-push:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,35 @@
+name: Lint PR Title
+
+# Third-party actions are pinned to a full commit SHA to harden against
+# supply-chain attacks on upstream tags. To upgrade, look up the commit at the
+# desired tag with `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` and
+# update both the SHA and the trailing `# <tag>` comment.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            revert
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            deps
+          requireScope: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-name: Create Release (mainnet-alpha-beta backport)
+name: Create Release (manual fallback)
 
-# Releases from `main` are automated by .github/workflows/release-please.yml.
-# This workflow is the manual fallback for cutting a release from the
-# long-lived `mainnet-alpha-beta` backport branch.
+# Releases from `main` are normally automated by
+# .github/workflows/release-please.yml. This workflow is the manual fallback
+# used only if release-please is broken or unavailable. To use it:
+#   1. Hand-edit `pkg/version/.version.json` on `main` to the new version.
+#   2. Dispatch this workflow with the matching version (e.g. v1.2.16).
 on:
   workflow_dispatch:
     inputs:
@@ -11,7 +13,7 @@ on:
         required: true
         type: choice
         options:
-          - mainnet-alpha-beta
+          - main
       version:
         description: 'Release version (e.g., v1.0.0, v2.0.0-beta.1)'
         required: true
@@ -79,6 +81,6 @@ jobs:
           generate_release_notes: true
 
   # Pushing the tag above triggers:
-  #   - .github/workflows/tag-released.yml (multi-arch image + version tag;
-  #     :stable is NOT moved because the tag is not reachable from main)
+  #   - .github/workflows/tag-released.yml (multi-arch image + version tag,
+  #     :stable retagged to the new version)
   #   - .github/workflows/buf-publish.yml  (buf module published with the tag)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
-name: Create Release
+name: Create Release (mainnet-alpha-beta backport)
 
+# Releases from `main` are automated by .github/workflows/release-please.yml.
+# This workflow is the manual fallback for cutting a release from the
+# long-lived `mainnet-alpha-beta` backport branch.
 on:
   workflow_dispatch:
     inputs:
@@ -8,7 +11,6 @@ on:
         required: true
         type: choice
         options:
-          - main
           - mainnet-alpha-beta
       version:
         description: 'Release version (e.g., v1.0.0, v2.0.0-beta.1)'
@@ -76,17 +78,7 @@ jobs:
           draft: false
           generate_release_notes: true
 
-  build-test-push:
-    uses: ./.github/workflows/docker-build.yml
-    with:
-      tag: ${{ inputs.version }}
-      ref: ${{ inputs.version }}
-      push: true
-    secrets: inherit
-
-  publish-to-buf:
-    needs: create-release
-    uses: ./.github/workflows/buf-publish.yml
-    with:
-      label: ${{ inputs.version }}
-    secrets: inherit
+  # Pushing the tag above triggers:
+  #   - .github/workflows/tag-released.yml (multi-arch image + version tag;
+  #     :stable is NOT moved because the tag is not reachable from main)
+  #   - .github/workflows/buf-publish.yml  (buf module published with the tag)

--- a/.github/workflows/tag-released.yml
+++ b/.github/workflows/tag-released.yml
@@ -32,33 +32,16 @@ jobs:
             -t openaudio/go-openaudio:${{ github.ref_name }} \
             openaudio/go-openaudio:${{ steps.lookup.outputs.sha }}
 
-  # Move :stable only when the released tag is reachable from main.
-  # mainnet-alpha-beta backports get a versioned image but do not move :stable.
   retag-stable:
     needs: retag-from-sha
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-      - id: on_main
-        run: |
-          git fetch origin main --depth=1
-          if git merge-base --is-ancestor "${{ github.ref_name }}" origin/main; then
-            echo "yes=true" >> $GITHUB_OUTPUT
-          else
-            echo "yes=false" >> $GITHUB_OUTPUT
-            echo "Tag ${{ github.ref_name }} is not reachable from main; skipping :stable retag (likely a mainnet-alpha-beta backport)."
-          fi
-      - if: steps.on_main.outputs.yes == 'true'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - if: steps.on_main.outputs.yes == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - if: steps.on_main.outputs.yes == 'true'
-        name: Retag version tag as :stable
+      - name: Retag version tag as :stable
         run: |
           docker buildx imagetools create \
             -t openaudio/go-openaudio:stable \

--- a/.github/workflows/tag-released.yml
+++ b/.github/workflows/tag-released.yml
@@ -1,0 +1,65 @@
+name: Tag Released
+
+# All third-party actions are pinned to a full commit SHA to harden against
+# supply-chain attacks on upstream tags. To upgrade an action, look up the
+# commit at the desired tag with `gh api repos/<owner>/<repo>/commits/<tag>
+# --jq .sha` and update both the SHA and the trailing `# <tag>` comment.
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  # Reuse the multi-arch manifest that ci.yml already built and pushed for
+  # the merge commit (openaudio/go-openaudio:<sha>). Retag it to the version
+  # tag instead of rebuilding from source.
+  retag-from-sha:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - id: lookup
+        run: echo "sha=$(git rev-list -n 1 ${{ github.ref_name }})" >> $GITHUB_OUTPUT
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Retag SHA manifest as version tag
+        run: |
+          docker buildx imagetools create \
+            -t openaudio/go-openaudio:${{ github.ref_name }} \
+            openaudio/go-openaudio:${{ steps.lookup.outputs.sha }}
+
+  # Move :stable only when the released tag is reachable from main.
+  # mainnet-alpha-beta backports get a versioned image but do not move :stable.
+  retag-stable:
+    needs: retag-from-sha
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - id: on_main
+        run: |
+          git fetch origin main --depth=1
+          if git merge-base --is-ancestor "${{ github.ref_name }}" origin/main; then
+            echo "yes=true" >> $GITHUB_OUTPUT
+          else
+            echo "yes=false" >> $GITHUB_OUTPUT
+            echo "Tag ${{ github.ref_name }} is not reachable from main; skipping :stable retag (likely a mainnet-alpha-beta backport)."
+          fi
+      - if: steps.on_main.outputs.yes == 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - if: steps.on_main.outputs.yes == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - if: steps.on_main.outputs.yes == 'true'
+        name: Retag version tag as :stable
+        run: |
+          docker buildx imagetools create \
+            -t openaudio/go-openaudio:stable \
+            openaudio/go-openaudio:${{ github.ref_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,40 @@ $ git cherry-pick {commit SHA from main}
 $ git push origin {new branch name}
 ```
 
+## Releases
+
+Releases on `main` are automated with [release-please](https://github.com/googleapis/release-please). You do not bump `pkg/version/.version.json` by hand and you do not dispatch a release workflow manually for `main`.
+
+### Commit conventions
+
+All commits on `main` must follow the [Conventional Commits](https://www.conventionalcommits.org/) format. Because PRs are squash-merged, the **PR title** is what lands on `main` — it is what release-please reads and what `.github/workflows/pr-title-lint.yml` checks.
+
+Bump rules:
+
+| Commit prefix | Bump |
+| --- | --- |
+| `fix:`, `perf:` | patch |
+| `feat:` | minor |
+| `feat!:`, or any type with a `BREAKING CHANGE:` footer | major |
+| `docs:`, `test:`, `build:`, `ci:`, `chore:`, `refactor:`, `deps:`, `revert:` | no bump (some hidden from CHANGELOG) |
+
+Scopes are optional, e.g. `feat(console): surface archive storage stats`.
+
+### How a release ships
+
+1. As Conventional Commits land on `main`, release-please opens (and keeps updated) a PR titled `chore: release X.Y.Z`. The PR bumps `pkg/version/.version.json`, updates `.release-please-manifest.json`, and rewrites `CHANGELOG.md`.
+2. Merging the release PR creates a GitHub Release, pushes the `vX.Y.Z` git tag, and triggers:
+   - `tag-released.yml` — retags the multi-arch image as `openaudio/go-openaudio:vX.Y.Z` and promotes `:stable` to that version.
+   - `buf-publish.yml` — publishes the proto module to the Buf Schema Registry under the version label.
+
+For the tag push to fire those downstream workflows, repo admins must set a `RELEASE_PLEASE_TOKEN` secret to a fine-grained PAT (or GitHub App token) with `contents: write` and `pull-requests: write`. Without it, release-please still opens the PR but the `:stable` retag and buf publish must be triggered manually.
+
+### Backports to `mainnet-alpha-beta`
+
+The long-lived chain branch does not use release-please. Cut a backport release by manually dispatching `.github/workflows/release.yml` (branch input: `mainnet-alpha-beta`, version input: e.g. `v1.2.15-mainnet.1`). The resulting tag still triggers the standard image build via `tag-released.yml`, but `:stable` is intentionally **not** moved for backports — `:stable` only ever points at a release cut from `main`.
+
+To avoid colliding with release-please's tag namespace, use a prerelease suffix (`-mainnet.N`) for backport versions.
+
 ## Testing
 
 Tests are located in _test.go files as directed by the Go testing package. If you're adding or removing a function, please check there's a TestType_Method test for it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,11 +63,14 @@ Scopes are optional, e.g. `feat(console): surface archive storage stats`.
 
 For the tag push to fire those downstream workflows, repo admins must set a `RELEASE_PLEASE_TOKEN` secret to a fine-grained PAT (or GitHub App token) with `contents: write` and `pull-requests: write`. Without it, release-please still opens the PR but the `:stable` retag and buf publish must be triggered manually.
 
-### Backports to `mainnet-alpha-beta`
+### Manual release fallback
 
-The long-lived chain branch does not use release-please. Cut a backport release by manually dispatching `.github/workflows/release.yml` (branch input: `mainnet-alpha-beta`, version input: e.g. `v1.2.15-mainnet.1`). The resulting tag still triggers the standard image build via `tag-released.yml`, but `:stable` is intentionally **not** moved for backports — `:stable` only ever points at a release cut from `main`.
+If release-please is broken or unavailable, you can cut a release by hand:
 
-To avoid colliding with release-please's tag namespace, use a prerelease suffix (`-mainnet.N`) for backport versions.
+1. Hand-edit `pkg/version/.version.json` on `main` to the new version and merge.
+2. Dispatch `.github/workflows/release.yml` with the matching version (e.g. `v1.2.16`).
+
+The resulting tag still triggers `tag-released.yml` and `buf-publish.yml`, so the image and buf module land the same way they do from a release-please release.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Wires up the downstream half of the release automation that #284 bootstrapped. When release-please's auto-PR is merged on `main`, the resulting `v*` tag now drives the rest of the release: a versioned image is produced, `:stable` is promoted, and the buf module publishes via its pre-existing tag trigger.

### Files

- **`.github/workflows/tag-released.yml`** (new) — on `push: tags: ['v*']`:
  - Retag the SHA-tagged multi-arch manifest that `ci.yml` already produced for the merge commit as `openaudio/go-openaudio:vX.Y.Z` (no rebuild from source — saves ~10 min of multi-arch build + test).
  - Retag `openaudio/go-openaudio:stable` to the same version.
- **`.github/workflows/pr-title-lint.yml`** (new) — enforce Conventional Commits on squash-merge PR titles via `amannn/action-semantic-pull-request`. Without this, a non-conformant PR title silently drops from the release-please changelog and bump calculation.
- **`.github/workflows/release.yml`** — kept as a **manual fallback** for `main` if release-please ever breaks. Renamed accordingly; the inline `build-test-push` and `publish-to-buf` jobs are removed since the tag triggers in `tag-released.yml` and `buf-publish.yml` now do the work for any pushed `v*` tag (whether from release-please or from this fallback).
- **`CONTRIBUTING.md`** — add a Releases section documenting Conventional Commits, bump rules, the release-please flow, the `RELEASE_PLEASE_TOKEN` secret, and the manual-fallback recipe.

### Supply-chain hardening

All third-party actions in the new workflows are pinned to full commit SHAs (with `# vX.Y.Z` comments and an upgrade-recipe header comment). Pre-existing unpinned actions in `ci.yml`, `release.yml`, `buf-publish.yml`, `docker-build.yml`, and `docker-retag.yml` are out of scope for this PR.

## Test plan

- [ ] Merge this PR.
- [ ] **`:stable` auto-promotion** (end-to-end): merge the release-please auto-PR currently sitting open on `main` (proposes `1.2.15`).
  - [ ] `Tag Released` workflow runs against the new `v1.2.15` tag.
  - [ ] `openaudio/go-openaudio:v1.2.15` exists on DockerHub.
  - [ ] `openaudio/go-openaudio:stable` digest matches `v1.2.15` (`docker buildx imagetools inspect openaudio/go-openaudio:stable`).
  - [ ] `buf-publish.yml` ran and pushed the buf module with label `v1.2.15`.
- [ ] **PR-title lint**: open a throwaway PR with a non-conformant title (e.g. `hotfix WIP`); the lint job fails. Edit the title to `chore: test lint`; the lint job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)