### PR TITLE
ci: authenticate release-please via GitHub App

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,17 +12,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived installation token from the release-bot GitHub App
+      # (vars.RELEASE_PLEASE_APP_ID + secrets.RELEASE_PLEASE_APP_PRIVATE_KEY).
+      # Using an App token instead of the default GITHUB_TOKEN is what allows
+      # the tag release-please pushes to fire downstream workflows like
+      # tag-released.yml and buf-publish.yml — GitHub's loop-prevention rule
+      # blocks workflow-triggered tags when GITHUB_TOKEN is the actor.
+      #
       # Pinned to a full commit SHA to harden against supply-chain attacks on
-      # the upstream action. To upgrade: look up the commit at the desired tag
-      # with `gh api repos/googleapis/release-please-action/commits/<tag> --jq .sha`
+      # the upstream action. To upgrade an action, look up the commit at the
+      # desired tag with `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`
       # and update both the SHA and the trailing `# <tag>` comment.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
-          # When release-please pushes the release tag using the default
-          # GITHUB_TOKEN, GitHub will NOT fire downstream workflows like
-          # tag-released.yml or buf-publish.yml (loop-prevention rule).
-          # To get the auto :stable retag and buf publish, set a repo secret
-          # named RELEASE_PLEASE_TOKEN to a fine-grained PAT with
-          # `contents: write` + `pull-requests: write`, or a GitHub App token.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,14 @@ Scopes are optional, e.g. `feat(console): surface archive storage stats`.
    - `tag-released.yml` — retags the multi-arch image as `openaudio/go-openaudio:vX.Y.Z` and promotes `:stable` to that version.
    - `buf-publish.yml` — publishes the proto module to the Buf Schema Registry under the version label.
 
-For the tag push to fire those downstream workflows, repo admins must set a `RELEASE_PLEASE_TOKEN` secret to a fine-grained PAT (or GitHub App token) with `contents: write` and `pull-requests: write`. Without it, release-please still opens the PR but the `:stable` retag and buf publish must be triggered manually.
+For the tag push to fire those downstream workflows, release-please authenticates as a dedicated GitHub App (`openaudio-release-bot`) rather than using the default `GITHUB_TOKEN`. The workflow mints a short-lived installation token at run time via `actions/create-github-app-token`, so there is no PAT to rotate or human-owned credential to maintain.
+
+Repo admins maintain two configuration values for this:
+
+- `vars.RELEASE_PLEASE_APP_ID` — the App's numeric ID (a repo or org **variable**, not sensitive).
+- `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY` — the App's private key (PEM contents).
+
+The App is installed only on this repository and granted the minimum permissions: **Contents: read/write** (push the release tag, create the GitHub Release) and **Pull requests: read/write** (open and maintain the release PR). If the App is ever removed or its key is rotated, the workflow falls back to no-op auth and the release PR will fail to open until the values are restored.
 
 ### Manual release fallback
 


### PR DESCRIPTION
## Summary

Replace the `RELEASE_PLEASE_TOKEN` PAT (with `GITHUB_TOKEN` fallback) added in #284/#288 with a dedicated GitHub App token minted at run time via `actions/create-github-app-token`.

A repo-scoped App is preferable to a PAT for three reasons:

- **No expiry to manage.** Installation tokens are short-lived and minted per workflow run.
- **Not tied to an individual user.** Survives staff turnover with no rotation work.
- **Narrower scope.** Permissions are limited to `contents: write` and `pull-requests: write` on this single repo — much tighter than a typical PAT.

The `actions/create-github-app-token` action is pinned to a full commit SHA (`v3.2.0`), consistent with the supply-chain hardening pattern used elsewhere in this pipeline.

`CONTRIBUTING.md`'s Releases section is updated to describe the App setup in place of the PAT-based instructions added in #288.

## One-time setup (by a repo admin, before merging)

1. Create a new GitHub App at `https://github.com/organizations/OpenAudio/settings/apps/new` named `openaudio-release-bot` (or similar).
   - **Webhook:** uncheck "Active" — no events needed.
   - **Repository permissions:**
     - `Contents`: Read and write
     - `Pull requests`: Read and write
     - `Metadata`: Read (auto-included)
   - **Where can this be installed:** Only on this account.
2. **Generate a private key** (App settings → "Generate a private key"). Save the `.pem` immediately — you cannot redownload it, only regenerate.
3. **Install** the App on `OpenAudio/go-openaudio`.
4. Add the following to repo (or org) settings:
   - **Variable** `RELEASE_PLEASE_APP_ID` → the App's numeric ID (not sensitive).
   - **Secret** `RELEASE_PLEASE_APP_PRIVATE_KEY` → the entire contents of the downloaded `.pem`.

If the previous `RELEASE_PLEASE_TOKEN` secret was ever set, it can be deleted after this PR merges.

## Caveats

- The release PR will be authored by `openaudio-release-bot[bot]`. If branch protection on `main` requires human commits or specific reviewers, the App needs to be added to the bypass/allow list.
- If commit signing is required on `main`, enable "Sign commits made by this GitHub App" in App settings — otherwise the release-please commits in the auto-PR will fail signature checks.

## Test plan

- [ ] App created, installed on the repo, `RELEASE_PLEASE_APP_ID` and `RELEASE_PLEASE_APP_PRIVATE_KEY` configured.
- [ ] Merge this PR.
- [ ] The next push to `main` triggers `Release Please`; the workflow run shows the `create-github-app-token` step succeeding and `release-please-action` using the minted token.
- [ ] Once a release PR is merged, the `v*` tag push fires `tag-released.yml` and `buf-publish.yml` (this was the whole point of switching off `GITHUB_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)