### PR TITLE
fix(ci): use App client-id (not app-id) for release-please auth

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Mint a short-lived installation token from the release-bot GitHub App
-      # (vars.RELEASE_PLEASE_APP_ID + secrets.RELEASE_PLEASE_APP_PRIVATE_KEY).
+      # (vars.RELEASE_PLEASE_APP_CLIENT_ID + secrets.RELEASE_PLEASE_APP_PRIVATE_KEY).
       # Using an App token instead of the default GITHUB_TOKEN is what allows
       # the tag release-please pushes to fire downstream workflows like
       # tag-released.yml and buf-publish.yml — GitHub's loop-prevention rule
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,10 @@ For the tag push to fire those downstream workflows, release-please authenticate
 
 Repo admins maintain two configuration values for this:
 
-- `vars.RELEASE_PLEASE_APP_ID` — the App's numeric ID (a repo or org **variable**, not sensitive).
+- `vars.RELEASE_PLEASE_APP_CLIENT_ID` — the App's **Client ID** (a string like `Iv23li…`, shown on the App's settings page). Stored as a repository **variable**, not a secret — Client IDs are public.
 - `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY` — the App's private key (PEM contents).
+
+Note: the App's **Client ID** is a string, distinct from the numeric **App ID** also shown on the same page. `actions/create-github-app-token@v3` expects the Client ID (the App ID input is deprecated).
 
 The App is installed only on this repository and granted the minimum permissions: **Contents: read/write** (push the release tag, create the GitHub Release) and **Pull requests: read/write** (open and maintain the release PR). If the App is ever removed or its key is rotated, the workflow falls back to no-op auth and the release PR will fail to open until the values are restored.
 


### PR DESCRIPTION
## Summary

`actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`. The current workflow fails on `main` with:

\`\`\`
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
\`\`\`

This PR:
- Switches the workflow input from `app-id` to `client-id`.
- Renames the GitHub Actions variable from `RELEASE_PLEASE_APP_ID` to `RELEASE_PLEASE_APP_CLIENT_ID`. The new name matches the value type — the App's **Client ID** (e.g. `Iv23li…`), which is distinct from the numeric App ID. v3 of the action only accepts the Client ID form going forward.
- Updates CONTRIBUTING to match and to clarify which value (Client ID, not App ID) to copy from the App's settings page.

The value is stored in `vars.*`, not `secrets.*` — Client IDs are public and don't need masking.

## Pre-merge configuration

Before merging, a repo admin needs to:

1. Add a repository **variable** named `RELEASE_PLEASE_APP_CLIENT_ID` containing the App's **Client ID** (the string starting with `Iv23li…` on the App's settings page).
2. (If applicable) Delete any existing `RELEASE_PLEASE_APP_ID` variable or secret — it's no longer read.

`secrets.RELEASE_PLEASE_APP_PRIVATE_KEY` from #289 is unchanged.

## Test plan

- [ ] Variable `RELEASE_PLEASE_APP_CLIENT_ID` is set with the Client ID string.
- [ ] Merge this PR.
- [ ] The next push to `main` triggers `Release Please`; the `create-github-app-token` step completes without the deprecation warning or empty-value error.
- [ ] release-please opens (or updates) the `chore: release 1.2.15` PR using the App-minted token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)