### PR TITLE
fix(ci): wait for SHA-tagged image before retagging release tag

### DIFF
--- a/.github/workflows/tag-released.yml
+++ b/.github/workflows/tag-released.yml
@@ -26,6 +26,30 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # When release-please's release PR is merged, the merge commit's
+      # `push: branches: [main]` event and the tag-push event fire
+      # simultaneously. ci.yml builds the SHA-tagged manifest from the
+      # `push: main` event, but this workflow (triggered by the tag push)
+      # may start first and find no image to retag. Poll DockerHub for the
+      # SHA manifest with a 25-minute budget — comfortably longer than the
+      # multi-arch build + integration tests in docker-build.yml.
+      - name: Wait for SHA-tagged manifest to exist
+        timeout-minutes: 30
+        run: |
+          SHA="${{ steps.lookup.outputs.sha }}"
+          IMAGE="openaudio/go-openaudio:$SHA"
+          for i in $(seq 1 100); do
+            if docker buildx imagetools inspect "$IMAGE" >/dev/null 2>&1; then
+              echo "Found $IMAGE after $((i * 15))s"
+              exit 0
+            fi
+            echo "Waiting for $IMAGE... ($((i * 15))s elapsed)"
+            sleep 15
+          done
+          echo "Timed out waiting for $IMAGE." >&2
+          echo "Likely cause: ci.yml on $SHA failed or has not yet started." >&2
+          echo "Investigate the CI run for that commit, then re-run this workflow." >&2
+          exit 1
       - name: Retag SHA manifest as version tag
         run: |
           docker buildx imagetools create \


### PR DESCRIPTION
## Summary

When the release-please PR is merged, the merge commit's `push: branches: [main]` event and the `push: tags: ['v*']` event fire near-simultaneously. `ci.yml` builds the SHA-tagged multi-arch manifest from the main-push, but `tag-released.yml` (on the tag-push) often starts first and fails:

\`\`\`
ERROR: docker.io/openaudio/go-openaudio:<sha>: not found
\`\`\`

Hit on the v1.3.0 release.

## Fix

Add a poll loop with a 25-minute budget (15s × 100 attempts) before the retag step. `docker buildx imagetools inspect` exits 0 once the SHA-tagged manifest is published, at which point retagging proceeds. If ci.yml never produces the image (build/test failure), the wait times out with a diagnostic pointing at the CI run.

The manual `release.yml` fallback path is unaffected: when it pushes a tag for an already-built commit, the wait short-circuits on the first poll.

## Recovery for the v1.3.0 release

CI for the v1.3.0 merge commit has finished by now, so the SHA-tagged manifest exists. To finish promoting v1.3.0 to `:stable` without merging this PR first:

1. Re-run the failed `tag-released.yml` workflow run from the Actions UI (Re-run failed jobs), **or**
2. Manually dispatch `docker-retag.yml` with `source_tag: v1.3.0`, `target_tag: stable`.

Future releases will use the polling logic added here.

## Test plan

- [ ] Merge this PR.
- [ ] On the next release-please release, observe `tag-released.yml`'s "Wait for SHA-tagged manifest" step polling, then succeeding once `ci.yml` finishes.
- [ ] `:stable` ends up pointing at the new version tag without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)