### PR TITLE
fix(core): pass --disable-triggers to pg_restore data section

### DIFF
--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -732,6 +732,15 @@ func (s *Server) RestoreDatabase(height int64) error {
 		if section != "" {
 			args = append(args, "--section="+section)
 		}
+		// pg_dump emits COPY items in TOC order, which can place a child table
+		// (e.g. sla_node_reports) before its parent (sla_rollups). The FK trigger
+		// created by pre-data then rejects the child rows during COPY, pg_restore
+		// exits 1, and the ABCI handler retries the whole snapshot — looping forever.
+		// --disable-triggers turns FK enforcement off for the data load only;
+		// constraints are restored automatically when pg_restore re-enables triggers.
+		if section == "data" {
+			args = append(args, "--disable-triggers")
+		}
 		args = append(args, dumpPath)
 
 		var stdout, stderr bytes.Buffer


### PR DESCRIPTION
## Summary

State-syncing nodes can get caught in an infinite restore loop. Root cause: `pg_dump` lays out the data section in TOC order, which can put a child table's `COPY` before its parent's. The FK trigger created during pre-data then rejects rows, `pg_restore` exits 1, and the ABCI snapshot handler treats it as fatal — returning `APPLY_SNAPSHOT_CHUNK_RESULT_RETRY` and restarting the entire ~1.5h restore.

```
pg_restore: error: COPY failed for table "sla_node_reports":
  ERROR: insert or update on table "sla_node_reports" violates foreign key constraint
         "sla_node_reports_sla_rollup_id_fkey"
  DETAIL: Key (sla_rollup_id)=(10) is not present in table "sla_rollups".
pg_restore: warning: errors ignored on restore: 1
```

