### PR TITLE
build(etl): replace stub parent require with v1.3.0 so module is consumable

### DIFF
--- a/pkg/etl/go.mod
+++ b/pkg/etl/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	connectrpc.com/connect v1.18.1
-	github.com/OpenAudio/go-openaudio v0.0.0
+	github.com/OpenAudio/go-openaudio v1.3.0 // x-release-please-version
 	github.com/ethereum/go-ethereum v1.14.9
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/jackc/pgx/v5 v5.6.0


### PR DESCRIPTION
## Summary

\`pkg/etl/go.mod\` has required \`github.com/OpenAudio/go-openaudio v0.0.0\` since the etl submodule was split out. The stub only ever resolved because of the in-repo \`replace ../..\` directive on the same file — **external consumers fail to resolve the parent and \`go mod download\` errors out**.

Replace \`v0.0.0\` with the current root tag \`v1.3.0\`. The trailing \`// x-release-please-version\` marker hooks release-please's generic updater configured in #295 so this version auto-bumps on every release once #295 lands.

## Why this is split out of #295

#295 adds the full release-please lockstep tooling (linked-versions plugin, multi-package config, manifest entry). It's correct work but takes longer to review and may sit. The single-line go.mod change is the only piece needed to **unblock external consumption right now** — particularly the api.audius.co vendoring work that wants to start importing etl as a Go module dep.

This PR is intentionally one-line so it can land immediately. #295 still merges on its own pace.

## After this merges

I'll tag \`etl/v1.3.0\` at the merge commit:

\`\`\`
git tag etl/v1.3.0 <merge-sha>
git push origin etl/v1.3.0
\`\`\`

External consumers can then \`require github.com/OpenAudio/go-openaudio/etl v1.3.0\` or use \`go get github.com/OpenAudio/go-openaudio/etl@main\` for a pseudo-version pinned to whatever main HEAD is.

## Verified

\`go build ./...\` clean in both the root module and \`pkg/etl/\`. The local \`replace github.com/OpenAudio/go-openaudio => ../..\` directive stays — replace directives in dependency modules are ignored by Go (only the consuming root module's replace matters), so this keeps in-repo builds resolving from the worktree without affecting external consumers.