### PR TITLE
feat(mediorum): flip health-check unhealthy when bucket writes fail

### DIFF
--- a/pkg/mediorum/server/monitor.go
+++ b/pkg/mediorum/server/monitor.go
@@ -90,6 +90,7 @@ func (ss *MediorumServer) monitorMetrics(ctx context.Context) error {
 			ticker.Reset(1 * time.Minute) // set longer interval after first attempt
 			ss.updateDiskAndDbStatus(ctx)
 			ss.updateTranscodeStats(ctx)
+			ss.runBucketWriteCanary(ctx)
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -104,10 +105,25 @@ func (ss *MediorumServer) monitorMetrics(ctx context.Context) error {
 		case <-ticker.C:
 			ss.updateDiskAndDbStatus(ctx)
 			ss.updateTranscodeStats(ctx)
+			ss.runBucketWriteCanary(ctx)
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 	}
+}
+
+// Probes the bucket so health-check catches backends that accept connections
+// but reject writes (e.g. provider quota hit).
+func (ss *MediorumServer) runBucketWriteCanary(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := ss.bucket.WriteAll(ctx, "__healthcheck__/canary", []byte("ok"), nil); err != nil {
+		ss.bucketWriteErr = err.Error()
+		slog.Error("bucket write canary failed", "err", err)
+		return
+	}
+	ss.bucketWriteErr = ""
 }
 
 func (ss *MediorumServer) monitorPeerReachability(ctx context.Context) error {

--- a/pkg/mediorum/server/monitor_test.go
+++ b/pkg/mediorum/server/monitor_test.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestRunBucketWriteCanary(t *testing.T) {
+	ss := &MediorumServer{bucket: openMemBucket(t), logger: zap.NewNop()}
+
+	ss.bucketWriteErr = "stale"
+	ss.runBucketWriteCanary(context.Background())
+	assert.Empty(t, ss.bucketWriteErr, "healthy bucket should clear the error")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ss.runBucketWriteCanary(ctx)
+	assert.NotEmpty(t, ss.bucketWriteErr, "failed write should surface as error")
+
+	ss.runBucketWriteCanary(context.Background())
+	assert.Empty(t, ss.bucketWriteErr, "next success should clear the error")
+}

--- a/pkg/mediorum/server/serve_health.go
+++ b/pkg/mediorum/server/serve_health.go
@@ -36,6 +36,7 @@ type HealthData struct {
 	LastSuccessfulCleanup     RepairTracker              `json:"lastSuccessfulCleanup"`
 	UploadsCount              int64                      `json:"uploadsCount"`
 	UploadsCountErr           string                     `json:"uploadsCountErr"`
+	BucketWriteErr            string                     `json:"bucketWriteErr"`
 	AutoUpgradeEnabled        bool                       `json:"autoUpgradeEnabled"`
 	TrustedNotifier           *ethcontracts.NotifierInfo `json:"trustedNotifier"`
 	Env                       string                     `json:"env"`
@@ -66,7 +67,7 @@ type HealthData struct {
 }
 
 func (ss *MediorumServer) getHealth() HealthData {
-	healthy := ss.databaseSize > 0 && ss.dbSizeErr == "" && ss.uploadsCountErr == ""
+	healthy := ss.databaseSize > 0 && ss.dbSizeErr == "" && ss.uploadsCountErr == "" && ss.bucketWriteErr == ""
 
 	blobStorePrefix, _, foundBlobStore := strings.Cut(ss.Config.BlobStoreDSN, "://")
 	if !foundBlobStore {
@@ -106,6 +107,7 @@ func (ss *MediorumServer) getHealth() HealthData {
 		LastSuccessfulCleanup:     ss.lastSuccessfulCleanup,
 		UploadsCount:              ss.uploadsCount,
 		UploadsCountErr:           ss.uploadsCountErr,
+		BucketWriteErr:            ss.bucketWriteErr,
 		AutoUpgradeEnabled:        ss.Config.AutoUpgradeEnabled,
 		TrustedNotifier:           ss.trustedNotifier,
 		Dir:                       ss.Config.Dir,

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -130,6 +130,8 @@ type MediorumServer struct {
 	uploadsCount    int64
 	uploadsCountErr string
 
+	bucketWriteErr string
+
 	isSeeding        bool
 	isAudiusdManaged bool
 


### PR DESCRIPTION
## What

Add a small canary write to the primary blob bucket on the existing 10-minute monitor loop and feed its result into the mediorum `healthy` boolean. When the write fails (e.g. provider quota cap, rotated creds, bucket misconfigured), `/health-check` flips to unhealthy.

## Test plan

- [x] `TestRunBucketWriteCanary` covers happy path (memblob clears error), failure path (cancelled context surfaces error), and recovery (next success clears error)
- [x] `make test-mediorum` passes the new test locally
- [ ] Verify a healthy production node continues to report healthy after deploy
- [ ] Verify that revoking bucket write perms (or hitting Backblaze cap) flips `healthy: false` and populates `bucketWriteErr` within ~10 minutes
