### PR TITLE
fix(core): auto-regenerate stale priv_validator_key.json on delegate key rotation

### DIFF
--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"math/big"
@@ -12,6 +13,7 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/core/config/genesis"
 	"github.com/OpenAudio/go-openaudio/pkg/env"
 	cconfig "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 	"go.uber.org/zap"
@@ -86,17 +88,9 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 	privValKeyFile := cometConfig.PrivValidatorKeyFile()
 	privValStateFile := cometConfig.PrivValidatorStateFile()
 
-	// set validator and state file for derived comet key
-	var pv *privval.FilePV
-	if common.FileExists(privValKeyFile) {
-		logger.Info("Found private validator", zap.String("keyFile", privValKeyFile),
-			zap.String("stateFile", privValStateFile))
-		pv = privval.LoadFilePV(privValKeyFile, privValStateFile)
-	} else {
-		pv = privval.NewFilePV(envConfig.CometKey, privValKeyFile, privValStateFile)
-		pv.Save()
-		logger.Info("Generated private validator", zap.String("keyFile", privValKeyFile),
-			zap.String("stateFile", privValStateFile))
+	pv, err := ensurePrivValidator(logger, envConfig.CometKey, privValKeyFile, privValStateFile)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// now that we know proposer addr, set in config
@@ -217,6 +211,51 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 	}
 
 	return envConfig, cometConfig, nil
+}
+
+// ensurePrivValidator returns a FilePV whose key matches the comet key derived
+// from the node's delegate private key. If priv_validator_key.json is missing,
+// it's generated. If it's present but holds a key that doesn't match the
+// derived one, it's regenerated — but only when the on-disk key has no prior
+// signing history (LastSignState.Height == 0), so we can't introduce a
+// double-sign risk.
+//
+// The mismatch case arises when an operator rotates OPENAUDIO_DELEGATE_PRIVATE_KEY
+// without also regenerating the CometBFT key files. The node then submits
+// registration txs whose PubKey (derived from the current delegate key) does
+// not hash to the CometAddress (loaded from the stale file), and peers reject
+// the tx with "address does not match public key".
+func ensurePrivValidator(logger *zap.Logger, derivedKey crypto.PrivKey, keyFile, stateFile string) (*privval.FilePV, error) {
+	if !common.FileExists(keyFile) {
+		pv := privval.NewFilePV(derivedKey, keyFile, stateFile)
+		pv.Save()
+		logger.Info("generated private validator", zap.String("keyFile", keyFile), zap.String("stateFile", stateFile))
+		return pv, nil
+	}
+
+	pv := privval.LoadFilePV(keyFile, stateFile)
+	if bytes.Equal(pv.Key.PubKey.Bytes(), derivedKey.PubKey().Bytes()) {
+		logger.Info("loaded private validator", zap.String("keyFile", keyFile), zap.String("stateFile", stateFile))
+		return pv, nil
+	}
+
+	diskAddr := pv.GetAddress().String()
+	derivedAddr := derivedKey.PubKey().Address().String()
+
+	if pv.LastSignState.Height > 0 {
+		return nil, fmt.Errorf(
+			"priv_validator_key.json (address %s) does not match key derived from delegate private key (address %s); on-disk key has prior signing history at height %d, refusing to auto-regenerate to avoid double-sign risk — resolve manually",
+			diskAddr, derivedAddr, pv.LastSignState.Height,
+		)
+	}
+
+	logger.Warn("priv_validator_key.json does not match derived comet key; regenerating (no prior signing history)",
+		zap.String("disk_address", diskAddr),
+		zap.String("derived_address", derivedAddr),
+	)
+	pv = privval.NewFilePV(derivedKey, keyFile, stateFile)
+	pv.Save()
+	return pv, nil
 }
 
 func moduloPersistentPeers(nodeAddress string, persistentPeers string, groupSize int) string {

--- a/pkg/core/config/setup_test.go
+++ b/pkg/core/config/setup_test.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/privval"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 // test that moduloPersistentPeers returns the expected number of persistent peers
@@ -23,4 +27,71 @@ func TestModuloPersistentPeers(t *testing.T) {
 	}
 
 	require.NotEqual(t, nodes, nodes2)
+}
+
+func TestEnsurePrivValidator(t *testing.T) {
+	derivedKey := ed25519.GenPrivKey()
+	staleKey := ed25519.GenPrivKey()
+	logger := zaptest.NewLogger(t)
+
+	paths := func(t *testing.T) (string, string) {
+		dir := t.TempDir()
+		return filepath.Join(dir, "priv_validator_key.json"),
+			filepath.Join(dir, "priv_validator_state.json")
+	}
+
+	t.Run("generates when files are missing", func(t *testing.T) {
+		keyFile, stateFile := paths(t)
+
+		pv, err := ensurePrivValidator(logger, &derivedKey, keyFile, stateFile)
+		require.NoError(t, err)
+		require.Equal(t, derivedKey.PubKey().Bytes(), pv.Key.PubKey.Bytes())
+		require.FileExists(t, keyFile)
+		require.FileExists(t, stateFile)
+	})
+
+	t.Run("loads existing matching files unchanged", func(t *testing.T) {
+		keyFile, stateFile := paths(t)
+		seed := privval.NewFilePV(&derivedKey, keyFile, stateFile)
+		seed.Save()
+
+		pv, err := ensurePrivValidator(logger, &derivedKey, keyFile, stateFile)
+		require.NoError(t, err)
+		require.Equal(t, derivedKey.PubKey().Bytes(), pv.Key.PubKey.Bytes())
+		require.Equal(t, seed.GetAddress(), pv.GetAddress())
+	})
+
+	t.Run("regenerates mismatched files when never signed", func(t *testing.T) {
+		keyFile, stateFile := paths(t)
+		stale := privval.NewFilePV(&staleKey, keyFile, stateFile)
+		stale.Save()
+		require.NotEqual(t, derivedKey.PubKey().Bytes(), stale.Key.PubKey.Bytes())
+
+		pv, err := ensurePrivValidator(logger, &derivedKey, keyFile, stateFile)
+		require.NoError(t, err)
+		require.Equal(t, derivedKey.PubKey().Bytes(), pv.Key.PubKey.Bytes(),
+			"on-disk key should be regenerated to match the derived key")
+
+		// And on-disk persisted state should reflect the new key on next load.
+		reloaded := privval.LoadFilePV(keyFile, stateFile)
+		require.Equal(t, derivedKey.PubKey().Bytes(), reloaded.Key.PubKey.Bytes())
+	})
+
+	t.Run("refuses to regenerate mismatched files with signing history", func(t *testing.T) {
+		keyFile, stateFile := paths(t)
+		stale := privval.NewFilePV(&staleKey, keyFile, stateFile)
+		stale.LastSignState.Height = 42 // pretend this key has signed
+		stale.Save()
+
+		pv, err := ensurePrivValidator(logger, &derivedKey, keyFile, stateFile)
+		require.Error(t, err)
+		require.Nil(t, pv)
+		require.Contains(t, err.Error(), "double-sign")
+		require.Contains(t, err.Error(), "height 42")
+
+		// Files must remain untouched so the operator can investigate.
+		reloaded := privval.LoadFilePV(keyFile, stateFile)
+		require.Equal(t, staleKey.PubKey().Bytes(), reloaded.Key.PubKey.Bytes())
+		require.Equal(t, int64(42), reloaded.LastSignState.Height)
+	})
 }


### PR DESCRIPTION
## Summary

When an operator rotates `OPENAUDIO_DELEGATE_PRIVATE_KEY` without also regenerating their CometBFT key files, the node enters a broken state: it submits validator registration txs whose `PubKey` (derived from the current delegate key via `EthToCometKey`) doesn't hash to the `CometAddress` (loaded from the stale `priv_validator_key.json`). Block-validation rejects with `address does not match public key …` and the node never joins `core_validators`.

This change detects the mismatch on startup and self-heals it, but only when it's provably safe to do so.

## How it works

`ensurePrivValidator` in `pkg/core/config/setup.go` now:

1. If `priv_validator_key.json` is missing → generate from the derived key (unchanged behaviour).
2. If present and the on-disk pubkey matches the derived key → load and proceed (unchanged behaviour).
3. If present and **mismatched, with `LastSignState.Height == 0`** → regenerate in place and log a warning. Safe because the on-disk key has provably never signed a block, so swapping it can't create a double-sign.
4. If present and **mismatched, with `LastSignState.Height > 0`** → refuse to start and return a clear error pointing the operator at the conflict. We don't auto-fix this because we can't rule out a slashable history.

## Why this is the right call

The CometBFT key in OpenAudio is *derived* from the delegate private key, not operator-managed. The file is effectively a cache of a derived value, so re-deriving when it drifts is conceptually correct. The height-gated guard preserves the only invariant that matters: never silently switch a key that has signed blocks.

## Test plan

- [x] Added `TestEnsurePrivValidator` covering all four branches (missing / match / mismatch-safe / mismatch-with-history)
- [x] `go test ./pkg/core/config/...` passes
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)