### PR TITLE
fix(etl): drop incompatible developer_apps UNIQUE(address); auto-seed block in tests

### DIFF
--- a/pkg/etl/db/sql/migrations/0002_entity_manager_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0002_entity_manager_tables.up.sql
@@ -310,9 +310,14 @@ CREATE TABLE IF NOT EXISTS developer_apps (
   updated_at timestamp without time zone NOT NULL,
   description character varying(255),
   image_url character varying,
-  CONSTRAINT developer_apps_pkey PRIMARY KEY (address, txhash),
-  CONSTRAINT unique_developer_apps_address UNIQUE (address)
+  CONSTRAINT developer_apps_pkey PRIMARY KEY (address, txhash)
 );
+
+-- Intentionally no UNIQUE (address) constraint here: developer_app update
+-- and delete use the row-versioning pattern (INSERT a new row with the same
+-- address, mark the previous row is_current=false), which a UNIQUE (address)
+-- would block. Older databases that picked up the constraint before this
+-- migration land drop it in 0026_drop_developer_apps_unique_address.up.sql.
 
 -- grants
 

--- a/pkg/etl/db/sql/migrations/0026_drop_developer_apps_unique_address.down.sql
+++ b/pkg/etl/db/sql/migrations/0026_drop_developer_apps_unique_address.down.sql
@@ -1,0 +1,5 @@
+-- Re-adding the UNIQUE constraint is intentionally a no-op: the constraint
+-- it would restore is incompatible with the row-versioning writes the
+-- entity manager performs against developer_apps, so reverting this
+-- migration on a database that has accumulated >1 row per address would
+-- fail. Leave the down side empty.

--- a/pkg/etl/db/sql/migrations/0026_drop_developer_apps_unique_address.up.sql
+++ b/pkg/etl/db/sql/migrations/0026_drop_developer_apps_unique_address.up.sql
@@ -1,0 +1,11 @@
+-- developer_apps was created with both PRIMARY KEY (address, txhash) and
+-- UNIQUE (address). The second constraint contradicts the row-versioning
+-- pattern: developer_app_update and developer_app_delete both INSERT a new
+-- row with the same address (different txhash) after marking the previous
+-- row is_current = false. UNIQUE (address) blocks that INSERT.
+--
+-- Fresh databases skip the constraint via the updated 0002 migration.
+-- This migration drops it for databases that ran the old 0002.
+
+ALTER TABLE developer_apps
+  DROP CONSTRAINT IF EXISTS unique_developer_apps_address;

--- a/pkg/etl/processors/entity_manager/developer_app_test.go
+++ b/pkg/etl/processors/entity_manager/developer_app_test.go
@@ -124,6 +124,49 @@ func TestDeveloperAppUpdate_Success(t *testing.T) {
 	}
 }
 
+// TestDeveloperAppUpdate_RowVersioning asserts that update keeps the prior
+// row (with is_current = false) and appends a new is_current row. This is
+// the contract the rest of the developer_app code relies on, and it would
+// silently break if a UNIQUE (address) constraint were ever reintroduced on
+// the developer_apps table — see migration
+// 0026_drop_developer_apps_unique_address for context.
+func TestDeveloperAppUpdate_RowVersioning(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xappowner", "appowner")
+
+	createMeta := `{"address":"0xrowver","name":"V1"}`
+	mustHandle(t, DeveloperAppCreate(), buildParams(t, pool, EntityTypeDeveloperApp, ActionCreate, uid, 1, "0xAppOwner", createMeta))
+
+	updateMeta := `{"address":"0xrowver","name":"V2"}`
+	mustHandle(t, DeveloperAppUpdate(), buildParams(t, pool, EntityTypeDeveloperApp, ActionUpdate, uid, 1, "0xAppOwner", updateMeta))
+
+	var total, currentCount int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM developer_apps WHERE address = '0xrowver'").Scan(&total); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 rows for address after one update, got %d", total)
+	}
+	if err := pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM developer_apps WHERE address = '0xrowver' AND is_current = true").Scan(&currentCount); err != nil {
+		t.Fatalf("count current: %v", err)
+	}
+	if currentCount != 1 {
+		t.Fatalf("expected exactly 1 is_current row, got %d", currentCount)
+	}
+
+	var currentName string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT name FROM developer_apps WHERE address = '0xrowver' AND is_current = true").Scan(&currentName); err != nil {
+		t.Fatalf("query current: %v", err)
+	}
+	if currentName != "V2" {
+		t.Errorf("is_current name = %q, want V2", currentName)
+	}
+}
+
 func TestDeveloperAppUpdate_RejectsWrongOwner(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)

--- a/pkg/etl/processors/entity_manager/testutil_test.go
+++ b/pkg/etl/processors/entity_manager/testutil_test.go
@@ -15,8 +15,11 @@ import (
 )
 
 // seedBlock inserts the block referenced by buildParams (number=100) so
-// FK references from tracks/playlists/etc. resolve. Lives here so any test
-// that goes through buildParams can satisfy the blocks FK.
+// FK references from users/tracks/playlists/etc. resolve. setupTestDB
+// calls this automatically — every handler that writes a domain row ends
+// up touching the blocks FK, so making it implicit means no test needs to
+// remember the call. Kept exported for tests that need to re-seed after a
+// custom migration reset.
 func seedBlock(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	if _, err := pool.Exec(context.Background(), `
@@ -29,7 +32,7 @@ func seedBlock(t *testing.T, pool *pgxpool.Pool) {
 }
 
 // setupTestDB connects to a test Postgres, runs all ETL migrations (down then up),
-// and returns the pool and a cleanup function.
+// seeds the block referenced by buildParams, and returns the pool.
 //
 // Set ETL_TEST_DB_URL to override the default connection string.
 // Example: ETL_TEST_DB_URL="postgres://localhost:5432/etl_test?sslmode=disable"
@@ -52,6 +55,8 @@ func setupTestDB(t *testing.T) *pgxpool.Pool {
 		t.Fatalf("failed to connect to test db: %v", err)
 	}
 	t.Cleanup(func() { pool.Close() })
+
+	seedBlock(t, pool)
 
 	return pool
 }


### PR DESCRIPTION
## Summary

Cleans up two loose ends from the ETL parity initiative:

### 1. \`developer_apps\` UNIQUE(address) blocks row-versioning

The table shipped with both \`PRIMARY KEY (address, txhash)\` and \`UNIQUE (address)\`. The second constraint contradicts the row-versioning pattern the handlers use — \`developer_app_update\` and \`developer_app_delete\` both:

1. Mark the existing row \`is_current = false\`.
2. \`INSERT\` a new row with the same \`address\` but a new \`txhash\`.

\`UNIQUE (address)\` blocks step 2, so update/delete were silently broken on any database that ran the original \`0002\` migration. Fix:

- New migration \`0026_drop_developer_apps_unique_address\` drops the constraint on existing databases.
- The canonical \`0002\` no longer creates it, with a comment explaining why.
- \`TestDeveloperAppUpdate_RowVersioning\` locks in the behavior (two rows per address after one update, exactly one \`is_current = true\`, current name matches the update).

### 2. Tests missing \`seedBlock\` → \`users_blocknumber_fkey\` failures

Domain tables (\`users\`, \`tracks\`, \`playlists\`, …) all reference \`blocks(number)\` via the \`blocknumber\` FK. \`buildParams\` hard-codes block \`100\`. Without the matching \`blocks\` row, any handler that writes a domain row fails with \`users_blocknumber_fkey\` (and similar). Only a handful of tests called \`seedBlock(t, pool)\` explicitly; the rest — including the long-standing \`TestUserVerify_Metadata\` failure — were silently broken.

Fix: inline \`seedBlock(t, pool)\` into \`setupTestDB(t)\` so every DB-backed test gets the row implicitly. The helper stays exported for tests that need to re-seed after a custom migration reset.

## Test plan

- [x] \`go vet ./pkg/etl/...\` clean
- [x] \`go test ./processors/entity_manager/ -run "TestUserVerify_Metadata|TestUserVerify_Success|TestDeveloperAppUpdate_RowVersioning|TestDeveloperAppUpdate_Success|TestDeveloperAppDelete_Success" -count=1\` — all pass
- [x] Full \`go test ./processors/entity_manager/\` against a working \`ETL_TEST_DB_URL\` went from ~70 failures (all \`users_blocknumber_fkey\`) to **6** unrelated pre-existing failures: \`TestAssociatedWalletCreate_SOL_Success\` (sig verify), \`TestAssociatedWalletDelete_Success\`, \`TestDashboardWalletCreate_Success\`, \`TestDashboardWalletDelete_Success\`, \`TestSave_Album_Success\` (save_type mapping), \`TestTrackUpdate_NotFound\` (validation ordering). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)