### PR TITLE
feat(mediorum): cap ops pruning at the active-peer cursor + retention-gap signal

### DIFF
--- a/pkg/mediorum/crudr/client.go
+++ b/pkg/mediorum/crudr/client.go
@@ -167,6 +167,20 @@ func (p *PeerClient) doSweep(ctx context.Context) error {
 	limited := resp.Header.Get(SweepLimitedHeader) == "true"
 	lastScannedULID := resp.Header.Get(SweepLastScannedULIDHeader)
 
+	// Retention-gap signal: the peer is telling us our cursor is below its
+	// oldest available op (older ops were pruned). Advance across the gap
+	// explicitly so we don't re-request the pruned range forever. The
+	// first-contact guard (lastUlid != "") prevents a peer from setting our
+	// initial cursor to an arbitrary position; we also reject implausible
+	// advertised ULIDs.
+	gapMinULID := resp.Header.Get(HeaderAvailableMin)
+	if resp.Header.Get(HeaderRetentionGap) == "true" && gapMinULID != "" &&
+		lastUlid != "" && isValidPeerSuppliedULID(gapMinULID) && gapMinULID > lastUlid {
+		p.logger.Warn("retention gap: cursor below peer's available history; advancing across gap",
+			"peer", host, "local_cursor", lastUlid, "peer_available_min_ulid", gapMinULID)
+		lastUlid = gapMinULID
+	}
+
 	var ops []*Op
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&ops)

--- a/pkg/mediorum/crudr/sweep.go
+++ b/pkg/mediorum/crudr/sweep.go
@@ -1,6 +1,82 @@
 package crudr
 
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"go.uber.org/zap"
+)
+
 const (
 	SweepLastScannedULIDHeader = "X-Crud-Sweep-Last-Scanned-Ulid"
 	SweepLimitedHeader         = "X-Crud-Sweep-Limited"
+
+	// Retention-gap signal: when a caller sweeps from a cursor below this
+	// node's oldest available op (because older ops have been pruned),
+	// ServeCrudSweep advertises the lowest ULID still available so the peer
+	// can advance its cursor across the gap explicitly instead of silently
+	// skipping it. Clients that don't understand these headers ignore them.
+	HeaderRetentionGap = "X-Mediorum-Retention-Gap"
+	HeaderAvailableMin = "X-Mediorum-Available-Min-Ulid"
 )
+
+// Reject gap/cursor ULIDs outside a plausible wall-clock window: a far-future
+// or epoch value from a buggy or hostile peer must not move our cursor or pin
+// the prune floor.
+var (
+	gapULIDEarliestPlausibleTime = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	gapULIDClockSkewWindow       = 24 * time.Hour
+)
+
+func isValidPeerSuppliedULID(candidate string) bool {
+	id, err := ulid.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	t := ulid.Time(id.Time())
+	if t.Before(gapULIDEarliestPlausibleTime) {
+		return false
+	}
+	return t.Before(time.Now().Add(gapULIDClockSkewWindow))
+}
+
+// SlowestActivePeerCursor returns the lowest sweep-cursor ULID among currently
+// active peers, or "" when no safe floor can be established. The ops pruner
+// caps its delete cutoff at this value so it never removes ops a still-active
+// peer has not yet swept.
+//
+// The cursors table is shared with non-peer workers (e.g. qm_fix_truncated
+// records a CID under its own host) and decommissioned peers leave stale rows;
+// either would otherwise pin the floor. We consider only hosts in the active
+// peer set and ignore unparseable or implausible cursors. A peer that has no
+// cursor yet is handled by the retention-gap signal on its next sweep, not by
+// blocking pruning here.
+func (c *Crudr) SlowestActivePeerCursor(ctx context.Context) string {
+	c.mu.Lock()
+	active := make(map[string]bool, len(c.peerClients))
+	for _, p := range c.peerClients {
+		active[p.Host] = true
+	}
+	c.mu.Unlock()
+
+	var cursors []Cursor
+	if err := c.DB.WithContext(ctx).Find(&cursors).Error; err != nil {
+		c.logger.Warn("retention floor: failed to load cursors", zap.Error(err))
+		return ""
+	}
+
+	floor := ""
+	for _, cur := range cursors {
+		if cur.Host == c.host || !active[cur.Host] {
+			continue
+		}
+		if !isValidPeerSuppliedULID(cur.LastULID) {
+			continue
+		}
+		if floor == "" || cur.LastULID < floor {
+			floor = cur.LastULID
+		}
+	}
+	return floor
+}

--- a/pkg/mediorum/crudr/sweep_test.go
+++ b/pkg/mediorum/crudr/sweep_test.go
@@ -1,0 +1,76 @@
+package crudr
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/lifecycle"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+func mkULID(t *testing.T, at time.Time) string {
+	id, err := ulid.New(ulid.Timestamp(at), rand.Reader)
+	require.NoError(t, err)
+	return id.String()
+}
+
+func newCrudrWithPeers(t *testing.T, db *gorm.DB, peers ...string) *Crudr {
+	z := zap.NewNop()
+	return New("https://self.example", nil, peers, db,
+		lifecycle.NewLifecycle(context.Background(), "crudr floor test", z), z, nil)
+}
+
+// The prune floor is the slowest *active* peer's cursor. Self, decommissioned
+// (no-longer-active) peers, and non-peer worker rows (e.g. qm_fix_truncated,
+// which stores a CID under its own host) must not pin or lower it.
+func TestSlowestActivePeerCursor(t *testing.T) {
+	db := SetupTestDB()
+	c := newCrudrWithPeers(t, db, "https://peer-a.example", "https://peer-b.example")
+	require.NoError(t, db.Exec("TRUNCATE ops, cursors").Error)
+
+	now := time.Now()
+	low := mkULID(t, now.Add(-2*time.Hour))     // peer-a: slowest active
+	high := mkULID(t, now.Add(-1*time.Hour))    // peer-b
+	veryLow := mkULID(t, now.Add(-9*time.Hour)) // peer-c: decommissioned (inactive)
+
+	require.NoError(t, db.Create(&[]Cursor{
+		{Host: "https://peer-a.example", LastULID: low},
+		{Host: "https://peer-b.example", LastULID: high},
+		{Host: "https://peer-c.example", LastULID: veryLow},
+		{Host: "https://self.example", LastULID: mkULID(t, now)},
+		{Host: "qm_fix_truncated", LastULID: "QmSomeContentIdNotAUlid"},
+	}).Error)
+
+	require.Equal(t, low, c.SlowestActivePeerCursor(context.Background()))
+}
+
+func TestSlowestActivePeerCursor_NoActivePeers(t *testing.T) {
+	db := SetupTestDB()
+	c := newCrudrWithPeers(t, db)
+	require.NoError(t, db.Exec("TRUNCATE ops, cursors").Error)
+	require.NoError(t, db.Create(&Cursor{Host: "https://peer-a.example", LastULID: mkULID(t, time.Now())}).Error)
+
+	require.Equal(t, "", c.SlowestActivePeerCursor(context.Background()))
+}
+
+func TestSlowestActivePeerCursor_IgnoresImplausibleActiveCursor(t *testing.T) {
+	db := SetupTestDB()
+	c := newCrudrWithPeers(t, db, "https://peer-a.example", "https://peer-b.example")
+	require.NoError(t, db.Exec("TRUNCATE ops, cursors").Error)
+
+	now := time.Now()
+	good := mkULID(t, now.Add(-1*time.Hour))
+	farFuture := mkULID(t, now.Add(72*time.Hour)) // outside the clock-skew window
+
+	require.NoError(t, db.Create(&[]Cursor{
+		{Host: "https://peer-a.example", LastULID: good},
+		{Host: "https://peer-b.example", LastULID: farFuture},
+	}).Error)
+
+	require.Equal(t, good, c.SlowestActivePeerCursor(context.Background()))
+}

--- a/pkg/mediorum/server/ops_prune.go
+++ b/pkg/mediorum/server/ops_prune.go
@@ -55,6 +55,16 @@ func (ss *MediorumServer) pruneOps(ctx context.Context, retention time.Duration)
 	}
 	cutoffStr := cutoff.String()
 
+	// Never prune ops a still-active peer has not yet swept: cap the cutoff at
+	// the slowest active peer's cursor. Caught-up peers sweep ~every 10min, so
+	// their cursor sits far newer than the retention cutoff and this is a no-op;
+	// it only restricts pruning when an active peer is legitimately behind the
+	// window. A peer below the floor is told to advance via the retention-gap
+	// signal on the sweep endpoint.
+	if floor := ss.crud.SlowestActivePeerCursor(ctx); floor != "" && floor < cutoffStr {
+		cutoffStr = floor
+	}
+
 	var total int64
 	for {
 		res := ss.crud.DB.WithContext(ctx).Exec(

--- a/pkg/mediorum/server/serve_crud.go
+++ b/pkg/mediorum/server/serve_crud.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -54,6 +55,7 @@ type crudSweepResponse struct {
 	limited         bool
 	scannedRows     int
 	responseRows    int
+	gapMinULID      string
 }
 
 func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
@@ -75,12 +77,31 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	if sweep.limited {
 		c.Response().Header().Set(crudr.SweepLimitedHeader, "true")
 	}
+	if sweep.gapMinULID != "" {
+		c.Response().Header().Set(crudr.HeaderRetentionGap, "true")
+		c.Response().Header().Set(crudr.HeaderAvailableMin, sweep.gapMinULID)
+	}
 	return c.Blob(200, echo.MIMEApplicationJSONCharsetUTF8, sweep.body)
 }
 
 func (ss *MediorumServer) buildCrudSweepResponse(ctx context.Context, after string, maxResponseBytes int) (crudSweepResponse, error) {
 	if maxResponseBytes <= 0 {
 		maxResponseBytes = crudSweepMaxResponseBytes
+	}
+
+	var sweep crudSweepResponse
+
+	// Retention-gap detection: if the caller's cursor is below our oldest
+	// available op (older ops were pruned), advertise our lowest ULID so the
+	// peer advances across the gap explicitly instead of silently skipping it.
+	if after != "" {
+		var minOut sql.NullString
+		if err := ss.crud.DB.WithContext(ctx).Raw(`SELECT MIN(ulid) FROM ops`).Scan(&minOut).Error; err != nil {
+			return crudSweepResponse{}, err
+		}
+		if minOut.Valid && after < minOut.String {
+			sweep.gapMinULID = minOut.String
+		}
 	}
 
 	rows, err := ss.crud.DB.
@@ -96,7 +117,6 @@ func (ss *MediorumServer) buildCrudSweepResponse(ctx context.Context, after stri
 	}
 	defer rows.Close()
 
-	var sweep crudSweepResponse
 	var body bytes.Buffer
 	body.WriteByte('[')
 


### PR DESCRIPTION
## Summary

#325 prunes the crudr `ops` log purely by age (`ulid < now - retention`). As noted there, a still-active peer behind the retention window — or one bootstrapping from genesis — can silently skip the pruned range. This adds the protocol-level safety #325 deferred to this PR:

- **Active-peer cursor floor.** `pruneOps` caps its cutoff at `min(time_cutoff, slowest_active_peer_cursor)`, so it never deletes ops a still-active peer hasn't swept. Caught-up peers sweep ~every 10 min (cursor far newer than any month/year cutoff), so this is a no-op in steady state; it only restricts pruning when an active peer is legitimately behind. The floor ignores self, decommissioned peers, and non-peer worker rows (e.g. `qm_fix_truncated`, which stores a CID under its own host) that would otherwise pin it.
- **Retention-gap signal.** When a peer sweeps from a cursor below our oldest available op, `serveCrudSweep` advertises the lowest available ULID (`X-Mediorum-Retention-Gap` / `X-Mediorum-Available-Min-Ulid`). The peer advances its cursor across the gap explicitly instead of silently skipping it, with a first-contact guard and implausible-ULID rejection. Wire format unchanged; older clients ignore the headers.

Supersedes this PR's original contents (one-time dormant cleanup + opt-in per-table retention sweep), which #325 made redundant — the dormant cleanup never drained the actively-written tables, and #325's pruner replaces the opt-in sweep so there aren't two systems.

+121/−1 across four files plus a focused floor test.

## Tests

`go test ./pkg/mediorum/crudr` — `TestSlowestActivePeerCursor{,_NoActivePeers,_IgnoresImplausibleActiveCursor}` cover the floor: slowest active peer wins; self, decommissioned, non-peer, and implausible cursors are ignored. `go build ./pkg/mediorum/...` and `go vet` clean.