### PR TITLE
fix(etl): scan custom Postgres enums; dedup repeat tx inserts

### DIFF
--- a/pkg/etl/db/models.go
+++ b/pkg/etl/db/models.go
@@ -8,6 +8,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type AlbumPriceHistory struct {
+	PlaylistID      int32            `json:"playlist_id"`
+	Splits          []byte           `json:"splits"`
+	TotalPriceCents int64            `json:"total_price_cents"`
+	Blocknumber     int32            `json:"blocknumber"`
+	BlockTimestamp  pgtype.Timestamp `json:"block_timestamp"`
+	CreatedAt       pgtype.Timestamp `json:"created_at"`
+}
+
 type AssociatedWallet struct {
 	ID          int32            `json:"id"`
 	UserID      int32            `json:"user_id"`
@@ -221,7 +230,7 @@ type EtlStorageProof struct {
 	Cid             string           `json:"cid"`
 	ProofSignature  []byte           `json:"proof_signature"`
 	Proof           []byte           `json:"proof"`
-	Status          interface{}      `json:"status"`
+	Status          string           `json:"status"`
 	BlockHeight     int64            `json:"block_height"`
 	TxHash          string           `json:"tx_hash"`
 	CreatedAt       pgtype.Timestamp `json:"created_at"`
@@ -378,6 +387,13 @@ type NotificationSeen struct {
 	Txhash      pgtype.Text      `json:"txhash"`
 }
 
+type OauthRedirectUri struct {
+	ID          int32              `json:"id"`
+	ClientID    string             `json:"client_id"`
+	RedirectUri string             `json:"redirect_uri"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+}
+
 type Playlist struct {
 	Blockhash                   pgtype.Text      `json:"blockhash"`
 	Blocknumber                 pgtype.Int4      `json:"blocknumber"`
@@ -434,6 +450,14 @@ type PlaylistSeen struct {
 	Txhash      pgtype.Text      `json:"txhash"`
 }
 
+type PlaylistTrack struct {
+	PlaylistID int32              `json:"playlist_id"`
+	TrackID    int32              `json:"track_id"`
+	IsRemoved  bool               `json:"is_removed"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
 type Reaction struct {
 	ID            int32            `json:"id"`
 	ReactionValue int32            `json:"reaction_value"`
@@ -444,12 +468,17 @@ type Reaction struct {
 	Blocknumber   int32            `json:"blocknumber"`
 }
 
+type Remix struct {
+	ParentTrackID int32 `json:"parent_track_id"`
+	ChildTrackID  int32 `json:"child_track_id"`
+}
+
 type Repost struct {
 	Blockhash        pgtype.Text      `json:"blockhash"`
 	Blocknumber      pgtype.Int4      `json:"blocknumber"`
 	UserID           int32            `json:"user_id"`
 	RepostItemID     int32            `json:"repost_item_id"`
-	RepostType       interface{}      `json:"repost_type"`
+	RepostType       string           `json:"repost_type"`
 	IsCurrent        bool             `json:"is_current"`
 	IsDelete         bool             `json:"is_delete"`
 	CreatedAt        pgtype.Timestamp `json:"created_at"`
@@ -463,7 +492,7 @@ type Safe struct {
 	Blocknumber    pgtype.Int4      `json:"blocknumber"`
 	UserID         int32            `json:"user_id"`
 	SaveItemID     int32            `json:"save_item_id"`
-	SaveType       interface{}      `json:"save_type"`
+	SaveType       string           `json:"save_type"`
 	IsCurrent      bool             `json:"is_current"`
 	IsDelete       bool             `json:"is_delete"`
 	CreatedAt      pgtype.Timestamp `json:"created_at"`
@@ -477,10 +506,15 @@ type Share struct {
 	Blocknumber pgtype.Int4      `json:"blocknumber"`
 	UserID      int32            `json:"user_id"`
 	ShareItemID int32            `json:"share_item_id"`
-	ShareType   interface{}      `json:"share_type"`
+	ShareType   string           `json:"share_type"`
 	CreatedAt   pgtype.Timestamp `json:"created_at"`
 	Txhash      string           `json:"txhash"`
 	Slot        pgtype.Int4      `json:"slot"`
+}
+
+type Stem struct {
+	ParentTrackID int32 `json:"parent_track_id"`
+	ChildTrackID  int32 `json:"child_track_id"`
 }
 
 type Subscription struct {
@@ -567,6 +601,7 @@ type Track struct {
 	CoverOriginalArtist                pgtype.Text      `json:"cover_original_artist"`
 	IsOwnedByUser                      bool             `json:"is_owned_by_user"`
 	NoAiUse                            pgtype.Bool      `json:"no_ai_use"`
+	AccessAuthorities                  []string         `json:"access_authorities"`
 }
 
 type TrackDownload struct {
@@ -579,6 +614,16 @@ type TrackDownload struct {
 	Region        pgtype.Text      `json:"region"`
 	Country       pgtype.Text      `json:"country"`
 	CreatedAt     pgtype.Timestamp `json:"created_at"`
+}
+
+type TrackPriceHistory struct {
+	TrackID         int32            `json:"track_id"`
+	Splits          []byte           `json:"splits"`
+	TotalPriceCents int64            `json:"total_price_cents"`
+	Blocknumber     int32            `json:"blocknumber"`
+	BlockTimestamp  pgtype.Timestamp `json:"block_timestamp"`
+	CreatedAt       pgtype.Timestamp `json:"created_at"`
+	Access          string           `json:"access"`
 }
 
 type TrackRoute struct {

--- a/pkg/etl/db/reads.sql.go
+++ b/pkg/etl/db/reads.sql.go
@@ -1612,10 +1612,10 @@ where height = $3 and address = $4
 `
 
 type UpdateStorageProofStatusParams struct {
-	Status  interface{} `json:"status"`
-	Proof   []byte      `json:"proof"`
-	Height  int64       `json:"height"`
-	Address string      `json:"address"`
+	Status  string `json:"status"`
+	Proof   []byte `json:"proof"`
+	Height  int64  `json:"height"`
+	Address string `json:"address"`
 }
 
 func (q *Queries) UpdateStorageProofStatus(ctx context.Context, arg UpdateStorageProofStatusParams) error {

--- a/pkg/etl/db/sql/writes.sql
+++ b/pkg/etl/db/sql/writes.sql
@@ -4,8 +4,14 @@ values ($1, $2, $3, $4)
 on conflict do nothing;
 
 -- name: InsertTransaction :exec
+-- tx_hash is the content-addressable hash of the chain transaction, which the
+-- migration declares UNIQUE. The indexer can occasionally re-deliver the same
+-- chain tx (see the prefetcher re-delivery issue tracked separately) — when
+-- that happens the payload is identical by construction, so DO NOTHING is the
+-- correct dedup. DO UPDATE would have nothing to update.
 insert into etl_transactions (tx_hash, block_height, tx_index, tx_type, address, created_at)
-values ($1, $2, $3, $4, $5, $6);
+values ($1, $2, $3, $4, $5, $6)
+on conflict (tx_hash) do nothing;
 
 -- name: InsertBlock :exec
 insert into etl_blocks (proposer_address, block_height, block_time)

--- a/pkg/etl/db/sqlc.yaml
+++ b/pkg/etl/db/sqlc.yaml
@@ -14,6 +14,22 @@ sql:
             go_type:
               import: "time"
               type: "time.Time"
+          # Map custom ENUM types to string. Without these overrides sqlc
+          # generates `interface{}` for each enum column, which pgx then
+          # cannot scan back into (`cannot scan unknown type (OID NNNNN) in
+          # text format into *interface {}`). Every caller already passes
+          # plain string literals like "pass" / "unresolved" / "track", so
+          # `string` is a drop-in fit and silently fixes reads too.
+          - db_type: "etl_proof_status"
+            go_type: "string"
+          - db_type: "reposttype"
+            go_type: "string"
+          - db_type: "savetype"
+            go_type: "string"
+          - db_type: "sharetype"
+            go_type: "string"
+          - db_type: "usdc_purchase_access_type"
+            go_type: "string"
 
   - engine: "postgresql"
     queries: "sql/writes.sql"
@@ -29,3 +45,13 @@ sql:
             go_type:
               import: "time"
               type: "time.Time"
+          - db_type: "etl_proof_status"
+            go_type: "string"
+          - db_type: "reposttype"
+            go_type: "string"
+          - db_type: "savetype"
+            go_type: "string"
+          - db_type: "sharetype"
+            go_type: "string"
+          - db_type: "usdc_purchase_access_type"
+            go_type: "string"

--- a/pkg/etl/db/writes.sql.go
+++ b/pkg/etl/db/writes.sql.go
@@ -284,7 +284,7 @@ type InsertStorageProofParams struct {
 	Cid             string           `json:"cid"`
 	ProofSignature  []byte           `json:"proof_signature"`
 	Proof           []byte           `json:"proof"`
-	Status          interface{}      `json:"status"`
+	Status          string           `json:"status"`
 	BlockHeight     int64            `json:"block_height"`
 	TxHash          string           `json:"tx_hash"`
 	CreatedAt       pgtype.Timestamp `json:"created_at"`
@@ -333,6 +333,7 @@ func (q *Queries) InsertStorageProofVerification(ctx context.Context, arg Insert
 const insertTransaction = `-- name: InsertTransaction :exec
 insert into etl_transactions (tx_hash, block_height, tx_index, tx_type, address, created_at)
 values ($1, $2, $3, $4, $5, $6)
+on conflict (tx_hash) do nothing
 `
 
 type InsertTransactionParams struct {
@@ -344,6 +345,11 @@ type InsertTransactionParams struct {
 	CreatedAt   pgtype.Timestamp `json:"created_at"`
 }
 
+// tx_hash is the content-addressable hash of the chain transaction, which the
+// migration declares UNIQUE. The indexer can occasionally re-deliver the same
+// chain tx (see the prefetcher re-delivery issue tracked separately) — when
+// that happens the payload is identical by construction, so DO NOTHING is the
+// correct dedup. DO UPDATE would have nothing to update.
 func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionParams) error {
 	_, err := q.db.Exec(ctx, insertTransaction,
 		arg.TxHash,


### PR DESCRIPTION
## Summary

Two production-run-observed bugs from the local-vs-prod-RPC indexing session:

### 1. Custom-enum scan failure (silent data loss on storage proofs)

`etl_storage_proofs.status` is the Postgres ENUM \`etl_proof_status\` (\`'unresolved' | 'pass' | 'fail'\`). sqlc had no override for the type, so it generated the field as \`Status interface{}\` — pgx then errors trying to scan the enum text back into \`*interface{}\`:

\`\`\`
error getting storage proofs for height N:
can't scan into dest[7]: cannot scan unknown type (OID 16396)
in text format into *interface {}
\`\`\`

Fires on every block carrying a storage proof (~1 per proof-bearing block, ~1,200 events over a 5h53m run). The consensus-update path silently fails because the read never returns rows.

Same latent shape exists for the other four custom enums (\`reposttype\`, \`savetype\`, \`sharetype\`, \`usdc_purchase_access_type\`) — also generated as \`interface{}\`, just not exercised by current read queries. Fix all five at the source.

**Change**: add sqlc.yaml \`overrides\` mapping each enum \`db_type\` to Go \`string\`. Every call site already passes plain string literals (\`\"pass\"\`, \`\"unresolved\"\`, \`\"track\"\`, …), so it's a drop-in change with no Go call-site edits.

### 2. Duplicate `etl_transactions_tx_hash_idx` violations on re-delivered txs

\`etl_transactions.tx_hash\` is UNIQUE. The CometBFT prefetcher occasionally re-delivers the same chain tx (~6% of inserts at head over 5h; tracked separately — investigation deferred). On the second delivery, the bare INSERT fired SQLSTATE 23505 and ERROR-logged ~600 times.

**Triple-checked semantics before applying:**

| Table | UNIQUE? | Action |
|---|---|---|
| `etl_transactions` | `UNIQUE (tx_hash)` | **Add `ON CONFLICT (tx_hash) DO NOTHING`** (this PR) |
| `etl_blocks` | none | No-op: nothing to conflict on; tracked separately |
| `etl_plays` | none | No-op: nothing to conflict on; tracked separately |
| `etl_manage_entities` | none | No-op: nothing to conflict on; tracked separately |

`tx_hash` is content-addressable on Audius/CometBFT (mempool dedups identical txs), so the second row is identical by construction — `DO NOTHING` is the correct semantic; `DO UPDATE` would have nothing meaningful to update.

The other three tables silently accumulate duplicate rows under the same re-delivery condition because they have no UNIQUE constraints — that gap is real but the fix is either (a) the deferred prefetcher re-delivery work or (b) a separate migration adding composite-unique constraints with careful thought. Not papered over with a no-op `ON CONFLICT` clause.

## Test plan

- [x] \`go build ./...\` and \`go vet ./...\` clean
- [x] \`sqlc generate\` regenerates: `models.go` now has `string` for `Status`/`RepostType`/`SaveType`/`ShareType`; no more `interface{}` fields
- [x] Targeted entity_manager tests pass: \`TestTrackCreate_Success\`, \`TestPlaylistCreate_Success\`, \`TestFollow_Success\`, \`TestUserVerify_Metadata\`, \`TestDeveloperAppUpdate_Success\`, \`TestDeveloperAppUpdate_RowVersioning\`
- [x] Full entity_manager sweep: only the 6 pre-existing failures from #302 remain (sig-verify, save_type mapping, validation ordering — all unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)