### PR TITLE
fix(etl): four prod-clone-run bugs + #307 test fixes folded in

### DIFF
--- a/pkg/etl/processors/entity_manager/associated_wallet.go
+++ b/pkg/etl/processors/entity_manager/associated_wallet.go
@@ -15,8 +15,8 @@ func (h *associatedWalletCreateHandler) EntityType() string { return EntityTypeA
 func (h *associatedWalletCreateHandler) Action() string     { return ActionCreate }
 
 func (h *associatedWalletCreateHandler) Handle(ctx context.Context, params *Params) error {
-	wallet := strings.ToLower(params.MetadataString("wallet"))
 	chain := params.MetadataString("chain")
+	wallet := canonicalizeWallet(params.MetadataString("wallet"), chain)
 
 	if err := validateAssociatedWalletCreate(ctx, params, wallet, chain); err != nil {
 		return err
@@ -37,10 +37,11 @@ func (h *associatedWalletCreateHandler) Handle(ctx context.Context, params *Para
 		return err
 	}
 
+	// blockhash is NOT NULL on prod's associated_wallets table.
 	_, err = params.DBTX.Exec(ctx, `
-		INSERT INTO associated_wallets (user_id, wallet, chain, is_current, is_delete, blocknumber, created_at, updated_at)
-		VALUES ($1, $2, $3, true, false, $4, $5, $5)
-	`, params.UserID, wallet, chain, params.BlockNumber, params.BlockTime)
+		INSERT INTO associated_wallets (user_id, wallet, chain, is_current, is_delete, blockhash, blocknumber, created_at, updated_at)
+		VALUES ($1, $2, $3, true, false, $4, $5, $6, $6)
+	`, params.UserID, wallet, chain, params.BlockHash, params.BlockNumber, params.BlockTime)
 	return err
 }
 
@@ -84,6 +85,20 @@ func verifyAssociatedWalletSignature(params *Params, wallet, chain string) error
 		}
 	}
 	return nil
+}
+
+// canonicalizeWallet normalizes a wallet address for storage and lookup.
+// ETH (hex) addresses are case-insensitive; we canonicalize to lowercase so
+// that the same wallet typed in any case maps to a single row. Solana
+// addresses are base58 — case-sensitive by construction — and MUST be
+// preserved verbatim (`L`→`l` would produce a base58-invalid character).
+// When the chain isn't known (e.g., delete tx that omits "chain"), the
+// `0x` prefix is a reliable ETH discriminator.
+func canonicalizeWallet(wallet, chain string) string {
+	if chain == "eth" || strings.HasPrefix(wallet, "0x") || strings.HasPrefix(wallet, "0X") {
+		return strings.ToLower(wallet)
+	}
+	return wallet
 }
 
 // verifySolSignature verifies an ed25519 signature from a Solana wallet.
@@ -154,16 +169,22 @@ func (h *associatedWalletDeleteHandler) EntityType() string { return EntityTypeA
 func (h *associatedWalletDeleteHandler) Action() string     { return ActionDelete }
 
 func (h *associatedWalletDeleteHandler) Handle(ctx context.Context, params *Params) error {
-	wallet := strings.ToLower(params.MetadataString("wallet"))
+	// Delete tx may not include `chain` in metadata (chain is implicit in the
+	// stored row), so canonicalize off the wallet format: `0x`-prefixed → ETH
+	// hex → lowercase; otherwise (Solana base58) preserve case.
 	chain := params.MetadataString("chain")
+	wallet := canonicalizeWallet(params.MetadataString("wallet"), chain)
 
 	if err := validateAssociatedWalletDelete(ctx, params, wallet, chain); err != nil {
 		return err
 	}
 
+	// Match validateAssociatedWalletDelete's lookup (no chain filter) — the
+	// (user_id, wallet) pair already uniquely identifies the row, and the
+	// delete metadata isn't required to repeat `chain`.
 	_, err := params.DBTX.Exec(ctx,
-		"UPDATE associated_wallets SET is_current = false, is_delete = true, updated_at = $1 WHERE user_id = $2 AND wallet = $3 AND chain = $4 AND is_current = true",
-		params.BlockTime, params.UserID, wallet, chain)
+		"UPDATE associated_wallets SET is_current = false, is_delete = true, updated_at = $1 WHERE user_id = $2 AND wallet = $3 AND is_current = true",
+		params.BlockTime, params.UserID, wallet)
 	return err
 }
 

--- a/pkg/etl/processors/entity_manager/dashboard_wallet_test.go
+++ b/pkg/etl/processors/entity_manager/dashboard_wallet_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -57,8 +58,9 @@ func TestDashboardWalletCreate_Success(t *testing.T) {
 	mustHandle(t, DashboardWalletCreate(), params)
 
 	var walletUserID int64
+	// Handler stores ETH addresses lowercased (canonical form); match that.
 	err := pool.QueryRow(context.Background(),
-		"SELECT user_id FROM dashboard_wallet_users WHERE wallet = $1", dashAddr).Scan(&walletUserID)
+		"SELECT user_id FROM dashboard_wallet_users WHERE wallet = $1", strings.ToLower(dashAddr)).Scan(&walletUserID)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -138,7 +140,7 @@ func TestDashboardWalletDelete_Success(t *testing.T) {
 
 	var isDelete bool
 	err := pool.QueryRow(context.Background(),
-		"SELECT is_delete FROM dashboard_wallet_users WHERE wallet = $1", dashAddr).Scan(&isDelete)
+		"SELECT is_delete FROM dashboard_wallet_users WHERE wallet = $1", strings.ToLower(dashAddr)).Scan(&isDelete)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}

--- a/pkg/etl/processors/entity_manager/event_create.go
+++ b/pkg/etl/processors/entity_manager/event_create.go
@@ -26,14 +26,17 @@ func (h *eventCreateHandler) Handle(ctx context.Context, params *Params) error {
 		eventDataJSON, _ = json.Marshal(ed)
 	}
 
+	// blockhash is NOT NULL on production's `events` table (our migration
+	// has a DEFAULT '' that masks the omission locally — see #305 follow-up).
+	// Always pass params.BlockHash so we don't rely on the default.
 	_, err := params.DBTX.Exec(ctx, `
 		INSERT INTO events (
 			event_id, event_type, user_id, entity_type, entity_id,
 			end_date, event_data, is_deleted,
-			created_at, updated_at, txhash, blocknumber
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, false, $8, $8, $9, $10)
+			created_at, updated_at, txhash, blockhash, blocknumber
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, false, $8, $8, $9, $10, $11)
 	`, params.EntityID, eventType, params.UserID, entityType, entityID,
-		endDateStr, eventDataJSON, params.BlockTime, params.TxHash, params.BlockNumber)
+		endDateStr, eventDataJSON, params.BlockTime, params.TxHash, params.BlockHash, params.BlockNumber)
 	return err
 }
 

--- a/pkg/etl/processors/entity_manager/muted_user.go
+++ b/pkg/etl/processors/entity_manager/muted_user.go
@@ -65,14 +65,15 @@ func (h *unmuteUserHandler) Handle(ctx context.Context, params *Params) error {
 // --- shared ---
 
 func insertMutedUser(ctx context.Context, params *Params, isDelete bool) error {
+	// blockhash is NOT NULL on prod's muted_users table.
 	_, err := params.DBTX.Exec(ctx, `
 		INSERT INTO muted_users (
 			muted_user_id, user_id, is_delete,
-			created_at, updated_at, txhash, blocknumber
-		) VALUES ($1, $2, $3, $4, $4, $5, $6)
+			created_at, updated_at, txhash, blockhash, blocknumber
+		) VALUES ($1, $2, $3, $4, $4, $5, $6, $7)
 		ON CONFLICT (muted_user_id, user_id)
-		DO UPDATE SET is_delete = $3, updated_at = $4, txhash = $5, blocknumber = $6
-	`, params.EntityID, params.UserID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
+		DO UPDATE SET is_delete = $3, updated_at = $4, txhash = $5, blockhash = $6, blocknumber = $7
+	`, params.EntityID, params.UserID, isDelete, params.BlockTime, params.TxHash, params.BlockHash, params.BlockNumber)
 	return err
 }
 

--- a/pkg/etl/processors/entity_manager/social_follow.go
+++ b/pkg/etl/processors/entity_manager/social_follow.go
@@ -84,11 +84,15 @@ func insertFollow(ctx context.Context, params *Params, isDelete bool) error {
 		return err
 	}
 
+	// PK is (follower_user_id, followee_user_id, txhash); re-delivery of the
+	// same chain tx would otherwise 23505 on the PK. Same txhash means
+	// identical row content, so DO NOTHING is correct.
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO follows (
 			follower_user_id, followee_user_id, is_current, is_delete,
 			created_at, txhash, blocknumber
 		) VALUES ($1, $2, true, $3, $4, $5, $6)
+		ON CONFLICT (follower_user_id, followee_user_id, txhash) DO NOTHING
 	`, params.UserID, params.EntityID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
 	if err != nil {
 		return err
@@ -101,11 +105,13 @@ func insertFollow(ctx context.Context, params *Params, isDelete bool) error {
 	if err != nil {
 		return err
 	}
+	// PK is (subscriber_id, user_id, txhash); same DO NOTHING rationale.
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO subscriptions (
 			subscriber_id, user_id, is_current, is_delete,
 			created_at, txhash, blocknumber
 		) VALUES ($1, $2, true, $3, $4, $5, $6)
+		ON CONFLICT (subscriber_id, user_id, txhash) DO NOTHING
 	`, params.UserID, params.EntityID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }

--- a/pkg/etl/processors/entity_manager/social_playlist_test.go
+++ b/pkg/etl/processors/entity_manager/social_playlist_test.go
@@ -83,3 +83,37 @@ func TestSave_Album_Success(t *testing.T) {
 		t.Errorf("save_type = %q, want album", saveType)
 	}
 }
+
+// TestSave_Playlist_WhenTrackIdCollides asserts that a Playlist save resolves
+// to save_type="playlist" even when a track happens to exist with the same
+// numeric id (track_id and playlist_id are independent namespaces — collisions
+// are real in prod data). Without the guard, `inferSaveType` would check
+// tracks first and write `save_type='track'` for the playlist save.
+func TestSave_Playlist_WhenTrackIdCollides(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 100)
+	collisionID := int64(TrackIDOffset + 4281) // same id used as both track + playlist
+	seedUser(t, pool, uid, "0xcollider", "collider")
+	seedUser(t, pool, UserIDOffset+101, "0xowner1", "owner1")
+	seedUser(t, pool, UserIDOffset+102, "0xowner2", "owner2")
+	// Seed a TRACK with the same numeric id as the playlist we'll save
+	seedTrack(t, pool, collisionID, UserIDOffset+101)
+	// Seed the playlist (non-album) the chain tx is about
+	seedPlaylist(t, pool, collisionID, UserIDOffset+102)
+
+	// Chain tx mimics observed prod tx: entity_type=Playlist, no "type" in metadata
+	meta := `{"is_save_of_repost":false}`
+	params := buildParams(t, pool, EntityTypePlaylist, ActionSave, uid, collisionID, "0xCollider", meta)
+	mustHandle(t, Save(), params)
+
+	var saveType string
+	err := pool.QueryRow(context.Background(),
+		"SELECT save_type::text FROM saves WHERE user_id = $1 AND save_item_id = $2 AND is_current = true",
+		uid, collisionID).Scan(&saveType)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if saveType != "playlist" {
+		t.Errorf("save_type = %q, want playlist (track with same id must not win)", saveType)
+	}
+}

--- a/pkg/etl/processors/entity_manager/social_repost.go
+++ b/pkg/etl/processors/entity_manager/social_repost.go
@@ -25,13 +25,7 @@ func validateRepost(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	repostType := repostTypeFromEntityType(params.EntityType)
-	if repostType == "" {
-		repostType = repostTypeFromEntityType(params.MetadataString("type"))
-	}
-	if repostType == "" {
-		repostType = inferRepostType(ctx, params.DBTX, params.EntityID)
-	}
+	repostType := resolveRepostType(ctx, params)
 	if repostType == "" {
 		return NewValidationError("cannot determine repost type for entity %d", params.EntityID)
 	}
@@ -68,13 +62,7 @@ func validateUnrepost(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	repostType := repostTypeFromEntityType(params.EntityType)
-	if repostType == "" {
-		repostType = repostTypeFromEntityType(params.MetadataString("type"))
-	}
-	if repostType == "" {
-		repostType = inferRepostType(ctx, params.DBTX, params.EntityID)
-	}
+	repostType := resolveRepostType(ctx, params)
 	if repostType == "" {
 		return NewValidationError("cannot determine repost type for entity %d", params.EntityID)
 	}
@@ -91,13 +79,7 @@ func validateUnrepost(ctx context.Context, params *Params) error {
 // --- shared ---
 
 func insertRepost(ctx context.Context, params *Params, isDelete bool) error {
-	repostType := repostTypeFromEntityType(params.EntityType)
-	if repostType == "" {
-		repostType = repostTypeFromEntityType(params.MetadataString("type"))
-	}
-	if repostType == "" {
-		repostType = inferRepostType(ctx, params.DBTX, params.EntityID)
-	}
+	repostType := resolveRepostType(ctx, params)
 	isRepostOfRepost := params.MetadataBoolOr("is_repost_of_repost", false)
 
 	// Mark existing repost rows as not current
@@ -108,11 +90,16 @@ func insertRepost(ctx context.Context, params *Params, isDelete bool) error {
 		return err
 	}
 
+	// PK is (user_id, repost_item_id, repost_type, txhash); re-delivery of
+	// the same chain tx would otherwise 23505 on the PK. Same txhash means
+	// identical row content by construction, so DO NOTHING is the correct
+	// dedup.
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO reposts (
 			user_id, repost_item_id, repost_type, is_current, is_delete, is_repost_of_repost,
 			created_at, txhash, blocknumber
 		) VALUES ($1, $2, $3::reposttype, true, $4, $5, $6, $7, $8)
+		ON CONFLICT (user_id, repost_item_id, repost_type, txhash) DO NOTHING
 	`, params.UserID, params.EntityID, repostType, isDelete, isRepostOfRepost, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }
@@ -123,6 +110,29 @@ func repostExists(ctx context.Context, dbtx db.DBTX, userID, itemID int64, repos
 		"SELECT EXISTS(SELECT 1 FROM reposts WHERE user_id = $1 AND repost_item_id = $2 AND repost_type = $3::reposttype AND is_current = true AND is_delete = false)",
 		userID, itemID, repostType).Scan(&exists)
 	return exists, err
+}
+
+// resolveRepostType — same priority as resolveSaveType (metadata.type wins,
+// chain entity_type next with is_album disambiguation for "Playlist", DB
+// inference last). See social_save.go:resolveSaveType for full rationale.
+// Crucially: when entity_type is "Playlist" we never cross over to "track"
+// even if a same-id track exists.
+func resolveRepostType(ctx context.Context, params *Params) string {
+	if t := repostTypeFromEntityType(params.MetadataString("type")); t != "" {
+		return t
+	}
+	switch repostTypeFromEntityType(params.EntityType) {
+	case "track":
+		return "track"
+	case "album":
+		return "album"
+	case "playlist":
+		if isAlbumPlaylist(ctx, params.DBTX, params.EntityID) {
+			return "album"
+		}
+		return "playlist"
+	}
+	return inferRepostType(ctx, params.DBTX, params.EntityID)
 }
 
 func repostTypeFromEntityType(entityType string) string {

--- a/pkg/etl/processors/entity_manager/social_save.go
+++ b/pkg/etl/processors/entity_manager/social_save.go
@@ -25,14 +25,7 @@ func validateSave(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
 	}
-	// Use tx entity_type first (e.g. "Track", "Playlist"), then metadata, then DB inference
-	saveType := saveTypeFromEntityType(params.EntityType)
-	if saveType == "" {
-		saveType = saveTypeFromEntityType(params.MetadataString("type"))
-	}
-	if saveType == "" {
-		saveType = inferSaveType(ctx, params.DBTX, params.EntityID)
-	}
+	saveType := resolveSaveType(ctx, params)
 	if saveType == "" {
 		return NewValidationError("cannot determine save type for entity %d", params.EntityID)
 	}
@@ -92,13 +85,7 @@ func validateUnsave(ctx context.Context, params *Params) error {
 // --- shared ---
 
 func insertSave(ctx context.Context, params *Params, isDelete bool) error {
-	saveType := saveTypeFromEntityType(params.EntityType)
-	if saveType == "" {
-		saveType = saveTypeFromEntityType(params.MetadataString("type"))
-	}
-	if saveType == "" {
-		saveType = inferSaveType(ctx, params.DBTX, params.EntityID)
-	}
+	saveType := resolveSaveType(ctx, params)
 	isSaveOfRepost := params.MetadataBoolOr("is_save_of_repost", false)
 
 	// Mark existing save rows as not current
@@ -109,11 +96,16 @@ func insertSave(ctx context.Context, params *Params, isDelete bool) error {
 		return err
 	}
 
+	// PK is (user_id, save_item_id, save_type, txhash); re-delivery of the
+	// same chain tx (prefetcher anomaly) would otherwise 23505 on the PK.
+	// Same txhash means identical row content by construction, so DO NOTHING
+	// is the correct dedup.
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO saves (
 			user_id, save_item_id, save_type, is_current, is_delete, is_save_of_repost,
 			created_at, txhash, blocknumber
 		) VALUES ($1, $2, $3::savetype, true, $4, $5, $6, $7, $8)
+		ON CONFLICT (user_id, save_item_id, save_type, txhash) DO NOTHING
 	`, params.UserID, params.EntityID, saveType, isDelete, isSaveOfRepost, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }
@@ -124,6 +116,50 @@ func saveExists(ctx context.Context, dbtx db.DBTX, userID, itemID int64, saveTyp
 		"SELECT EXISTS(SELECT 1 FROM saves WHERE user_id = $1 AND save_item_id = $2 AND save_type = $3::savetype AND is_current = true AND is_delete = false)",
 		userID, itemID, saveType).Scan(&exists)
 	return exists, err
+}
+
+// resolveSaveType determines the save_type for the saves row.
+//
+// Priority:
+//  1. Metadata `type` if explicitly set ("track" / "playlist" / "album").
+//  2. Chain entity_type — but the chain only distinguishes "Track" vs
+//     "Playlist" (albums are stored as playlists with is_album=true), so we
+//     disambiguate playlist-vs-album by reading playlists.is_album. We
+//     deliberately do NOT fall back to track inference here: the chain said
+//     Playlist, so a same-id track is unrelated.
+//  3. Pure DB inference when neither metadata nor entity_type tells us.
+//
+// The "do not cross over to track when entity_type is Playlist" rule
+// matters: track_id and playlist_id namespaces can collide, and treating a
+// Playlist save as a Track save (via inferSaveType, which checks tracks
+// first) writes the wrong row — observed in production.
+func resolveSaveType(ctx context.Context, params *Params) string {
+	if t := saveTypeFromEntityType(params.MetadataString("type")); t != "" {
+		return t
+	}
+	switch saveTypeFromEntityType(params.EntityType) {
+	case "track":
+		return "track"
+	case "album":
+		return "album"
+	case "playlist":
+		if isAlbumPlaylist(ctx, params.DBTX, params.EntityID) {
+			return "album"
+		}
+		return "playlist"
+	}
+	return inferSaveType(ctx, params.DBTX, params.EntityID)
+}
+
+// isAlbumPlaylist returns true if the given playlist_id is currently flagged
+// as an album. Used to disambiguate playlist-vs-album when the chain
+// entity_type is "Playlist".
+func isAlbumPlaylist(ctx context.Context, dbtx db.DBTX, playlistID int64) bool {
+	var isAlbum bool
+	_ = dbtx.QueryRow(ctx,
+		"SELECT is_album FROM playlists WHERE playlist_id = $1 AND is_current = true LIMIT 1",
+		playlistID).Scan(&isAlbum)
+	return isAlbum
 }
 
 func saveTypeFromEntityType(entityType string) string {

--- a/pkg/etl/processors/entity_manager/social_share.go
+++ b/pkg/etl/processors/entity_manager/social_share.go
@@ -27,10 +27,14 @@ func (h *shareHandler) Handle(ctx context.Context, params *Params) error {
 		return err
 	}
 
+	// PK is (user_id, share_item_id, share_type, txhash); re-delivery of the
+	// same chain tx would otherwise 23505 on the PK. Same txhash = identical
+	// row content, so DO NOTHING is correct.
 	_, err := params.DBTX.Exec(ctx, `
 		INSERT INTO shares (
 			user_id, share_item_id, share_type, created_at, txhash, blocknumber
 		) VALUES ($1, $2, $3::sharetype, $4, $5, $6)
+		ON CONFLICT (user_id, share_item_id, share_type, txhash) DO NOTHING
 	`, params.UserID, params.EntityID, shareType, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }

--- a/pkg/etl/processors/entity_manager/track_update_test.go
+++ b/pkg/etl/processors/entity_manager/track_update_test.go
@@ -33,7 +33,9 @@ func TestTrackUpdate_NotFound(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)
 	tid := int64(TrackIDOffset + 99)
-	seedUser(t, pool, uid, "0xo", "o")
+	// Seed user wallet matches the signer so ValidateSigner passes and the
+	// test reaches the track-existence check it actually means to exercise.
+	seedUser(t, pool, uid, "0xowner", "o")
 	params := buildParams(t, pool, EntityTypeTrack, ActionUpdate, uid, tid, "0xOwner", `{"title":"X"}`)
 	mustReject(t, TrackUpdate(), params, "does not exist")
 }

--- a/pkg/etl/processors/entity_manager/user_update.go
+++ b/pkg/etl/processors/entity_manager/user_update.go
@@ -165,15 +165,25 @@ func updateUser(ctx context.Context, params *Params) error {
 	return err
 }
 
-// mergeNullStr returns the metadata value if present, otherwise the existing value.
-// If metadata provides an empty string, it clears the field (returns nil).
+// mergeNullStr returns the metadata value if present and non-empty;
+// otherwise it preserves the existing value.
+//
+// The chain convention is "empty string = no change". Treating "" as "clear
+// the field" caused real data corruption against production data: User
+// Update txs with `"handle":""` (meaning the client didn't want to change
+// handle) were wiping `users.handle` to NULL while leaving `handle_lc`
+// populated, producing an inconsistent row. Matches the prod indexer's
+// behavior.
+//
+// Callers that genuinely need to clear a field on chain-supplied null
+// should check for that explicitly upstream of this helper.
 func mergeNullStr(p *Params, key string, existing *string) *string {
 	if _, ok := p.Metadata[key]; !ok {
 		return existing
 	}
 	s := p.MetadataString(key)
 	if s == "" {
-		return nil
+		return existing
 	}
 	return &s
 }


### PR DESCRIPTION
## Summary

Findings from running the indexer for ~3h against a production database clone (audius_discovery on 104.198.147.20) and diffing the result against the live production read replica. Bundles fixes for four prod-only bugs that only surface against populated/prod-schema data, plus the five non-regression fixes from #307 (which this PR supersedes — see "Why this supersedes #307" below).

## Bugs and fixes

### 1. `save_type` / `repost_type` mistyped on entity-id collisions — REGRESSION from PR #307

When chain entity_type is `"Playlist"`, PR #307's `resolveSaveType` / `resolveRepostType` fell through to `inferSaveType`, which ranks tracks first. Whenever a track exists with the same numeric id as the playlist being saved (track_id and playlist_id are independent namespaces — collisions are real in prod), the save was written with `save_type='track'` instead of `'playlist'`.

**Observed against prod**:
- chain tx: Playlist/Save, entity_id=4281, metadata=`{"is_save_of_repost":false}`
- replica row: `save_type='playlist'` ✓
- clone row (pre-fix): `save_type='track'` ✗
- track 4281 and playlist 4281 are unrelated entities by different artists
- ~1% of our 1,437 saves had this wrong type

**Fix**: `resolveSaveType` / `resolveRepostType` only disambiguate `"Playlist"` via `playlists.is_album` — they never cross over to `"track"`. New `TestSave_Playlist_WhenTrackIdCollides` locks this in: seeds both a track and a playlist with the same id and asserts the Playlist save writes `save_type='playlist'`.

### 2. `mergeNullStr` empty-string semantics

Chain User Update txs commonly include `"handle":""` when the client doesn't want to change handle. The old `mergeNullStr` treated `""` as "clear the field" → wiped `users.handle` to NULL while leaving `handle_lc` populated (inconsistent row state).

**Observed against prod**: user `richard627` (id 169901003) had `handle=NULL` on clone but `handle='richard627'` on replica — same chain tx, different interpretation.

**Fix**: `""` now preserves the existing value, matching the prod indexer's behavior.

### 3. PRIMARY KEY violations on re-delivered txs (family bug)

`shares_pkey`, `reposts_pkey`, `saves_pkey`, `follows_pkey`, `subscriptions_pkey` — all five have `(entity_keys..., txhash)` row-versioning PKs. The bare INSERTs in social_save / social_repost / social_share / social_follow hit 23505 when the prefetcher re-delivers a chain tx (root cause of re-delivery deferred — separate investigation).

**Fix**: each INSERT now has `ON CONFLICT (entity_keys..., txhash) DO NOTHING`. `txhash` is content-addressable, so re-delivered data is identical by construction.

### 4. `blockhash NOT NULL` violations on prod schema

Our migrations declare `blockhash ... NOT NULL DEFAULT ''` (so omitting the column locally silently writes `''`), but the prod schema for 14 tables has no default — every INSERT must include `blockhash` explicitly. Observed: `events.blockhash` 23502 violations during prod-clone run.

**Fix**: added `params.BlockHash` to INSERTs into `events`, `associated_wallets`, `muted_users`. (Sweeping the other 11 NOT-NULL-blockhash tables is a follow-up; the handlers for them already include blockhash.)

## Why this supersedes #307

PR #307 had six test fixes; one of them (the `resolveSaveType` for `TestSave_Album_Success`) introduced the save_type regression in bug #1 above. Rather than force-push #307, this PR includes the corrected version of that fix plus the other five (which were good). Recommend closing #307 in favor of this PR.

The five non-regression fixes carried forward:

- `AssociatedWalletCreate` SOL base58 case preservation (new `canonicalizeWallet` helper)
- `AssociatedWalletDelete` UPDATE drops the bogus `chain = $4` filter that matched empty string
- `dashboard_wallet_test.go` queries use lowercase wallet (matches handler's canonical storage)
- `track_update_test.go` seeds user wallet matching the signer

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] All six previously-failing entity_manager tests now pass (including the original `TestSave_Album_Success`)
- [x] New `TestSave_Playlist_WhenTrackIdCollides` covers the regression
- [x] Full `go test ./pkg/etl/...` clean except for the pre-existing migrate-down/up flake on `TestTrackCreate_AppliesAccessNormalization` (unrelated)

## Deferred follow-ups

- `no rows in result set` raw error from some handler (needs context attribution — `indexer.go:425` log line doesn't carry entity_type/action; sweeping handlers for unwrapped `QueryRow.Scan` will catch it)
- Transient TCP "can't assign requested address" — environmental, pgxpool tuning if it recurs under sustained load
- Prefetcher re-delivery investigation (root cause of all the PK violations we just papered over)
- Sweep the other 11 NOT-NULL-blockhash tables (comment_*, playlist_routes, track_routes, etc.) — quick scan showed they already pass blockhash, but worth a full audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)