### PR TITLE
fix(etl): playlist_seen PK, ErrNoRows on soft-deletes, attribute dispatch errors

### DIFF
--- a/pkg/etl/db/sql/migrations/0005_notification_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0005_notification_tables.up.sql
@@ -26,6 +26,13 @@ CREATE TABLE IF NOT EXISTS notification_seen (
   CONSTRAINT notification_seen_pkey PRIMARY KEY (user_id, seen_at)
 );
 
+-- playlist_seen PK matches prod's schema: (user_id, playlist_id, seen_at).
+-- The `is_current` column is retained for backward compatibility with the
+-- legacy schema (always written as `true` by the playlist-seen handler), but
+-- is NOT part of the uniqueness contract — including it in the PK would
+-- mismatch prod and cause 42P10 on any ON CONFLICT clause that names the
+-- prod target columns. Older databases that were created with the wrong PK
+-- get fixed by migration 0027_fix_playlist_seen_pkey.up.sql.
 CREATE TABLE IF NOT EXISTS playlist_seen (
   is_current boolean NOT NULL,
   user_id integer NOT NULL,
@@ -34,5 +41,5 @@ CREATE TABLE IF NOT EXISTS playlist_seen (
   blocknumber integer,
   blockhash character varying,
   txhash character varying,
-  CONSTRAINT playlist_seen_pkey PRIMARY KEY (is_current, user_id, playlist_id, seen_at)
+  CONSTRAINT playlist_seen_pkey PRIMARY KEY (user_id, playlist_id, seen_at)
 );

--- a/pkg/etl/db/sql/migrations/0027_fix_playlist_seen_pkey.down.sql
+++ b/pkg/etl/db/sql/migrations/0027_fix_playlist_seen_pkey.down.sql
@@ -1,0 +1,3 @@
+-- Reverting to the broken (is_current,...) PK is intentionally a no-op —
+-- it would re-introduce the 42P10 incompatibility with prod and break the
+-- ON CONFLICT in the playlist_seen handler. Leave the down side empty.

--- a/pkg/etl/db/sql/migrations/0027_fix_playlist_seen_pkey.up.sql
+++ b/pkg/etl/db/sql/migrations/0027_fix_playlist_seen_pkey.up.sql
@@ -1,0 +1,17 @@
+-- playlist_seen primary key was originally declared as
+-- (is_current, user_id, playlist_id, seen_at) — `is_current` was a column
+-- but never a meaningful part of the uniqueness contract (the handler
+-- always writes is_current=true). Prod's schema has the PK without
+-- is_current. ON CONFLICT clauses that name the prod target — which is
+-- the right thing to do — get rejected with 42P10 against the older
+-- in-house PK.
+--
+-- Fresh databases skip this migration via the corrected 0005. This
+-- migration converts older databases (that already ran the bad 0005) to
+-- the prod-compatible shape.
+
+ALTER TABLE playlist_seen
+  DROP CONSTRAINT IF EXISTS playlist_seen_pkey;
+
+ALTER TABLE playlist_seen
+  ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (user_id, playlist_id, seen_at);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -422,7 +422,18 @@ func (e *Indexer) indexBlocks() error {
 							zap.String("hash", tx.Hash),
 						)
 					} else {
-						e.logger.Error("entity manager dispatch error", zap.Error(dErr))
+						// Include entity_type / action / hash so we can attribute
+						// non-validation handler errors. Without this context the
+						// log line is unreadable (e.g. a bare "no rows in result
+						// set" with no clue which handler emitted it).
+						e.logger.Error("entity manager dispatch error",
+							zap.String("entity_type", me.GetEntityType()),
+							zap.String("action", me.GetAction()),
+							zap.Int64("entity_id", me.GetEntityId()),
+							zap.Int64("user_id", me.GetUserId()),
+							zap.String("hash", tx.Hash),
+							zap.Error(dErr),
+						)
 					}
 				} else {
 					e.logger.Debug("tx indexed",

--- a/pkg/etl/processors/entity_manager/notification.go
+++ b/pkg/etl/processors/entity_manager/notification.go
@@ -93,11 +93,16 @@ func (h *notificationViewPlaylistHandler) Handle(ctx context.Context, params *Pa
 		return NewValidationError("playlist %d does not exist", params.EntityID)
 	}
 
+	// PK on prod is (user_id, playlist_id, seen_at) — `is_current` is not
+	// part of the unique index, so it must not appear in the ON CONFLICT
+	// target (Postgres 42P10 otherwise). Observed firing during the
+	// prod-clone validation run: same user seeing the same playlist twice
+	// in the indexed window.
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO playlist_seen (
 			is_current, user_id, playlist_id, seen_at, txhash, blocknumber
 		) VALUES (true, $1, $2, $3, $4, $5)
-		ON CONFLICT (is_current, user_id, playlist_id, seen_at) DO NOTHING
+		ON CONFLICT (user_id, playlist_id, seen_at) DO NOTHING
 	`, params.UserID, params.EntityID, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }

--- a/pkg/etl/processors/entity_manager/playlist_row.go
+++ b/pkg/etl/processors/entity_manager/playlist_row.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -59,6 +61,11 @@ func loadCurrentPlaylistRow(ctx context.Context, dbtx db.DBTX, playlistID int64)
 		&upc, &ddex, &ddexRel, &artists, &copyright, &producerCopyright,
 		&parentalWarning, &r.CreatedAt,
 	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Same race as loadCurrentTrackRow: validation accepts is_delete=true
+		// rows but this loader filters them out. Convert to ValidationError.
+		return nil, NewValidationError("playlist %d is deleted or does not exist", playlistID)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/etl/processors/entity_manager/track_row.go
+++ b/pkg/etl/processors/entity_manager/track_row.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -68,6 +70,13 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 		&releaseDate, &r.IsScheduledRelease, &aiAttr, &r.IsPlaylistUpload, &ddex, &ddexRel,
 		&r.IsAvailable, &segments, &r.CreatedAt,
 	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Track was soft-deleted between validation and now (validateTrackUpdate
+		// uses trackExists which accepts is_delete=true; this function filters
+		// is_delete=false). Convert raw ErrNoRows to a ValidationError so the
+		// dispatcher logs it at WARN, not ERROR.
+		return nil, NewValidationError("track %d is deleted or does not exist", trackID)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/etl/processors/entity_manager/user_update.go
+++ b/pkg/etl/processors/entity_manager/user_update.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+	"github.com/jackc/pgx/v5"
 )
 
 type userUpdateHandler struct{}
@@ -258,6 +260,13 @@ func getCurrentUser(ctx context.Context, dbtx db.DBTX, userID int64) (*currentUs
 func getUserHandle(ctx context.Context, dbtx db.DBTX, userID int64) (string, error) {
 	var handleLC sql.NullString
 	err := dbtx.QueryRow(ctx, "SELECT handle_lc FROM users WHERE user_id = $1 AND is_current = true LIMIT 1", userID).Scan(&handleLC)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// User has no current row (deleted between validation and now, or
+		// never existed under is_current=true). Treat as empty handle —
+		// callers compare against the new handle, so empty here means
+		// "different, run the uniqueness check".
+		return "", nil
+	}
 	if handleLC.Valid {
 		return handleLC.String, err
 	}


### PR DESCRIPTION
## Summary

Follow-ups from the overnight prod-clone validation run (38,834 chain blocks, 69 deep diff cycles against the prod read replica). PR #308's fixes held up cleanly — these are the remaining two real findings + one observability gap, all surgical.

## Changes

### 1. `playlist_seen` primary key mismatch with prod

Our `0005_notification_tables.up.sql` declared the PK as `(is_current, user_id, playlist_id, seen_at)`. Prod's schema has `(user_id, playlist_id, seen_at)` — no `is_current`. This caused an asymmetric bug:

- The handler's `ON CONFLICT (is_current, user_id, playlist_id, seen_at)` matched our in-house PK but silently mismatched prod.
- The fixed version `ON CONFLICT (user_id, playlist_id, seen_at)` matches prod but breaks against our in-house PK with `42P10 no unique or exclusion constraint matching`.

Observed firing 7 times in the 11h validation run. Fix:

- **`0005_notification_tables.up.sql`**: declare the prod-correct PK on fresh databases.
- **`0027_fix_playlist_seen_pkey.up.sql`** (new): DROP+ADD the PK on databases that already ran the broken `0005`.
- **`notification.go:100`**: drop `is_current` from the ON CONFLICT target.

### 2. `loadCurrentTrackRow` / `loadCurrentPlaylistRow` propagated raw `pgx.ErrNoRows` on soft-deleted rows

`validateTrackUpdate` / `validatePlaylistUpdate` use `trackExists` / `playlistExists` which accept `is_delete = true` rows. The row-loaders `loadCurrentTrackRow` and `loadCurrentPlaylistRow` filter `is_delete = false` — so a track that was soft-deleted between validation and update returns raw `pgx.ErrNoRows`, which the dispatcher then logs at ERROR level as `no rows in result set`.

Observed firing 14 times during the 11h run, clustered with `Track/Repost "already exists"` rejections during follow surges — strongly correlated with high-activity windows where soft-deletes and updates race.

Wrap `ErrNoRows` in both row-loaders as a `NewValidationError("X N is deleted or does not exist")` so the dispatcher logs at WARN, not ERROR.

### 3. `getUserHandle` race-window ErrNoRows

Same shape as #2 — `validateUserUpdate` checks `userExists`, but if the user disappears in the narrow window before `getUserHandle` runs, the raw `ErrNoRows` leaks out. Fix: treat `ErrNoRows` as empty handle (callers compare against the new handle).

### 4. Attribute dispatch errors to a handler — observability fix

The dispatch-error log line at `indexer.go:425` had no context fields, so when one fired we could see `no rows in result set` but had no clue which handler emitted it. Made #2 hard to attribute — only discovered via correlation analysis after multi-hour runs.

Add `entity_type / action / entity_id / user_id / hash` to the log so future occurrences are self-attributing. Mirrors the fields already on the WARN line for ValidationErrors.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] Full `go test ./pkg/etl/...` against fresh Postgres: **all green** (including the previously-affected `TestPlaylistSeenView_Success`)
- [x] `TestPlaylistSeenView_Success` now exercises the new PK on the test side and passes
- [x] `TestPlaylistUpdate_Success` (which exercises `loadCurrentPlaylistRow`) still passes
- [x] No new test failures introduced

## Open follow-ups (out of scope, called out in run findings)

- **Shares semantic mismatch with prod** — we write ~5× more share rows than prod's python indexer. Product call (not an indexer bug).
- **Album vs playlist disambiguation** — PR #308's `is_album` check produces `save_type='album'` where prod writes `'playlist'`. Intentional, but downstream consumers should know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)