### PR TITLE
feat(etl): auto-subscribe uploader to remix-contest event on Track Create

### DIFF
--- a/pkg/etl/db/sql/migrations/0007_subscription_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0007_subscription_tables.up.sql
@@ -9,6 +9,9 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   is_delete boolean NOT NULL,
   created_at timestamp without time zone NOT NULL,
   txhash character varying NOT NULL DEFAULT '',
+  -- When entity_type='Event', user_id is overloaded to hold the event_id.
+  entity_type text NOT NULL DEFAULT 'User',
+  entity_id integer,
   CONSTRAINT subscriptions_pkey PRIMARY KEY (subscriber_id, user_id, txhash)
 );
 

--- a/pkg/etl/db/sql/migrations/0029_subscriptions_entity_type.down.sql
+++ b/pkg/etl/db/sql/migrations/0029_subscriptions_entity_type.down.sql
@@ -1,0 +1,1 @@
+-- No-op: dropping these columns would lose Event-subscription data.

--- a/pkg/etl/db/sql/migrations/0029_subscriptions_entity_type.up.sql
+++ b/pkg/etl/db/sql/migrations/0029_subscriptions_entity_type.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS entity_type text NOT NULL DEFAULT 'User';
+
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS entity_id integer;

--- a/pkg/etl/processors/entity_manager/comment_create.go
+++ b/pkg/etl/processors/entity_manager/comment_create.go
@@ -113,8 +113,7 @@ func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) er
 		}
 	}
 
-	// entity_type supports Track and FanClub
-	if et := params.MetadataString("entity_type"); et != "" && et != EntityTypeTrack && et != "FanClub" {
+	if et := params.MetadataString("entity_type"); et != "" && et != EntityTypeTrack && et != "FanClub" && et != EntityTypeEvent {
 		return NewValidationError("entity type %q is not supported for comments", et)
 	}
 
@@ -130,6 +129,17 @@ func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) er
 		}
 		if !exists {
 			return NewValidationError("track %d does not exist", entityID)
+		}
+	}
+	if et == EntityTypeEvent {
+		var exists bool
+		if err := params.DBTX.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM events WHERE event_id = $1 AND is_deleted = false)",
+			entityID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return NewValidationError("event %d does not exist", entityID)
 		}
 	}
 

--- a/pkg/etl/processors/entity_manager/track_contest_subscribe.go
+++ b/pkg/etl/processors/entity_manager/track_contest_subscribe.go
@@ -1,0 +1,92 @@
+package entity_manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+	"github.com/jackc/pgx/v5"
+)
+
+// SubscriptionEntityTypeEvent: when subscriptions.entity_type is "Event",
+// subscriptions.user_id is the event_id (the column is overloaded).
+const SubscriptionEntityTypeEvent = "Event"
+
+// autoSubscribeToContestOnSubmission writes a subscriptions row when a Track
+// Create is a remix submission to an active remix_contest event.
+func autoSubscribeToContestOnSubmission(ctx context.Context, params *Params) error {
+	if stemMap, ok := params.Metadata["stem_of"].(map[string]any); ok && stemMap != nil {
+		return nil
+	}
+	parentIDs := getRemixParentTrackIDs(params.Metadata)
+	if len(parentIDs) == 0 {
+		return nil
+	}
+	parentTrackID := parentIDs[0]
+
+	var eventID, hostID int64
+	err := params.DBTX.QueryRow(ctx, `
+		SELECT event_id, user_id FROM events
+		WHERE event_type = 'remix_contest'
+		  AND entity_id = $1
+		  AND is_deleted = false
+		  AND (end_date IS NULL OR end_date > $2)
+		LIMIT 1
+	`, parentTrackID, params.BlockTime).Scan(&eventID, &hostID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if params.UserID == hostID {
+		return nil
+	}
+
+	already, err := contestEventSubscriptionExists(ctx, params.DBTX, params.UserID, eventID)
+	if err != nil {
+		return err
+	}
+	if already {
+		return nil
+	}
+
+	// Synthetic txhash so re-processed chain txs collide on the PK.
+	syntheticTxHash := fmt.Sprintf("auto_e%d_%s", eventID, params.TxHash)
+	if len(syntheticTxHash) > 200 {
+		syntheticTxHash = syntheticTxHash[:200]
+	}
+
+	_, err = params.DBTX.Exec(ctx, `
+		INSERT INTO subscriptions (
+			subscriber_id, user_id, entity_type, entity_id,
+			is_current, is_delete,
+			created_at, txhash, blockhash, blocknumber
+		) VALUES (
+			$1, $2, $3, $2,
+			true, false,
+			$4, $5, $6, $7
+		)
+		ON CONFLICT (subscriber_id, user_id, txhash) DO NOTHING
+	`,
+		params.UserID, eventID, SubscriptionEntityTypeEvent,
+		params.BlockTime, syntheticTxHash, params.BlockHash, params.BlockNumber)
+	return err
+}
+
+func contestEventSubscriptionExists(ctx context.Context, dbtx db.DBTX, subscriberID, eventID int64) (bool, error) {
+	var exists bool
+	err := dbtx.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM subscriptions
+			WHERE subscriber_id = $1
+			  AND user_id = $2
+			  AND entity_type = $3
+			  AND is_current = true
+			  AND is_delete = false
+		)
+	`, subscriberID, eventID, SubscriptionEntityTypeEvent).Scan(&exists)
+	return exists, err
+}

--- a/pkg/etl/processors/entity_manager/track_contest_subscribe_test.go
+++ b/pkg/etl/processors/entity_manager/track_contest_subscribe_test.go
@@ -1,0 +1,143 @@
+package entity_manager
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAutoSubscribeOnRemixContestSubmission(t *testing.T) {
+	pool := setupTestDB(t)
+	hostID := int64(UserIDOffset + 100)
+	parentTrackID := int64(TrackIDOffset + 100)
+	uploaderID := int64(UserIDOffset + 101)
+	remixID := int64(TrackIDOffset + 200)
+
+	seedUser(t, pool, hostID, "0xhost", "host")
+	seedTrack(t, pool, parentTrackID, hostID)
+	seedUser(t, pool, uploaderID, "0xuploader", "uploader")
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	eventMeta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(parentTrackID) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(),
+		buildParams(t, pool, EntityTypeEvent, ActionCreate, hostID, 500, "0xhost", eventMeta))
+
+	remixMeta := `{"owner_id":` + itoa(uploaderID) + `,"title":"My Remix","remix_of":{"tracks":[{"parent_track_id":` + itoa(parentTrackID) + `}]}}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uploaderID, remixID, "0xuploader", remixMeta))
+
+	var subscriberID, eventUserID int64
+	var entityType, txhash string
+	err := pool.QueryRow(context.Background(), `
+		SELECT subscriber_id, user_id, entity_type, txhash
+		FROM subscriptions
+		WHERE subscriber_id = $1 AND entity_type = 'Event' AND is_current = true AND is_delete = false
+		LIMIT 1
+	`, uploaderID).Scan(&subscriberID, &eventUserID, &entityType, &txhash)
+	if err != nil {
+		t.Fatalf("expected an auto-subscribe row for uploader %d; query: %v", uploaderID, err)
+	}
+	if entityType != "Event" {
+		t.Errorf("entity_type = %q, want Event", entityType)
+	}
+	if !strings.HasPrefix(txhash, "auto_e") {
+		t.Errorf("expected synthetic txhash prefixed `auto_e`, got %q", txhash)
+	}
+}
+
+func TestAutoSubscribe_SkipsWhenUploaderIsHost(t *testing.T) {
+	pool := setupTestDB(t)
+	hostID := int64(UserIDOffset + 110)
+	parentTrackID := int64(TrackIDOffset + 110)
+	remixID := int64(TrackIDOffset + 211)
+
+	seedUser(t, pool, hostID, "0xhost2", "host2")
+	seedTrack(t, pool, parentTrackID, hostID)
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	eventMeta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(parentTrackID) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(),
+		buildParams(t, pool, EntityTypeEvent, ActionCreate, hostID, 501, "0xhost2", eventMeta))
+
+	remixMeta := `{"owner_id":` + itoa(hostID) + `,"title":"Host Remix","remix_of":{"tracks":[{"parent_track_id":` + itoa(parentTrackID) + `}]}}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, hostID, remixID, "0xhost2", remixMeta))
+
+	var cnt int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*) FROM subscriptions
+		WHERE subscriber_id = $1 AND entity_type = 'Event'
+	`, hostID).Scan(&cnt); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if cnt != 0 {
+		t.Errorf("host should not auto-subscribe to their own contest, found %d Event subscriptions", cnt)
+	}
+}
+
+func TestAutoSubscribe_SkipsWhenNoActiveContest(t *testing.T) {
+	pool := setupTestDB(t)
+	ownerID := int64(UserIDOffset + 120)
+	parentTrackID := int64(TrackIDOffset + 120)
+	uploaderID := int64(UserIDOffset + 121)
+	remixID := int64(TrackIDOffset + 220)
+
+	seedUser(t, pool, ownerID, "0xowner3", "owner3")
+	seedTrack(t, pool, parentTrackID, ownerID)
+	seedUser(t, pool, uploaderID, "0xuploader3", "uploader3")
+
+	remixMeta := `{"owner_id":` + itoa(uploaderID) + `,"title":"Casual Remix","remix_of":{"tracks":[{"parent_track_id":` + itoa(parentTrackID) + `}]}}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uploaderID, remixID, "0xuploader3", remixMeta))
+
+	var cnt int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*) FROM subscriptions
+		WHERE subscriber_id = $1 AND entity_type = 'Event'
+	`, uploaderID).Scan(&cnt); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if cnt != 0 {
+		t.Errorf("no contest exists, expected 0 Event subscriptions, found %d", cnt)
+	}
+}
+
+// Idempotency: a second remix submission from the same uploader must not
+// produce a second is_current row for the same (subscriber, event) pair.
+func TestAutoSubscribe_SkipsWhenAlreadySubscribed(t *testing.T) {
+	pool := setupTestDB(t)
+	hostID := int64(UserIDOffset + 130)
+	parentTrackID := int64(TrackIDOffset + 130)
+	uploaderID := int64(UserIDOffset + 131)
+	remix1ID := int64(TrackIDOffset + 230)
+	remix2ID := int64(TrackIDOffset + 231)
+
+	seedUser(t, pool, hostID, "0xhost4", "host4")
+	seedTrack(t, pool, parentTrackID, hostID)
+	seedUser(t, pool, uploaderID, "0xuploader4", "uploader4")
+
+	endDate := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	eventMeta := `{"event_type":"remix_contest","entity_type":"track","entity_id":` + itoa(parentTrackID) + `,"end_date":"` + endDate + `","event_data":{}}`
+	mustHandle(t, EventCreate(),
+		buildParams(t, pool, EntityTypeEvent, ActionCreate, hostID, 502, "0xhost4", eventMeta))
+
+	remix1Meta := `{"owner_id":` + itoa(uploaderID) + `,"title":"Remix 1","remix_of":{"tracks":[{"parent_track_id":` + itoa(parentTrackID) + `}]}}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uploaderID, remix1ID, "0xuploader4", remix1Meta))
+
+	remix2Meta := `{"owner_id":` + itoa(uploaderID) + `,"title":"Remix 2","remix_of":{"tracks":[{"parent_track_id":` + itoa(parentTrackID) + `}]}}`
+	mustHandle(t, TrackCreate(),
+		buildParams(t, pool, EntityTypeTrack, ActionCreate, uploaderID, remix2ID, "0xuploader4", remix2Meta))
+
+	var cnt int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*) FROM subscriptions
+		WHERE subscriber_id = $1 AND entity_type = 'Event' AND is_current = true AND is_delete = false
+	`, uploaderID).Scan(&cnt); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if cnt != 1 {
+		t.Errorf("expected exactly 1 is_current Event subscription after two remixes, got %d", cnt)
+	}
+}

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -182,6 +182,9 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 	if err := updateRemixesTable(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
 		return err
 	}
+	if err := autoSubscribeToContestOnSubmission(ctx, params); err != nil {
+		return err
+	}
 	if err := updateTrackPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Ports `auto_subscribe_to_contest_on_submission` from AudiusProject/apps#14159 to our Go ETL. Required so apps/api's existing notification triggers have non-empty Event-subscription recipient sets.

## Why this is needed

apps/api already computes the contest notifications via Postgres triggers:

| Notification | apps/api trigger | Reads from |
|---|---|---|
| `fan_remix_contest_started` | `handle_event.sql` (ON INSERT events) | followers ∪ savers ∪ **`subscriptions WHERE entity_type='Event'`** |
| `artist_remix_contest_submissions` (milestones) | `handle_track.sql` (ON INSERT tracks) | submission count |
| `fan_remix_contest_submission` (per-submission) | `handle_track.sql` (ON INSERT tracks) | **`subscriptions WHERE entity_type='Event'`** ∪ host |

Two of those triggers require `subscriptions` rows with `entity_type='Event'` to exist. Without our ETL writing them, the triggers fire but fan out to empty sets and event subscribers never get notified.

This PR provides the base-table data those triggers depend on. The architectural split holds:

- **ETL** writes base tables (subscriptions, tracks, comments, events, …)
- **apps/api** computes notifications via triggers on those base tables

## Changes

### `track_contest_subscribe.go` (new)

`autoSubscribeToContestOnSubmission`:

- Skips if the track is a stem (non-empty `stem_of` in metadata)
- Reads the remix parent track id from `metadata.remix_of.tracks[0].parent_track_id`
- Looks up an active `remix_contest` event for the parent (`is_deleted=false AND (end_date IS NULL OR end_date > now)`)
- Skips if the uploader is the contest host
- Skips if the uploader already has an active `is_current` Event subscription to this event
- Otherwise INSERTs a `Subscription` row with synthetic txhash `auto_e{event_id}_{tx_hash}` (capped at 200 chars), `entity_type='Event'`, `entity_id=event_id`, `is_current=true`
- `ON CONFLICT (subscriber_id, user_id, txhash) DO NOTHING` for idempotency on re-processed chain txs

Wired into `createTrack` after `updateRemixesTable`.

### Supporting

- **`validateCommentWrite`** now accepts `entity_type='Event'` (previously rejected; only Track + FanClub were supported). Required so comments on Event entities can land in the `comments` table — downstream apps/api can then fire trigger-based notifications on those rows when the `handle_comment.sql` contest section is added on that side. Existence is verified via the `events` table.
- **`subscriptions` migrations** add `entity_type text NOT NULL DEFAULT 'User'` and `entity_id integer` columns. Updated `0007` for fresh DBs; added `0028` ALTER for existing DBs. Default `'User'` keeps existing follow rows unchanged. Down for `0028` is intentionally a no-op (don't drop columns we're writing into).

## Explicitly NOT in this PR (scope kept narrow per review)

- **`remix_contest_update` notification fan-out from the ETL.** The other three contest notifications live as Postgres triggers in apps/api (one in `handle_event.sql`, two in `handle_track.sql`). The natural home for `remix_contest_update` is `handle_comment.sql` in apps/api — alongside its siblings. This PR holds the line that "notifications are computed downstream of base-table writes" instead of crossing it for one entry.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] 4 new tests in `track_contest_subscribe_test.go` pass (happy path + 3 skip cases)
- [x] Full `go test ./pkg/etl/...` clean against fresh Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)