### PR TITLE
feat(etl): comments.is_members_only + video_url for fan club text posts

### DIFF
--- a/pkg/etl/db/sql/migrations/0028_comments_fan_club_fields.down.sql
+++ b/pkg/etl/db/sql/migrations/0028_comments_fan_club_fields.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE comments
+  DROP COLUMN IF EXISTS video_url,
+  DROP COLUMN IF EXISTS is_members_only;

--- a/pkg/etl/db/sql/migrations/0028_comments_fan_club_fields.up.sql
+++ b/pkg/etl/db/sql/migrations/0028_comments_fan_club_fields.up.sql
@@ -1,0 +1,12 @@
+-- Add fan-club text-post fields to comments.
+--
+-- is_members_only gates a FanClub text post to paying members; only honored
+-- when entity_type='FanClub' (validation enforced in comment_create.go).
+-- video_url stores an attached video URL on a text post (apps#14080).
+--
+-- Mirrors apps' models/social/comment.py and entity_manager/entities/comment.py
+-- additions from PRs #14029, #14054, #14058, #14080.
+
+ALTER TABLE comments
+  ADD COLUMN IF NOT EXISTS is_members_only boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS video_url text;

--- a/pkg/etl/processors/entity_manager/comment_create.go
+++ b/pkg/etl/processors/entity_manager/comment_create.go
@@ -22,16 +22,26 @@ func (h *commentCreateHandler) Handle(ctx context.Context, params *Params) error
 	}
 	trackTimestamp, hasTimestamp := params.MetadataInt64("track_timestamp_s")
 
+	// Fan-club text post fields (apps#14029, #14080). is_members_only is
+	// only honored when entity_type='FanClub'; the matching validation in
+	// validateCommentWrite rejects the truthy-on-non-FanClub case so we
+	// never silently flip the bit here.
+	isMembersOnly := entityType == "FanClub" && params.MetadataBoolOr("is_members_only", false)
+	videoURL := params.MetadataString("video_url")
+
 	_, err := params.DBTX.Exec(ctx, `
 		INSERT INTO comments (
 			comment_id, text, user_id, entity_id, entity_type,
 			track_timestamp_s, created_at, updated_at,
 			is_delete, is_visible, is_edited,
+			is_members_only, video_url,
 			txhash, blockhash, blocknumber
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $7, false, true, false, $8, $9, $10)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $7, false, true, false, $8, $9, $10, $11, $12)
 	`, params.EntityID, body, params.UserID, entityID, entityType,
 		nullableInt(trackTimestamp, hasTimestamp),
-		params.BlockTime, params.TxHash, params.BlockHash, params.BlockNumber)
+		params.BlockTime,
+		isMembersOnly, nullString(videoURL),
+		params.TxHash, params.BlockHash, params.BlockNumber)
 	if err != nil {
 		return err
 	}
@@ -129,6 +139,24 @@ func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) er
 	}
 	if len(body) > CharacterLimitCommentBody {
 		return NewValidationError("comment body exceeds %d character limit", CharacterLimitCommentBody)
+	}
+
+	// Fan-club text post fields. is_members_only is only meaningful on
+	// FanClub comments — reject a truthy flag on any other entity type so
+	// we don't silently drop user intent. video_url has a length cap that
+	// mirrors apps' MAX_REDIRECT_URI_LENGTH (no separate constant in apps
+	// for this; reuse 2000 as a sane upper bound).
+	if isCreate && params.MetadataBoolOr("is_members_only", false) {
+		etCheck := et
+		if etCheck == "" {
+			etCheck = EntityTypeTrack
+		}
+		if etCheck != "FanClub" {
+			return NewValidationError("is_members_only requires entity_type=FanClub (got %q)", etCheck)
+		}
+	}
+	if v := params.MetadataString("video_url"); len(v) > 2000 {
+		return NewValidationError("video_url exceeds 2000 character limit")
 	}
 
 	// Validate parent_comment_id (or parent_id) if provided.

--- a/pkg/etl/processors/entity_manager/comment_fan_club_test.go
+++ b/pkg/etl/processors/entity_manager/comment_fan_club_test.go
@@ -1,0 +1,170 @@
+package entity_manager
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestCommentCreate_FanClubMembersOnly verifies that an is_members_only=true
+// comment on a FanClub entity persists with both the flag and an attached
+// video_url. Mirrors apps' fan-club text-post flow (PRs #14029, #14080).
+func TestCommentCreate_FanClubMembersOnly(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	author := int64(UserIDOffset + 7000)
+	target := int64(UserIDOffset + 7001)
+	cid := int64(CommentIDOffset + 7000)
+	seedUser(t, pool, author, "0xfc1", "fc1u")
+	seedUser(t, pool, target, "0xfc2", "fc2u")
+
+	// FanClub entity_id is the target user id; the trackExists check is
+	// skipped because entity_type != "Track".
+	meta := `{
+		"comment_id":4007000,
+		"body":"members only",
+		"entity_id":3007001,
+		"entity_type":"FanClub",
+		"is_members_only":true,
+		"video_url":"https://example.com/post.mp4"
+	}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, author, cid, "0xfc1", meta))
+
+	var isMembersOnly bool
+	var videoURL *string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_members_only, video_url FROM comments WHERE comment_id = $1",
+		cid).Scan(&isMembersOnly, &videoURL); err != nil {
+		t.Fatalf("query comment: %v", err)
+	}
+	if !isMembersOnly {
+		t.Error("is_members_only should be true")
+	}
+	if videoURL == nil || *videoURL != "https://example.com/post.mp4" {
+		t.Errorf("video_url = %v, want https://example.com/post.mp4", videoURL)
+	}
+}
+
+// TestCommentCreate_RejectsMembersOnlyOnTrack — is_members_only is only
+// meaningful for FanClub comments; setting it on a Track comment must error.
+func TestCommentCreate_RejectsMembersOnlyOnTrack(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	author := int64(UserIDOffset + 7010)
+	owner := int64(UserIDOffset + 7011)
+	tid := int64(TrackIDOffset + 7010)
+	cid := int64(CommentIDOffset + 7010)
+	seedUser(t, pool, author, "0xfc3", "fc3u")
+	seedUser(t, pool, owner, "0xfc4", "fc4u")
+	seedTrackFull(t, pool, tid, owner, "Tk")
+
+	meta := `{
+		"comment_id":4007010,
+		"body":"nope",
+		"entity_id":2007010,
+		"entity_type":"Track",
+		"is_members_only":true
+	}`
+	mustReject(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, author, cid, "0xfc3", meta),
+		"FanClub")
+}
+
+// TestCommentCreate_RejectsOverlongVideoURL caps video_url at 2000 chars.
+func TestCommentCreate_RejectsOverlongVideoURL(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	author := int64(UserIDOffset + 7020)
+	target := int64(UserIDOffset + 7021)
+	cid := int64(CommentIDOffset + 7020)
+	seedUser(t, pool, author, "0xfc5", "fc5u")
+	seedUser(t, pool, target, "0xfc6", "fc6u")
+
+	longURL := "https://example.com/" + strings.Repeat("a", 2000)
+	meta := `{
+		"comment_id":4007020,
+		"body":"x",
+		"entity_id":3007021,
+		"entity_type":"FanClub",
+		"video_url":"` + longURL + `"
+	}`
+	mustReject(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, author, cid, "0xfc5", meta),
+		"video_url")
+}
+
+// TestCommentCreate_FanClubVideoURLOnly — video_url without is_members_only is
+// allowed (and lands) for FanClub entities. Default for is_members_only
+// stays false.
+func TestCommentCreate_FanClubVideoURLOnly(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	author := int64(UserIDOffset + 7030)
+	target := int64(UserIDOffset + 7031)
+	cid := int64(CommentIDOffset + 7030)
+	seedUser(t, pool, author, "0xfc7", "fc7u")
+	seedUser(t, pool, target, "0xfc8", "fc8u")
+
+	meta := `{
+		"comment_id":4007030,
+		"body":"public text post",
+		"entity_id":3007031,
+		"entity_type":"FanClub",
+		"video_url":"https://cdn.example.com/v.mp4"
+	}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, author, cid, "0xfc7", meta))
+
+	var isMembersOnly bool
+	var videoURL *string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_members_only, video_url FROM comments WHERE comment_id = $1",
+		cid).Scan(&isMembersOnly, &videoURL); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if isMembersOnly {
+		t.Error("is_members_only should default to false when omitted")
+	}
+	if videoURL == nil || *videoURL != "https://cdn.example.com/v.mp4" {
+		t.Errorf("video_url = %v, want https://cdn.example.com/v.mp4", videoURL)
+	}
+}
+
+// TestCommentCreate_NonFanClubLeavesMembersOnlyFalse — even without an
+// is_members_only key in metadata, a Track comment should persist
+// is_members_only=false (column default).
+func TestCommentCreate_NonFanClubDefaultsFalse(t *testing.T) {
+	pool := setupTestDB(t)
+	seedBlock(t, pool)
+	author := int64(UserIDOffset + 7040)
+	owner := int64(UserIDOffset + 7041)
+	tid := int64(TrackIDOffset + 7040)
+	cid := int64(CommentIDOffset + 7040)
+	seedUser(t, pool, author, "0xfc9", "fc9u")
+	seedUser(t, pool, owner, "0xfca", "fcau")
+	seedTrackFull(t, pool, tid, owner, "Tk")
+
+	meta := `{
+		"comment_id":4007040,
+		"body":"plain track comment",
+		"entity_id":2007040,
+		"entity_type":"Track"
+	}`
+	mustHandle(t, CommentCreate(),
+		buildParams(t, pool, EntityTypeComment, ActionCreate, author, cid, "0xfc9", meta))
+
+	var isMembersOnly bool
+	var videoURL *string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_members_only, video_url FROM comments WHERE comment_id = $1",
+		cid).Scan(&isMembersOnly, &videoURL); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if isMembersOnly {
+		t.Error("is_members_only should default to false on Track comments")
+	}
+	if videoURL != nil {
+		t.Errorf("video_url should be NULL, got %v", *videoURL)
+	}
+}


### PR DESCRIPTION
## Summary

Picks up the fan-club text-post feature set from apps' last 2 months of discovery-provider changes (PRs #14029, #14054, #14058, #14080, #14306). Two new columns on \`comments\` plus matching handler + validation; one migration, ~30 LOC of handler change, 5 DB-backed tests.

## Surfaced via

The last-2-months parity audit (2026-05-22) flagged these two columns as the only remaining gap from the post-#237 ETL work:

- \`is_members_only boolean\` — gates a FanClub text post to paying members
- \`video_url text\` — optional video attachment on a text post

Everything else from apps' last 2 months (empty playlist_contents fix, hashid track_ids, comment threading guards, contest event handlers, etc.) is either already in pkg/etl or by-design out of scope (notifications, trending payouts, plays indexer).

## Behavior

### Migration 0028

\`\`\`sql
ALTER TABLE comments
  ADD COLUMN IF NOT EXISTS is_members_only boolean NOT NULL DEFAULT false,
  ADD COLUMN IF NOT EXISTS video_url text;
\`\`\`

### comment_create.go

- Reads \`is_members_only\` from metadata, but **only honors it when \`entity_type='FanClub'\`**. Apps' \`comment.py\` silently drops it on non-FanClub; we instead error in validation so user intent isn't lost.
- Reads \`video_url\`; persists \`NULL\` for empty string.
- Validates \`video_url\` length ≤ 2000 chars (mirrors apps' \`MAX_REDIRECT_URI_LENGTH\` convention).

### comment_update.go

**No change.** Apps' \`update_comment\` only mutates \`text\` and \`is_edited\`; both new fields are write-once at create.

## Test plan

5 DB-backed tests in [comment_fan_club_test.go](pkg/etl/processors/entity_manager/comment_fan_club_test.go):

- [x] \`TestCommentCreate_FanClubMembersOnly\` — happy path, both fields persist
- [x] \`TestCommentCreate_FanClubVideoURLOnly\` — \`video_url\` without flag, FanClub
- [x] \`TestCommentCreate_NonFanClubDefaultsFalse\` — Track comments default false
- [x] \`TestCommentCreate_RejectsMembersOnlyOnTrack\` — validation error
- [x] \`TestCommentCreate_RejectsOverlongVideoURL\` — 2000-char cap

Plus:

- [x] All existing \`TestComment*\` tests pass (no regressions)
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)