### PR TITLE
fix(core): coerce nil ProverAddresses in finalizeStorageProof to unstick prod chain

### DIFF
--- a/pkg/core/server/pos.go
+++ b/pkg/core/server/pos.go
@@ -298,6 +298,14 @@ func (s *Server) finalizeStorageProof(ctx context.Context, tx *v1.SignedTransact
 
 	proofSigStr := base64.StdEncoding.EncodeToString(sp.ProofSignature)
 
+	// pgx serializes a nil slice as SQL NULL, which violates the NOT NULL
+	// constraint on storage_proofs.prover_addresses and aborts the
+	// FinalizeBlock transaction — halting the chain.
+	proverAddresses := sp.ProverAddresses
+	if proverAddresses == nil {
+		proverAddresses = []string{}
+	}
+
 	if err := qtx.InsertStorageProof(
 		ctx,
 		db.InsertStorageProofParams{
@@ -305,7 +313,7 @@ func (s *Server) finalizeStorageProof(ctx context.Context, tx *v1.SignedTransact
 			Address:         sp.Address,
 			Cid:             pgtype.Text{String: sp.Cid, Valid: true},
 			ProofSignature:  pgtype.Text{String: proofSigStr, Valid: true},
-			ProverAddresses: sp.ProverAddresses,
+			ProverAddresses: proverAddresses,
 		},
 	); err != nil {
 		return nil, fmt.Errorf("could not persist storage proof in db: %v", err)


### PR DESCRIPTION
## Summary

Prod chain (audius-mainnet-alpha-beta) halted at block 25229899 on 2026-05-26 09:47:22 UTC. Every validator hits the same deterministic failure attempting to commit block 25229900.

A \`StorageProof\` transaction in block 25229900 has an empty/nil \`ProverAddresses\`. \`finalizeStorageProof\` (\`pkg/core/server/pos.go:285\`) passes that nil slice straight to \`InsertStorageProof\`. pgx serializes the nil slice as SQL \`NULL\`, which violates the \`NOT NULL\` constraint on \`storage_proofs.prover_addresses\` (migration \`00013_proof_of_storage.sql:27\`):

\`\`\`
ERROR: null value in column "prover_addresses" of relation "storage_proofs"
       violates not-null constraint (SQLSTATE 23502)
\`\`\`

That leaves the pgx transaction in aborted state (\`SQLSTATE 25P02\`), so every subsequent write in the same FinalizeBlock errors. \`Commit\` returns ROLLBACK:

\`\`\`
ERROR  client error during proxyAppConn.CommitSync  err=commit unexpectedly resulted in rollback
ERROR  CONSENSUS FAILURE!!!  err=failed to apply block; error commit failed for application
\`\`\`

CometBFT panics in \`finalizeCommit\` at \`0x180fa4c\` = 25229900. Because the failure is deterministic against the same proposed block, every validator hits it and consensus cannot advance.

This patch coerces a nil \`ProverAddresses\` to \`[]string{}\` before insert so the column receives \`'{}'\` instead of \`NULL\`. The change is deterministic — once a supermajority of validators is on the new binary, block 25229900 commits with \`prover_addresses = '{}'\` and the chain advances.

## What this PR does NOT do

Intentionally avoiding new \`CheckTx\` rejection rules in this patch — adding a "reject empty \`ProverAddresses\`" check would keep the chain stuck. Stricter validation in \`isValidStorageProofTx\` and a guard in \`sendPoSChallengeToStorage\` to skip submission when no provers resolve should ship as a follow-up once the chain is unstuck.
