### PR TITLE
[DO NOT MERGE] hotfix(1.3.0): coerce nil ProverAddresses — chain-halt CI build

### DIFF
--- a/pkg/core/server/pos.go
+++ b/pkg/core/server/pos.go
@@ -298,6 +298,14 @@ func (s *Server) finalizeStorageProof(ctx context.Context, tx *v1.SignedTransact
 
 	proofSigStr := base64.StdEncoding.EncodeToString(sp.ProofSignature)
 
+	// pgx serializes a nil slice as SQL NULL, which violates the NOT NULL
+	// constraint on storage_proofs.prover_addresses and aborts the
+	// FinalizeBlock transaction — halting the chain.
+	proverAddresses := sp.ProverAddresses
+	if proverAddresses == nil {
+		proverAddresses = []string{}
+	}
+
 	if err := qtx.InsertStorageProof(
 		ctx,
 		db.InsertStorageProofParams{
@@ -305,7 +313,7 @@ func (s *Server) finalizeStorageProof(ctx context.Context, tx *v1.SignedTransact
 			Address:         sp.Address,
 			Cid:             pgtype.Text{String: sp.Cid, Valid: true},
 			ProofSignature:  pgtype.Text{String: proofSigStr, Valid: true},
-			ProverAddresses: sp.ProverAddresses,
+			ProverAddresses: proverAddresses,
 		},
 	); err != nil {
 		return nil, fmt.Errorf("could not persist storage proof in db: %v", err)


### PR DESCRIPTION
## Purpose

**Do not merge this PR.** It exists only to make CI build a Docker image of \`v1.3.0\` + the chain-halt fix from #313, so the resulting SHA-tagged image can be promoted to \`:stable\` manually.

Branch: \`hotfix/v1.3.0-pos-nil-prover-addresses\`
Base of branch: tag \`v1.3.0\` (\`ad0b9b3\`)
Cherry-picked from: #313 (\`a0c179e\`)

Diff against \`v1.3.0\` is a single one-file change in \`pkg/core/server/pos.go\`.

## CI caveat

\`ci.yml\` runs on \`pull_request\` targeting \`main\` and uses \`ref: \${{ github.ref }}\` (the \`refs/pull/N/merge\` ref), so the image CI builds for this PR is actually \`main + fix\`, **not** \`v1.3.0 + fix\`. If you need a true \`v1.3.0 + fix\` image, we'll need a different path (e.g. add \`workflow_dispatch\` to \`ci.yml\` keyed on a branch name, or tag-then-retag via \`tag-released.yml\`).

## Context

Prod chain halted at block 25229899 (2026-05-26 09:47:22 UTC). Every validator panics in \`FinalizeBlock\` for height 25229900 because a \`StorageProof\` tx in that block has nil \`ProverAddresses\`, which pgx serializes as SQL \`NULL\` and trips the \`NOT NULL\` constraint on \`storage_proofs.prover_addresses\`. Full root cause in #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)