### PR TITLE
fix(etl): tolerate co-existing writers + process each block atomically

### DIFF
--- a/pkg/etl/etl.go
+++ b/pkg/etl/etl.go
@@ -20,9 +20,8 @@ type Indexer struct {
 	startingBlockHeight int64
 	endingBlockHeight   int64
 	checkReadiness      bool
-	ChainID             string
-	config      Config
-	lastEmBlock int64 // last assigned blocks.number; incremented only for blocks with EM txs
+	ChainID string
+	config  Config
 
 	core       corev1connect.CoreServiceClient
 	pool       *pgxpool.Pool

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -305,373 +305,19 @@ func (e *Indexer) indexBlocks() error {
 	for pb := range pf.C() {
 		block := pb.Block
 
-		// Insert into etl_blocks
-		err := e.db.InsertBlock(context.Background(), db.InsertBlockParams{
-			ProposerAddress: block.Proposer,
-			BlockHeight:     block.Height,
-			BlockTime:       pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-		})
+		res, err := e.processBlock(ctx, pb)
 		if err != nil {
-			e.logger.Error("error inserting block", zap.Int64("height", block.Height), zap.Error(err))
+			// Block-level failure rolled back the entire block's tx — no
+			// partial state landed. Skip; the outer loop will reprocess
+			// when the prefetcher hands us this block on a future pass
+			// (or it stays unindexed if the failure is persistent and we
+			// crash-restart from MAX(core_indexed_blocks.height)).
+			e.logger.Error("processBlock failed",
+				zap.Int64("height", block.Height),
+				zap.Error(err))
 			continue
 		}
 
-		// Check if this block has any ManageEntity transactions.
-		// blocks.number (em_block) is only assigned for blocks with EM txs.
-		hasEM := false
-		for _, tx := range block.Transactions {
-			if _, ok := tx.Transaction.Transaction.(*corev1.SignedTransaction_ManageEntity); ok {
-				hasEM = true
-				break
-			}
-		}
-
-		// Assign em_block only for blocks with EM transactions.
-		// resolveBlockNumber is idempotent and tolerant of co-existing writers:
-		// it adopts an existing row by blockhash if one is present, otherwise
-		// inserts MAX(number)+1 via ON CONFLICT DO NOTHING. After return, the
-		// invariant `exactly one row WHERE is_current IS TRUE` holds and the
-		// row for blockHash is the one that holds it.
-		var emBlock int64
-		if hasEM {
-			n, err := e.resolveBlockNumber(block.Hash)
-			if err != nil {
-				// One retry covers the rare race where two writers picked the
-				// same number for different hashes — by retrying, we re-read
-				// MAX and try again.
-				n, err = e.resolveBlockNumber(block.Hash)
-			}
-			if err != nil {
-				e.logger.Error("error resolving block number",
-					zap.Int64("height", block.Height), zap.Error(err))
-				continue
-			}
-			emBlock = n
-		}
-
-		// Update core_indexed_blocks to track what we've indexed.
-		// em_block is NULL for blocks without EM transactions.
-		var emBlockParam any
-		if hasEM {
-			emBlockParam = emBlock
-		}
-		_, err = e.pool.Exec(context.Background(),
-			`INSERT INTO core_indexed_blocks (blockhash, chain_id, height, em_block)
-			 VALUES ($1, $2, $3, $4)
-			 ON CONFLICT (chain_id, height) DO UPDATE SET em_block = $4, blockhash = $1`,
-			block.Hash, e.ChainID, block.Height, emBlockParam)
-		if err != nil {
-			e.logger.Error("error inserting into core_indexed_blocks", zap.Int64("height", block.Height), zap.Error(err))
-		}
-
-		var emTxCount, emRejectCount int
-		blockStart := time.Now()
-
-		for index, tx := range block.Transactions {
-			insertTxParams := db.InsertTransactionParams{
-				TxHash:      tx.Hash,
-				BlockHeight: block.Height,
-				TxIndex:     int32(index),
-				TxType:      "",
-				Address:     pgtype.Text{Valid: false},
-				CreatedAt:   pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-			}
-
-			switch signedTx := tx.Transaction.Transaction.(type) {
-			case *corev1.SignedTransaction_Plays:
-				txCtx := &processors.TxContext{
-					Block:     block,
-					TxHash:    tx.Hash,
-					TxIndex:   index,
-					BlockTime: pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-					InsertTx:  insertTxParams,
-				}
-				res, err := processors.Play().Process(context.Background(), tx.Transaction, txCtx, e.db)
-				if err != nil {
-					e.logger.Error("error processing plays", zap.Error(err))
-				} else {
-					insertTxParams = res.InsertTx
-				}
-
-			case *corev1.SignedTransaction_ManageEntity:
-				me := signedTx.ManageEntity
-				emTxCount++
-
-				txCtx := &processors.TxContext{
-					Block:     block,
-					TxHash:    tx.Hash,
-					TxIndex:   index,
-					BlockTime: pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-					InsertTx:  insertTxParams,
-				}
-				res, err := processors.ManageEntity().Process(context.Background(), tx.Transaction, txCtx, e.db)
-				if err != nil {
-					e.logger.Error("error processing manage entity", zap.Error(err))
-				} else {
-					insertTxParams = res.InsertTx
-				}
-
-				txStart := time.Now()
-				emParams := em.NewParams(me, emBlock, block.Timestamp.AsTime(), block.Hash, tx.Hash, e.pool, e.logger)
-				if dErr := e.dispatcher.Dispatch(context.Background(), emParams); dErr != nil {
-					emRejectCount++
-					if em.IsValidationError(dErr) {
-						e.logger.Warn("entity manager validation rejected",
-							zap.String("entity_type", me.GetEntityType()),
-							zap.String("action", me.GetAction()),
-							zap.Int64("entity_id", me.GetEntityId()),
-							zap.Int64("user_id", me.GetUserId()),
-							zap.String("reason", dErr.Error()),
-							zap.String("hash", tx.Hash),
-						)
-					} else {
-						// Include entity_type / action / hash so we can attribute
-						// non-validation handler errors. Without this context the
-						// log line is unreadable (e.g. a bare "no rows in result
-						// set" with no clue which handler emitted it).
-						e.logger.Error("entity manager dispatch error",
-							zap.String("entity_type", me.GetEntityType()),
-							zap.String("action", me.GetAction()),
-							zap.Int64("entity_id", me.GetEntityId()),
-							zap.Int64("user_id", me.GetUserId()),
-							zap.String("hash", tx.Hash),
-							zap.Error(dErr),
-						)
-					}
-				} else {
-					e.logger.Debug("tx indexed",
-						zap.String("type", "manage_entity"),
-						zap.String("hash", tx.Hash),
-						zap.Duration("elapsed", time.Since(txStart)),
-					)
-				}
-
-				case *corev1.SignedTransaction_ValidatorRegistration:
-					insertTxParams.TxType = TxTypeValidatorRegistrationLegacy
-					// Legacy validator registration - no specific table insert needed
-				case *corev1.SignedTransaction_ValidatorDeregistration:
-					insertTxParams.TxType = TxTypeValidatorMisbehaviorDereg
-					vd := signedTx.ValidatorDeregistration
-					// For deregistration we only have comet address, we'll need to look up eth address
-					// For now use comet address, can be improved later
-					insertTxParams.Address = pgtype.Text{String: vd.CometAddress, Valid: true}
-					err = e.db.InsertValidatorMisbehaviorDeregistration(context.Background(), db.InsertValidatorMisbehaviorDeregistrationParams{
-						CometAddress: vd.CometAddress,
-						PubKey:       vd.PubKey,
-						BlockHeight:  block.Height,
-						TxHash:       tx.Hash,
-						CreatedAt:    pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-					})
-					if err != nil {
-						e.logger.Error("error inserting validator misbehavior deregistration", zap.Error(err))
-					}
-				case *corev1.SignedTransaction_SlaRollup:
-					insertTxParams.TxType = TxTypeSlaRollup
-					sr := signedTx.SlaRollup
-					// SLA rollups affect multiple validators, so we leave address as null
-
-					// Use the number of reports in the rollup as the validator count
-					// This matches what the original core system does
-					validatorCount := int32(len(sr.Reports))
-
-					// Calculate block quota (total blocks divided by number of validators)
-					var blockQuota int32 = 0
-					if sr.BlockEnd > sr.BlockStart && validatorCount > 0 {
-						blockQuota = int32(sr.BlockEnd-sr.BlockStart) / validatorCount
-					}
-
-					// Calculate BPS and TPS for this rollup period
-					blockRange := sr.BlockEnd - sr.BlockStart
-					var bps, tps float64 = 0.0, 0.0
-
-					if blockRange > 0 {
-						// Get transaction count for this block range
-						txCount := int64(0)
-						for blockHeight := sr.BlockStart; blockHeight <= sr.BlockEnd; blockHeight++ {
-							blockTxCount, err := e.db.GetBlockTransactionCount(context.Background(), blockHeight)
-							if err != nil {
-								e.logger.Debug("failed to get transaction count for block", zap.Int64("height", blockHeight), zap.Error(err))
-								continue
-							}
-							txCount += blockTxCount
-						}
-
-						// Calculate time duration from the rollup timestamp and previous rollup
-						rollupTime := sr.Timestamp.AsTime()
-						var duration float64 = 0
-
-						// Try to get the previous rollup to calculate time difference
-						if latestRollup, err := e.db.GetLatestSlaRollup(context.Background()); err == nil {
-							if latestRollup.CreatedAt.Valid {
-								duration = rollupTime.Sub(latestRollup.CreatedAt.Time).Seconds()
-							}
-						}
-
-						// If we couldn't get duration from previous rollup, estimate from block count
-						// Assuming average block time of 2 seconds
-						if duration <= 0 {
-							duration = float64(blockRange) * 2.0
-						}
-
-						// Calculate BPS and TPS
-						if duration > 0 {
-							bps = float64(blockRange) / duration
-							tps = float64(txCount) / duration
-						}
-					}
-
-					// Insert SLA rollup and get the ID
-					rollupId, err := e.db.InsertSlaRollupReturningId(context.Background(), db.InsertSlaRollupReturningIdParams{
-						BlockStart:     sr.BlockStart,
-						BlockEnd:       sr.BlockEnd,
-						BlockHeight:    block.Height,
-						ValidatorCount: validatorCount,
-						BlockQuota:     blockQuota,
-						Bps:            bps,
-						Tps:            tps,
-						TxHash:         tx.Hash,
-						CreatedAt:      pgtype.Timestamp{Time: sr.Timestamp.AsTime(), Valid: true}, // Use rollup timestamp, not block timestamp
-					})
-					if err != nil {
-						e.logger.Error("error inserting SLA rollup", zap.Error(err))
-					} else {
-						// Get storage proof challenge statistics for this SLA period
-						challengeStats, err := e.calculateChallengeStatistics(sr.BlockStart, sr.BlockEnd)
-						if err != nil {
-							e.logger.Error("error calculating challenge statistics", zap.Error(err))
-							challengeStats = make(map[string]ChallengeStats) // fallback to empty map
-						}
-
-						// Insert SLA node reports with the actual rollup ID and challenge data
-						for _, report := range sr.Reports {
-							stats := challengeStats[report.Address] // Get challenge stats for this validator
-
-							err = e.db.InsertSlaNodeReport(context.Background(), db.InsertSlaNodeReportParams{
-								SlaRollupID:        rollupId, // Use the actual rollup ID
-								Address:            report.Address,
-								NumBlocksProposed:  report.NumBlocksProposed,
-								ChallengesReceived: stats.ChallengesReceived,
-								ChallengesFailed:   stats.ChallengesFailed,
-								BlockHeight:        block.Height,
-								TxHash:             tx.Hash,
-								CreatedAt:          pgtype.Timestamp{Time: sr.Timestamp.AsTime(), Valid: true}, // Use rollup timestamp
-							})
-							if err != nil {
-								e.logger.Error("error inserting SLA node report", zap.Error(err))
-							}
-						}
-					}
-				case *corev1.SignedTransaction_StorageProof:
-					insertTxParams.TxType = TxTypeStorageProof
-					sp := signedTx.StorageProof
-					insertTxParams.Address = pgtype.Text{String: sp.Address, Valid: true}
-					err = e.db.InsertStorageProof(context.Background(), db.InsertStorageProofParams{
-						Height:          sp.Height,
-						Address:         sp.Address,
-						ProverAddresses: sp.ProverAddresses,
-						Cid:             sp.Cid,
-						ProofSignature:  sp.ProofSignature,
-						Proof:           nil, // Will be set during verification
-						Status:          "unresolved",
-						BlockHeight:     block.Height,
-						TxHash:          tx.Hash,
-						CreatedAt:       pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-					})
-					if err != nil {
-						e.logger.Error("error inserting storage proof", zap.Error(err))
-					}
-				case *corev1.SignedTransaction_StorageProofVerification:
-					insertTxParams.TxType = TxTypeStorageProofVerification
-					spv := signedTx.StorageProofVerification
-					// Storage proof verification doesn't have a specific address, leave as null
-					err = e.db.InsertStorageProofVerification(context.Background(), db.InsertStorageProofVerificationParams{
-						Height:      spv.Height,
-						Proof:       spv.Proof,
-						BlockHeight: block.Height,
-						TxHash:      tx.Hash,
-						CreatedAt:   pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-					})
-					if err != nil {
-						e.logger.Error("error inserting storage proof verification", zap.Error(err))
-					} else {
-						// Process consensus for this storage proof challenge
-						err = e.processStorageProofConsensus(spv.Height, spv.Proof, block.Height, tx.Hash, block.Timestamp.AsTime())
-						if err != nil {
-							e.logger.Error("error processing storage proof consensus", zap.Error(err))
-						}
-					}
-				case *corev1.SignedTransaction_Attestation:
-					at := signedTx.Attestation
-					if vr := at.GetValidatorRegistration(); vr != nil {
-						insertTxParams.TxType = TxTypeValidatorRegistration
-						insertTxParams.Address = pgtype.Text{String: vr.DelegateWallet, Valid: true}
-						err = e.db.InsertValidatorRegistration(context.Background(), db.InsertValidatorRegistrationParams{
-							Address:      vr.DelegateWallet,
-							Endpoint:     vr.Endpoint,
-							CometAddress: vr.CometAddress,
-							EthBlock:     fmt.Sprintf("%d", vr.EthBlock),
-							NodeType:     vr.NodeType,
-							Spid:         vr.SpId,
-							CometPubkey:  vr.PubKey,
-							VotingPower:  vr.Power,
-							BlockHeight:  block.Height,
-							TxHash:       tx.Hash,
-						})
-						if err != nil {
-							e.logger.Error("error inserting validator registration", zap.Error(err))
-						}
-						// insert RegisteredValidator record
-						err = e.db.RegisterValidator(context.Background(), db.RegisterValidatorParams{
-							Address:        vr.DelegateWallet,
-							Endpoint:       vr.Endpoint,
-							CometAddress:   vr.CometAddress,
-							NodeType:       vr.NodeType,
-							Spid:           vr.SpId,
-							VotingPower:    vr.Power,
-							Status:         "active",
-							RegisteredAt:   block.Height,
-							DeregisteredAt: pgtype.Int8{Valid: false},
-							CreatedAt:      pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-							UpdatedAt:      pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-						})
-						if err != nil {
-							e.logger.Error("error registering validator", zap.Error(err))
-						}
-					}
-					if vd := at.GetValidatorDeregistration(); vd != nil {
-						insertTxParams.TxType = TxTypeValidatorDeregistration
-						// For attestation deregistration we only have comet address, need to look up eth address
-						// For now use comet address, can be improved later
-						insertTxParams.Address = pgtype.Text{String: vd.CometAddress, Valid: true}
-						err = e.db.InsertValidatorDeregistration(context.Background(), db.InsertValidatorDeregistrationParams{
-							CometAddress: vd.CometAddress,
-							CometPubkey:  vd.PubKey,
-							BlockHeight:  block.Height,
-							TxHash:       tx.Hash,
-						})
-						if err != nil {
-							e.logger.Error("error inserting validator deregistration", zap.Error(err))
-						}
-						// insert DeregisteredValidator record
-						err = e.db.DeregisterValidator(context.Background(), db.DeregisterValidatorParams{
-							DeregisteredAt: pgtype.Int8{Int64: block.Height, Valid: true},
-							UpdatedAt:      pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
-							Status:         "deregistered",
-							CometAddress:   vd.CometAddress,
-						})
-						if err != nil {
-							e.logger.Error("error deregistering validator", zap.Error(err))
-						}
-					}
-				}
-
-			err = e.db.InsertTransaction(context.Background(), insertTxParams)
-			if err != nil {
-				e.logger.Error("error inserting transaction", zap.String("tx", tx.Hash), zap.Error(err))
-			}
-		}
-
-		blockElapsed := time.Since(blockStart)
 		blocksProcessed++
 		txsProcessed += int64(len(block.Transactions))
 
@@ -685,9 +331,9 @@ func (e *Indexer) indexBlocks() error {
 				zap.Int64("block", block.Height),
 				zap.Int64("blocks_behind", blocksBehind),
 				zap.Int("txs_in_block", len(block.Transactions)),
-				zap.Int("em_txs", emTxCount),
-				zap.Int("em_rejected", emRejectCount),
-				zap.Duration("block_time", blockElapsed),
+				zap.Int("em_txs", res.emTxCount),
+				zap.Int("em_rejected", res.emRejectCount),
+				zap.Duration("block_time", res.blockElapsed),
 				zap.Float64("blocks_per_sec", blocksPerSec),
 				zap.Float64("txs_per_sec", txsPerSec),
 				zap.Int64("total_blocks", blocksProcessed),
@@ -708,8 +354,469 @@ func (e *Indexer) indexBlocks() error {
 	return nil
 }
 
+// blockResult carries per-block stats out of processBlock for use by the
+// caller's progress logging.
+type blockResult struct {
+	emTxCount     int
+	emRejectCount int
+	blockElapsed  time.Duration
+}
+
+// processBlock indexes one CometBFT block atomically.
+//
+// All writes for the block — etl_blocks, blocks (chain head row + tip
+// promotion), core_indexed_blocks, and every entity-table write performed
+// by the per-tx handlers — share a single pgx.Tx and commit together or
+// roll back together. On any block-level error (e.g. failure to insert
+// etl_blocks, failure to resolve blocks.number even after a retry),
+// nothing for this block lands.
+//
+// Each individual transaction within the block runs inside its own
+// SAVEPOINT (via tx.Begin). A handler's failure rolls back only that
+// tx's writes; other txs in the same block continue. This matches the
+// Python discovery-provider's "swallow validation errors, continue
+// indexing" semantics, but does it correctly: partial writes from a
+// failed handler do not leak into the committed block state.
+//
+// On success the caller may advance its progress counters and assume
+// the block is fully indexed.
+func (e *Indexer) processBlock(ctx context.Context, pb prefetchedBlock) (*blockResult, error) {
+	block := pb.Block
+	blockStart := time.Now()
+	res := &blockResult{}
+
+	tx, err := e.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin block tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // safe no-op after Commit
+
+	q := e.db.WithTx(tx)
+
+	// etl_blocks: our own per-CometBFT-block tracking row.
+	if err := q.InsertBlock(ctx, db.InsertBlockParams{
+		ProposerAddress: block.Proposer,
+		BlockHeight:     block.Height,
+		BlockTime:       pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+	}); err != nil {
+		return nil, fmt.Errorf("insert etl_blocks: %w", err)
+	}
+
+	// Decide whether this block needs a `blocks` row (only blocks with EM
+	// transactions get one in the legacy schema's chain-head model).
+	hasEM := false
+	for _, t := range block.Transactions {
+		if _, ok := t.Transaction.Transaction.(*corev1.SignedTransaction_ManageEntity); ok {
+			hasEM = true
+			break
+		}
+	}
+
+	var emBlock int64
+	if hasEM {
+		n, err := e.resolveBlockNumber(ctx, tx, block.Hash)
+		if err != nil {
+			// One retry for the rare race where another writer claimed
+			// our MAX+1 with a different hash. Within our tx, both calls
+			// see the same snapshot semantics (READ COMMITTED), so the
+			// retry only helps if the conflict was with a *committed*
+			// outside writer — which is exactly the cutover scenario.
+			n, err = e.resolveBlockNumber(ctx, tx, block.Hash)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("resolve block number: %w", err)
+		}
+		emBlock = n
+	}
+
+	// core_indexed_blocks: what chain height we've indexed. em_block is
+	// NULL for blocks without EM transactions.
+	var emBlockParam any
+	if hasEM {
+		emBlockParam = emBlock
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO core_indexed_blocks (blockhash, chain_id, height, em_block)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (chain_id, height) DO UPDATE SET em_block = $4, blockhash = $1`,
+		block.Hash, e.ChainID, block.Height, emBlockParam); err != nil {
+		return nil, fmt.Errorf("insert core_indexed_blocks: %w", err)
+	}
+
+	// Per-transaction loop. Each tx runs in a SAVEPOINT so a handler
+	// error rolls back only that tx's writes — not the whole block.
+	for index, t := range block.Transactions {
+		insertTxParams := db.InsertTransactionParams{
+			TxHash:      t.Hash,
+			BlockHeight: block.Height,
+			TxIndex:     int32(index),
+			TxType:      "",
+			Address:     pgtype.Text{Valid: false},
+			CreatedAt:   pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+		}
+
+		sp, err := tx.Begin(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("begin savepoint for tx %s: %w", t.Hash, err)
+		}
+		qsp := e.db.WithTx(sp)
+
+		spOK := e.processOneTx(ctx, sp, qsp, block, emBlock, &insertTxParams, t, res)
+
+		// Always try to persist the transactions row, even if the
+		// type-specific handler rolled back its savepoint — the
+		// transactions table is an audit log of what was on-chain,
+		// independent of whether handlers consumed it. If the savepoint
+		// is gone (rolled back), we use the outer tx's queries handle.
+		if spOK {
+			if err := qsp.InsertTransaction(ctx, insertTxParams); err != nil {
+				e.logger.Error("error inserting transaction",
+					zap.String("tx", t.Hash), zap.Error(err))
+				_ = sp.Rollback(ctx)
+				continue
+			}
+			if err := sp.Commit(ctx); err != nil {
+				e.logger.Error("error committing savepoint for tx",
+					zap.String("tx", t.Hash), zap.Error(err))
+			}
+		} else {
+			// processOneTx already rolled back sp; record the tx row in
+			// the outer tx so the audit log still reflects it.
+			if err := q.InsertTransaction(ctx, insertTxParams); err != nil {
+				e.logger.Error("error inserting transaction (post-rollback)",
+					zap.String("tx", t.Hash), zap.Error(err))
+			}
+		}
+	}
+
+	res.blockElapsed = time.Since(blockStart)
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit block tx: %w", err)
+	}
+	return res, nil
+}
+
+// processOneTx dispatches a single core transaction inside its caller-
+// supplied savepoint. Returns true if the savepoint is still active for
+// the caller to Commit; false if processOneTx already rolled it back due
+// to a handler error.
+//
+// Note: ManageEntity validation errors are logged but kept on the
+// savepoint (they don't roll back) because the validation-failed state
+// is "this tx was on-chain but our handler chose not to act on it",
+// which matches Python's swallow-and-continue behavior. Hard errors
+// from a handler do trigger a rollback so partial writes don't land.
+func (e *Indexer) processOneTx(
+	ctx context.Context,
+	sp pgx.Tx,
+	q *db.Queries,
+	block *corev1.Block,
+	emBlock int64,
+	insertTxParams *db.InsertTransactionParams,
+	t *corev1.Transaction,
+	res *blockResult,
+) bool {
+	txCtx := &processors.TxContext{
+		Block:     block,
+		TxHash:    t.Hash,
+		TxIndex:   int(insertTxParams.TxIndex),
+		BlockTime: pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+		InsertTx:  *insertTxParams,
+	}
+
+	switch signedTx := t.Transaction.Transaction.(type) {
+	case *corev1.SignedTransaction_Plays:
+		pr, err := processors.Play().Process(ctx, t.Transaction, txCtx, q)
+		if err != nil {
+			e.logger.Error("error processing plays",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+		*insertTxParams = pr.InsertTx
+
+	case *corev1.SignedTransaction_ManageEntity:
+		me := signedTx.ManageEntity
+		res.emTxCount++
+
+		pr, err := processors.ManageEntity().Process(ctx, t.Transaction, txCtx, q)
+		if err != nil {
+			e.logger.Error("error processing manage entity",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+		*insertTxParams = pr.InsertTx
+
+		txStart := time.Now()
+		emParams := em.NewParams(me, emBlock, block.Timestamp.AsTime(),
+			block.Hash, t.Hash, sp, e.logger)
+		if dErr := e.dispatcher.Dispatch(ctx, emParams); dErr != nil {
+			res.emRejectCount++
+			if em.IsValidationError(dErr) {
+				// Validation errors mean "the tx was on-chain but its
+				// payload was malformed, so we choose not to act on it".
+				// Match Python's swallow-and-continue: keep the savepoint
+				// alive so the tx's audit row still lands.
+				e.logger.Warn("entity manager validation rejected",
+					zap.String("entity_type", me.GetEntityType()),
+					zap.String("action", me.GetAction()),
+					zap.Int64("entity_id", me.GetEntityId()),
+					zap.Int64("user_id", me.GetUserId()),
+					zap.String("reason", dErr.Error()),
+					zap.String("hash", t.Hash),
+				)
+			} else {
+				// Hard error from the handler: any partial writes are
+				// rolled back via the savepoint. The tx's audit row is
+				// still recorded by processBlock using the outer tx.
+				e.logger.Error("entity manager dispatch error",
+					zap.String("entity_type", me.GetEntityType()),
+					zap.String("action", me.GetAction()),
+					zap.Int64("entity_id", me.GetEntityId()),
+					zap.Int64("user_id", me.GetUserId()),
+					zap.String("hash", t.Hash),
+					zap.Error(dErr),
+				)
+				_ = sp.Rollback(ctx)
+				return false
+			}
+		} else {
+			e.logger.Debug("tx indexed",
+				zap.String("type", "manage_entity"),
+				zap.String("hash", t.Hash),
+				zap.Duration("elapsed", time.Since(txStart)),
+			)
+		}
+
+	case *corev1.SignedTransaction_ValidatorRegistration:
+		insertTxParams.TxType = TxTypeValidatorRegistrationLegacy
+		// Legacy validator registration - no specific table insert needed
+
+	case *corev1.SignedTransaction_ValidatorDeregistration:
+		insertTxParams.TxType = TxTypeValidatorMisbehaviorDereg
+		vd := signedTx.ValidatorDeregistration
+		insertTxParams.Address = pgtype.Text{String: vd.CometAddress, Valid: true}
+		if err := q.InsertValidatorMisbehaviorDeregistration(ctx, db.InsertValidatorMisbehaviorDeregistrationParams{
+			CometAddress: vd.CometAddress,
+			PubKey:       vd.PubKey,
+			BlockHeight:  block.Height,
+			TxHash:       t.Hash,
+			CreatedAt:    pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+		}); err != nil {
+			e.logger.Error("error inserting validator misbehavior deregistration",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+
+	case *corev1.SignedTransaction_SlaRollup:
+		insertTxParams.TxType = TxTypeSlaRollup
+		sr := signedTx.SlaRollup
+
+		validatorCount := int32(len(sr.Reports))
+		var blockQuota int32
+		if sr.BlockEnd > sr.BlockStart && validatorCount > 0 {
+			blockQuota = int32(sr.BlockEnd-sr.BlockStart) / validatorCount
+		}
+
+		blockRange := sr.BlockEnd - sr.BlockStart
+		var bps, tps float64
+		if blockRange > 0 {
+			txCount := int64(0)
+			for blockHeight := sr.BlockStart; blockHeight <= sr.BlockEnd; blockHeight++ {
+				blockTxCount, err := q.GetBlockTransactionCount(ctx, blockHeight)
+				if err != nil {
+					e.logger.Debug("failed to get transaction count for block",
+						zap.Int64("height", blockHeight), zap.Error(err))
+					continue
+				}
+				txCount += blockTxCount
+			}
+
+			rollupTime := sr.Timestamp.AsTime()
+			var duration float64
+			if latestRollup, err := q.GetLatestSlaRollup(ctx); err == nil {
+				if latestRollup.CreatedAt.Valid {
+					duration = rollupTime.Sub(latestRollup.CreatedAt.Time).Seconds()
+				}
+			}
+			if duration <= 0 {
+				duration = float64(blockRange) * 2.0
+			}
+			if duration > 0 {
+				bps = float64(blockRange) / duration
+				tps = float64(txCount) / duration
+			}
+		}
+
+		rollupId, err := q.InsertSlaRollupReturningId(ctx, db.InsertSlaRollupReturningIdParams{
+			BlockStart:     sr.BlockStart,
+			BlockEnd:       sr.BlockEnd,
+			BlockHeight:    block.Height,
+			ValidatorCount: validatorCount,
+			BlockQuota:     blockQuota,
+			Bps:            bps,
+			Tps:            tps,
+			TxHash:         t.Hash,
+			CreatedAt:      pgtype.Timestamp{Time: sr.Timestamp.AsTime(), Valid: true},
+		})
+		if err != nil {
+			e.logger.Error("error inserting SLA rollup",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+
+		challengeStats, err := e.calculateChallengeStatistics(ctx, q, sr.BlockStart, sr.BlockEnd)
+		if err != nil {
+			e.logger.Error("error calculating challenge statistics",
+				zap.String("hash", t.Hash), zap.Error(err))
+			challengeStats = make(map[string]ChallengeStats)
+		}
+
+		for _, report := range sr.Reports {
+			stats := challengeStats[report.Address]
+			if err := q.InsertSlaNodeReport(ctx, db.InsertSlaNodeReportParams{
+				SlaRollupID:        rollupId,
+				Address:            report.Address,
+				NumBlocksProposed:  report.NumBlocksProposed,
+				ChallengesReceived: stats.ChallengesReceived,
+				ChallengesFailed:   stats.ChallengesFailed,
+				BlockHeight:        block.Height,
+				TxHash:             t.Hash,
+				CreatedAt:          pgtype.Timestamp{Time: sr.Timestamp.AsTime(), Valid: true},
+			}); err != nil {
+				e.logger.Error("error inserting SLA node report",
+					zap.String("hash", t.Hash),
+					zap.String("address", report.Address),
+					zap.Error(err))
+				_ = sp.Rollback(ctx)
+				return false
+			}
+		}
+
+	case *corev1.SignedTransaction_StorageProof:
+		insertTxParams.TxType = TxTypeStorageProof
+		spx := signedTx.StorageProof
+		insertTxParams.Address = pgtype.Text{String: spx.Address, Valid: true}
+		if err := q.InsertStorageProof(ctx, db.InsertStorageProofParams{
+			Height:          spx.Height,
+			Address:         spx.Address,
+			ProverAddresses: spx.ProverAddresses,
+			Cid:             spx.Cid,
+			ProofSignature:  spx.ProofSignature,
+			Proof:           nil, // Will be set during verification
+			Status:          "unresolved",
+			BlockHeight:     block.Height,
+			TxHash:          t.Hash,
+			CreatedAt:       pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+		}); err != nil {
+			e.logger.Error("error inserting storage proof",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+
+	case *corev1.SignedTransaction_StorageProofVerification:
+		insertTxParams.TxType = TxTypeStorageProofVerification
+		spv := signedTx.StorageProofVerification
+		if err := q.InsertStorageProofVerification(ctx, db.InsertStorageProofVerificationParams{
+			Height:      spv.Height,
+			Proof:       spv.Proof,
+			BlockHeight: block.Height,
+			TxHash:      t.Hash,
+			CreatedAt:   pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+		}); err != nil {
+			e.logger.Error("error inserting storage proof verification",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+		if err := e.processStorageProofConsensus(ctx, q, spv.Height, spv.Proof,
+			block.Height, t.Hash, block.Timestamp.AsTime()); err != nil {
+			e.logger.Error("error processing storage proof consensus",
+				zap.String("hash", t.Hash), zap.Error(err))
+			_ = sp.Rollback(ctx)
+			return false
+		}
+
+	case *corev1.SignedTransaction_Attestation:
+		at := signedTx.Attestation
+		if vr := at.GetValidatorRegistration(); vr != nil {
+			insertTxParams.TxType = TxTypeValidatorRegistration
+			insertTxParams.Address = pgtype.Text{String: vr.DelegateWallet, Valid: true}
+			if err := q.InsertValidatorRegistration(ctx, db.InsertValidatorRegistrationParams{
+				Address:      vr.DelegateWallet,
+				Endpoint:     vr.Endpoint,
+				CometAddress: vr.CometAddress,
+				EthBlock:     fmt.Sprintf("%d", vr.EthBlock),
+				NodeType:     vr.NodeType,
+				Spid:         vr.SpId,
+				CometPubkey:  vr.PubKey,
+				VotingPower:  vr.Power,
+				BlockHeight:  block.Height,
+				TxHash:       t.Hash,
+			}); err != nil {
+				e.logger.Error("error inserting validator registration",
+					zap.String("hash", t.Hash), zap.Error(err))
+				_ = sp.Rollback(ctx)
+				return false
+			}
+			if err := q.RegisterValidator(ctx, db.RegisterValidatorParams{
+				Address:        vr.DelegateWallet,
+				Endpoint:       vr.Endpoint,
+				CometAddress:   vr.CometAddress,
+				NodeType:       vr.NodeType,
+				Spid:           vr.SpId,
+				VotingPower:    vr.Power,
+				Status:         "active",
+				RegisteredAt:   block.Height,
+				DeregisteredAt: pgtype.Int8{Valid: false},
+				CreatedAt:      pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+				UpdatedAt:      pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+			}); err != nil {
+				e.logger.Error("error registering validator",
+					zap.String("hash", t.Hash), zap.Error(err))
+				_ = sp.Rollback(ctx)
+				return false
+			}
+		}
+		if vd := at.GetValidatorDeregistration(); vd != nil {
+			insertTxParams.TxType = TxTypeValidatorDeregistration
+			insertTxParams.Address = pgtype.Text{String: vd.CometAddress, Valid: true}
+			if err := q.InsertValidatorDeregistration(ctx, db.InsertValidatorDeregistrationParams{
+				CometAddress: vd.CometAddress,
+				CometPubkey:  vd.PubKey,
+				BlockHeight:  block.Height,
+				TxHash:       t.Hash,
+			}); err != nil {
+				e.logger.Error("error inserting validator deregistration",
+					zap.String("hash", t.Hash), zap.Error(err))
+				_ = sp.Rollback(ctx)
+				return false
+			}
+			if err := q.DeregisterValidator(ctx, db.DeregisterValidatorParams{
+				DeregisteredAt: pgtype.Int8{Int64: block.Height, Valid: true},
+				UpdatedAt:      pgtype.Timestamp{Time: block.Timestamp.AsTime(), Valid: true},
+				Status:         "deregistered",
+				CometAddress:   vd.CometAddress,
+			}); err != nil {
+				e.logger.Error("error deregistering validator",
+					zap.String("hash", t.Hash), zap.Error(err))
+				_ = sp.Rollback(ctx)
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 // resolveBlockNumber returns the blocks.number for blockHash and ensures
-// the row for blockHash is the unique tip (is_current = true).
+// the row for blockHash is the unique tip (is_current = true), all within
+// the caller-supplied transaction.
 //
 // Idempotent and tolerant of co-existing writers (e.g. the legacy Python
 // indexer during a cutover): if a row for blockHash already exists, its
@@ -720,22 +827,17 @@ func (e *Indexer) indexBlocks() error {
 //
 // On a number-collision race with another writer (our INSERT no-op'd
 // because some other hash claimed MAX+1 first), the final SELECT returns
-// pgx.ErrNoRows. The caller retries — the next attempt sees a higher MAX
-// and proceeds.
-func (e *Indexer) resolveBlockNumber(blockHash string) (int64, error) {
-	ctx := context.Background()
-
-	tx, err := e.pool.Begin(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("begin: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
+// pgx.ErrNoRows wrapped in the returned error. The caller retries — the
+// next attempt sees a higher MAX and proceeds.
+//
+// Operates on the caller's tx (or savepoint) so the block-row work
+// commits atomically with the rest of the block's entity writes.
+func (e *Indexer) resolveBlockNumber(ctx context.Context, tx pgx.Tx, blockHash string) (int64, error) {
 	// Snapshot the prior tip's hash for our parenthash. nil when the table
 	// is empty or has no current row (e.g. mid-recovery after an interrupted
 	// writer left no is_current=true).
 	var parentHash *string
-	err = tx.QueryRow(ctx,
+	err := tx.QueryRow(ctx,
 		"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&parentHash)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return 0, fmt.Errorf("read prev tip: %w", err)
@@ -782,9 +884,6 @@ func (e *Indexer) resolveBlockNumber(blockHash string) (int64, error) {
 			blockHash, err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return 0, fmt.Errorf("commit: %w", err)
-	}
 	return num, nil
 }
 
@@ -841,12 +940,14 @@ func (e *Indexer) startPgNotifyListener(ctx context.Context) error {
 // NOTE: This function may be called before all storage proof data for the block range is available,
 // leading to potentially inaccurate pre-calculated statistics. Consider calculating these dynamically
 // in the UI instead of storing them in the database.
-func (e *Indexer) calculateChallengeStatistics(blockStart, blockEnd int64) (map[string]ChallengeStats, error) {
-	ctx := context.Background()
+// calculateChallengeStatistics reads challenge stats over a block range
+// using the caller's tx-scoped queries handle, so its reads see the
+// in-progress block's writes.
+func (e *Indexer) calculateChallengeStatistics(ctx context.Context, q *db.Queries, blockStart, blockEnd int64) (map[string]ChallengeStats, error) {
 	stats := make(map[string]ChallengeStats)
 
 	// Use the ETL database method to get challenge statistics with proper status tracking
-	results, err := e.db.GetChallengeStatisticsForBlockRange(ctx, db.GetChallengeStatisticsForBlockRangeParams{
+	results, err := q.GetChallengeStatisticsForBlockRange(ctx, db.GetChallengeStatisticsForBlockRangeParams{
 		Height:   blockStart,
 		Height_2: blockEnd,
 	})
@@ -865,11 +966,11 @@ func (e *Indexer) calculateChallengeStatistics(blockStart, blockEnd int64) (map[
 	return stats, nil
 }
 
-func (e *Indexer) processStorageProofConsensus(height int64, proof []byte, blockHeight int64, txHash string, blockTime time.Time) error {
-	ctx := context.Background()
-
+// processStorageProofConsensus reads and writes storage proof state using
+// the caller's tx-scoped queries handle.
+func (e *Indexer) processStorageProofConsensus(ctx context.Context, q *db.Queries, height int64, proof []byte, blockHeight int64, txHash string, blockTime time.Time) error {
 	// Get all storage proofs for this height
-	storageProofs, err := e.db.GetStorageProofsForHeight(ctx, height)
+	storageProofs, err := q.GetStorageProofsForHeight(ctx, height)
 	if err != nil {
 		return fmt.Errorf("error getting storage proofs for height %d: %v", height, err)
 	}
@@ -898,7 +999,7 @@ func (e *Indexer) processStorageProofConsensus(height int64, proof []byte, block
 	for _, sp := range storageProofs {
 		if sp.Address != "" && sp.ProofSignature != nil {
 			// This prover submitted a proof - mark as passed
-			err = e.db.UpdateStorageProofStatus(ctx, db.UpdateStorageProofStatusParams{
+			err = q.UpdateStorageProofStatus(ctx, db.UpdateStorageProofStatusParams{
 				Status:  "pass",
 				Proof:   proof,
 				Height:  height,
@@ -916,7 +1017,7 @@ func (e *Indexer) processStorageProofConsensus(height int64, proof []byte, block
 	for expectedProver, voteCount := range expectedProvers {
 		if voteCount > majorityThreshold && !passedProvers[expectedProver] {
 			// This validator was expected by majority consensus but didn't submit a proof
-			err = e.db.InsertFailedStorageProof(ctx, db.InsertFailedStorageProofParams{
+			err = q.InsertFailedStorageProof(ctx, db.InsertFailedStorageProofParams{
 				Height:      height,
 				Address:     expectedProver,
 				BlockHeight: blockHeight,

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -180,19 +180,10 @@ func (e *Indexer) Run() error {
 		e.logger.Error("error initializing chain ID", zap.Error(err))
 	}
 
-	// Initialize lastEmBlock: the last assigned blocks.number value.
-	// em_block is incremented sequentially, only for blocks with EM transactions.
-	// We continue the sequence from wherever the existing DB left off.
-	err = e.pool.QueryRow(context.Background(),
-		"SELECT COALESCE(MAX(number), 0) FROM blocks").Scan(&e.lastEmBlock)
-	if err != nil {
-		e.logger.Warn("could not determine last em_block, starting from 0", zap.Error(err))
-		e.lastEmBlock = 0
-	} else {
-		e.logger.Info("last em_block (blocks.number) determined",
-			zap.Int64("last_em_block", e.lastEmBlock),
-		)
-	}
+	// blocks.number is resolved per-block at indexing time via
+	// resolveBlockNumber, which uses MAX(number)+1 in-statement. The DB is
+	// the source of truth — no in-memory counter to drift from concurrent
+	// writers or stale snapshots.
 
 	e.logger.Info("starting etl service")
 
@@ -335,20 +326,27 @@ func (e *Indexer) indexBlocks() error {
 			}
 		}
 
-		// Assign em_block only for blocks with EM transactions. Marks the previous
-		// block is_current=false then inserts the new one is_current=true. The
-		// blocks table has a unique partial index on (is_current) WHERE
-		// is_current IS TRUE, so the previous block must be updated BEFORE
-		// inserting the new one.
+		// Assign em_block only for blocks with EM transactions.
+		// resolveBlockNumber is idempotent and tolerant of co-existing writers:
+		// it adopts an existing row by blockhash if one is present, otherwise
+		// inserts MAX(number)+1 via ON CONFLICT DO NOTHING. After return, the
+		// invariant `exactly one row WHERE is_current IS TRUE` holds and the
+		// row for blockHash is the one that holds it.
 		var emBlock int64
 		if hasEM {
-			e.lastEmBlock++
-			emBlock = e.lastEmBlock
-
-			if err := e.insertCurrentBlock(block.Hash, emBlock, block.Height); err != nil {
-				e.lastEmBlock--
+			n, err := e.resolveBlockNumber(block.Hash)
+			if err != nil {
+				// One retry covers the rare race where two writers picked the
+				// same number for different hashes — by retrying, we re-read
+				// MAX and try again.
+				n, err = e.resolveBlockNumber(block.Hash)
+			}
+			if err != nil {
+				e.logger.Error("error resolving block number",
+					zap.Int64("height", block.Height), zap.Error(err))
 				continue
 			}
+			emBlock = n
 		}
 
 		// Update core_indexed_blocks to track what we've indexed.
@@ -710,47 +708,84 @@ func (e *Indexer) indexBlocks() error {
 	return nil
 }
 
-// insertCurrentBlock atomically swaps the is_current block in a transaction.
-func (e *Indexer) insertCurrentBlock(blockHash string, emBlock int64, height int64) error {
-	tx, err := e.pool.Begin(context.Background())
-	if err != nil {
-		e.logger.Error("error starting blocks transaction", zap.Error(err))
-		return err
-	}
-	defer tx.Rollback(context.Background())
+// resolveBlockNumber returns the blocks.number for blockHash and ensures
+// the row for blockHash is the unique tip (is_current = true).
+//
+// Idempotent and tolerant of co-existing writers (e.g. the legacy Python
+// indexer during a cutover): if a row for blockHash already exists, its
+// number is adopted and is_current is re-asserted. If not, a new row is
+// inserted at MAX(number)+1 computed in-statement. The DB is the source
+// of truth; no in-memory counter to drift from concurrent writers or
+// stale snapshots.
+//
+// On a number-collision race with another writer (our INSERT no-op'd
+// because some other hash claimed MAX+1 first), the final SELECT returns
+// pgx.ErrNoRows. The caller retries — the next attempt sees a higher MAX
+// and proceeds.
+func (e *Indexer) resolveBlockNumber(blockHash string) (int64, error) {
+	ctx := context.Background()
 
-	// Get the previous current block's hash (for parenthash).
-	var prevHash *string
-	err = tx.QueryRow(context.Background(),
-		"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&prevHash)
+	tx, err := e.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Snapshot the prior tip's hash for our parenthash. nil when the table
+	// is empty or has no current row (e.g. mid-recovery after an interrupted
+	// writer left no is_current=true).
+	var parentHash *string
+	err = tx.QueryRow(ctx,
+		"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&parentHash)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		e.logger.Error("error fetching previous current block hash", zap.Error(err))
-		return err
+		return 0, fmt.Errorf("read prev tip: %w", err)
 	}
 
-	// Mark previous block as not current.
-	_, err = tx.Exec(context.Background(),
-		"UPDATE blocks SET is_current = false WHERE is_current IS TRUE")
+	// Demote the prior tip — but not ourselves, so idempotent re-processing
+	// of the same block doesn't briefly flip its row to is_current=false.
+	if _, err := tx.Exec(ctx,
+		"UPDATE blocks SET is_current = false WHERE is_current IS TRUE AND blockhash != $1",
+		blockHash); err != nil {
+		return 0, fmt.Errorf("demote prev tip: %w", err)
+	}
+
+	// Insert with MAX(number)+1 computed atomically. If a row for blockHash
+	// already exists (we're re-processing, or another writer beat us), or
+	// if another writer claimed MAX+1 with a different hash, ON CONFLICT
+	// silently no-ops. The subsequent UPDATE + SELECT then decide what
+	// happened.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO blocks (blockhash, parenthash, number, is_current)
+		SELECT $1, $2, COALESCE((SELECT MAX(number) FROM blocks), 0) + 1, true
+		ON CONFLICT DO NOTHING`,
+		blockHash, parentHash); err != nil {
+		return 0, fmt.Errorf("insert block: %w", err)
+	}
+
+	// Re-assert is_current on the row for blockHash. If we just inserted
+	// it, the INSERT already set is_current=true and this is a no-op. If
+	// the row pre-existed with is_current=false, this promotes it to tip.
+	if _, err := tx.Exec(ctx,
+		"UPDATE blocks SET is_current = true WHERE blockhash = $1 AND is_current IS FALSE",
+		blockHash); err != nil {
+		return 0, fmt.Errorf("re-assert is_current: %w", err)
+	}
+
+	var num int64
+	err = tx.QueryRow(ctx,
+		"SELECT number FROM blocks WHERE blockhash = $1", blockHash).Scan(&num)
 	if err != nil {
-		e.logger.Error("error marking previous block not current", zap.Error(err))
-		return err
+		// No row for our hash: we lost a (number) race with a different
+		// hash and our INSERT was the one ON CONFLICT skipped. Surface so
+		// the caller retries with a higher MAX.
+		return 0, fmt.Errorf("block %s not present after insert (number race): %w",
+			blockHash, err)
 	}
 
-	// Insert new block as current.
-	_, err = tx.Exec(context.Background(),
-		`INSERT INTO blocks (blockhash, parenthash, number, is_current)
-		 VALUES ($1, $2, $3, true)`,
-		blockHash, prevHash, emBlock)
-	if err != nil {
-		e.logger.Error("error inserting into blocks table", zap.Int64("height", height), zap.Error(err))
-		return err
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
 	}
-
-	if err := tx.Commit(context.Background()); err != nil {
-		e.logger.Error("error committing blocks transaction", zap.Error(err))
-		return err
-	}
-	return nil
+	return num, nil
 }
 
 func (e *Indexer) startPgNotifyListener(ctx context.Context) error {

--- a/pkg/etl/resolve_block_number_test.go
+++ b/pkg/etl/resolve_block_number_test.go
@@ -39,6 +39,28 @@ func newTestIndexer(pool *pgxpool.Pool) *Indexer {
 	return &Indexer{pool: pool, logger: zap.NewNop()}
 }
 
+// callResolveBlockNumber wraps resolveBlockNumber in its own transaction
+// for the test. Production callers (processBlock) own the tx; in tests
+// we provide one inline so the assertions can read the committed state.
+func callResolveBlockNumber(t *testing.T, pool *pgxpool.Pool, ix *Indexer, blockHash string) (int64, error) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	num, err := ix.resolveBlockNumber(ctx, tx, blockHash)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit tx: %v", err)
+	}
+	return num, nil
+}
+
 // countCurrentTips counts how many blocks have is_current = true. The
 // partial unique index guarantees this is at most 1 in steady state;
 // we use it to assert the tip invariant after every resolveBlockNumber call.
@@ -94,7 +116,7 @@ func TestResolveBlockNumber_EmptyTable(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ix := newTestIndexer(pool)
 
-	got, err := ix.resolveBlockNumber("blk-genesis")
+	got, err := callResolveBlockNumber(t, pool, ix, "blk-genesis")
 	if err != nil {
 		t.Fatalf("resolveBlockNumber: %v", err)
 	}
@@ -118,7 +140,7 @@ func TestResolveBlockNumber_AppendsToChain(t *testing.T) {
 
 	// Build up a 3-block chain via the function under test.
 	for i, hash := range []string{"blk-1", "blk-2", "blk-3"} {
-		n, err := ix.resolveBlockNumber(hash)
+		n, err := callResolveBlockNumber(t, pool, ix, hash)
 		if err != nil {
 			t.Fatalf("step %d resolveBlockNumber: %v", i, err)
 		}
@@ -154,7 +176,7 @@ func TestResolveBlockNumber_AdoptsExistingByHash(t *testing.T) {
 	}
 
 	ix := newTestIndexer(pool)
-	got, err := ix.resolveBlockNumber("blk-prewritten")
+	got, err := callResolveBlockNumber(t, pool, ix, "blk-prewritten")
 	if err != nil {
 		t.Fatalf("resolveBlockNumber: %v", err)
 	}
@@ -199,7 +221,7 @@ func TestResolveBlockNumber_TipInvariantAfterFossils(t *testing.T) {
 	}
 
 	ix := newTestIndexer(pool)
-	got, err := ix.resolveBlockNumber("blk-new")
+	got, err := callResolveBlockNumber(t, pool, ix, "blk-new")
 	if err != nil {
 		t.Fatalf("resolveBlockNumber: %v", err)
 	}
@@ -221,11 +243,11 @@ func TestResolveBlockNumber_IdempotentSameHash(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ix := newTestIndexer(pool)
 
-	first, err := ix.resolveBlockNumber("blk-X")
+	first, err := callResolveBlockNumber(t, pool, ix, "blk-X")
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
-	second, err := ix.resolveBlockNumber("blk-X")
+	second, err := callResolveBlockNumber(t, pool, ix, "blk-X")
 	if err != nil {
 		t.Fatalf("second: %v", err)
 	}
@@ -248,10 +270,10 @@ func TestResolveBlockNumber_ParentHashIsPriorTip(t *testing.T) {
 	ctx := context.Background()
 	ix := newTestIndexer(pool)
 
-	if _, err := ix.resolveBlockNumber("blk-A"); err != nil {
+	if _, err := callResolveBlockNumber(t, pool, ix, "blk-A"); err != nil {
 		t.Fatalf("seed A: %v", err)
 	}
-	if _, err := ix.resolveBlockNumber("blk-B"); err != nil {
+	if _, err := callResolveBlockNumber(t, pool, ix, "blk-B"); err != nil {
 		t.Fatalf("insert B: %v", err)
 	}
 
@@ -276,7 +298,7 @@ func TestResolveBlockNumber_NumberValueIsStoredCorrectly(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ix := newTestIndexer(pool)
 
-	got, err := ix.resolveBlockNumber("blk-Y")
+	got, err := callResolveBlockNumber(t, pool, ix, "blk-Y")
 	if err != nil {
 		t.Fatalf("resolveBlockNumber: %v", err)
 	}

--- a/pkg/etl/resolve_block_number_test.go
+++ b/pkg/etl/resolve_block_number_test.go
@@ -1,0 +1,287 @@
+package etl
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap"
+)
+
+// setupBlocksTestDB returns a pool with ETL migrations applied and the
+// `blocks` table truncated. Skips if ETL_TEST_DB_URL is unset.
+func setupBlocksTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dbURL := os.Getenv("ETL_TEST_DB_URL")
+	if dbURL == "" {
+		t.Skip("ETL_TEST_DB_URL not set")
+	}
+	logger, _ := zap.NewDevelopment()
+	if err := db.RunMigrations(logger, dbURL, true); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	if _, err := pool.Exec(context.Background(), `TRUNCATE blocks CASCADE`); err != nil {
+		t.Fatalf("truncate blocks: %v", err)
+	}
+	return pool
+}
+
+func newTestIndexer(pool *pgxpool.Pool) *Indexer {
+	return &Indexer{pool: pool, logger: zap.NewNop()}
+}
+
+// countCurrentTips counts how many blocks have is_current = true. The
+// partial unique index guarantees this is at most 1 in steady state;
+// we use it to assert the tip invariant after every resolveBlockNumber call.
+func countCurrentTips(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM blocks WHERE is_current IS TRUE`).Scan(&n); err != nil {
+		t.Fatalf("count tips: %v", err)
+	}
+	return n
+}
+
+// currentTipHash returns the blockhash of the unique is_current=true row.
+// Fails the test if zero or more than one row matches.
+func currentTipHash(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	var h string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT blockhash FROM blocks WHERE is_current IS TRUE`).Scan(&h); err != nil {
+		t.Fatalf("read current tip hash: %v", err)
+	}
+	return h
+}
+
+// blockNumber returns the number stored for a given blockhash, failing the
+// test if no row exists.
+func blockNumber(t *testing.T, pool *pgxpool.Pool, hash string) int64 {
+	t.Helper()
+	var n int64
+	if err := pool.QueryRow(context.Background(),
+		`SELECT number FROM blocks WHERE blockhash = $1`, hash).Scan(&n); err != nil {
+		t.Fatalf("read block number for %s: %v", hash, err)
+	}
+	return n
+}
+
+// blockRowCount returns the total number of rows in `blocks`. Used to
+// catch unintended duplicate inserts.
+func blockRowCount(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM blocks`).Scan(&n); err != nil {
+		t.Fatalf("count blocks: %v", err)
+	}
+	return n
+}
+
+// TestResolveBlockNumber_EmptyTable: on a fresh table, the first call
+// inserts the block at number=1 and marks it the unique tip.
+func TestResolveBlockNumber_EmptyTable(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ix := newTestIndexer(pool)
+
+	got, err := ix.resolveBlockNumber("blk-genesis")
+	if err != nil {
+		t.Fatalf("resolveBlockNumber: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("returned number = %d, want 1", got)
+	}
+	if tips := countCurrentTips(t, pool); tips != 1 {
+		t.Errorf("is_current=true count = %d, want 1 (tip invariant)", tips)
+	}
+	if tip := currentTipHash(t, pool); tip != "blk-genesis" {
+		t.Errorf("tip hash = %s, want blk-genesis", tip)
+	}
+}
+
+// TestResolveBlockNumber_AppendsToChain: with an existing chain, the
+// next call increments the number, demotes the prior tip, and promotes
+// the new block. Tip invariant holds throughout.
+func TestResolveBlockNumber_AppendsToChain(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ix := newTestIndexer(pool)
+
+	// Build up a 3-block chain via the function under test.
+	for i, hash := range []string{"blk-1", "blk-2", "blk-3"} {
+		n, err := ix.resolveBlockNumber(hash)
+		if err != nil {
+			t.Fatalf("step %d resolveBlockNumber: %v", i, err)
+		}
+		if want := int64(i + 1); n != want {
+			t.Errorf("step %d returned %d, want %d", i, n, want)
+		}
+		if tips := countCurrentTips(t, pool); tips != 1 {
+			t.Errorf("step %d tip count = %d, want 1", i, tips)
+		}
+		if tip := currentTipHash(t, pool); tip != hash {
+			t.Errorf("step %d tip = %s, want %s", i, tip, hash)
+		}
+	}
+}
+
+// TestResolveBlockNumber_AdoptsExistingByHash: when a row already
+// exists for this hash (e.g. another writer wrote it during a cutover),
+// the function adopts its number without inserting a new row and
+// promotes it to the tip.
+func TestResolveBlockNumber_AdoptsExistingByHash(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ctx := context.Background()
+
+	// Simulate a co-existing writer's row at number=42, is_current=false.
+	// Plus a separate "stale tip" at number=43 with is_current=true,
+	// which our call should demote.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO blocks (blockhash, parenthash, number, is_current) VALUES
+		  ('blk-prewritten', NULL, 42, false),
+		  ('blk-stale-tip', NULL, 43, true)
+	`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	ix := newTestIndexer(pool)
+	got, err := ix.resolveBlockNumber("blk-prewritten")
+	if err != nil {
+		t.Fatalf("resolveBlockNumber: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("returned number = %d, want 42 (adopted)", got)
+	}
+	if rows := blockRowCount(t, pool); rows != 2 {
+		t.Errorf("row count = %d, want 2 (no new row inserted)", rows)
+	}
+	if tips := countCurrentTips(t, pool); tips != 1 {
+		t.Errorf("tip count = %d, want 1", tips)
+	}
+	if tip := currentTipHash(t, pool); tip != "blk-prewritten" {
+		t.Errorf("tip = %s, want blk-prewritten (promoted from is_current=false)", tip)
+	}
+}
+
+// TestResolveBlockNumber_TipInvariantAfterFossils: a co-running writer
+// left "fossil" rows ahead of where we last knew MAX(number) to be —
+// possibly with one of them still flagged is_current=true — then died.
+// We must skip past all fossils, insert at the true MAX+1, and end up
+// as the unique tip. This is the production failure mode that dropped
+// ray52726.
+func TestResolveBlockNumber_TipInvariantAfterFossils(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ctx := context.Background()
+
+	// Fossils 100..109, with the last one still flagged as the tip — as
+	// if the prior writer was killed mid-stream after marking 109 current.
+	for i := 100; i <= 108; i++ {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO blocks (blockhash, parenthash, number, is_current)
+			 VALUES ($1, NULL, $2, false)`,
+			"fossil-"+strconv.Itoa(i), i); err != nil {
+			t.Fatalf("seed fossil %d: %v", i, err)
+		}
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO blocks (blockhash, parenthash, number, is_current)
+		 VALUES ('fossil-109-tip', NULL, 109, true)`); err != nil {
+		t.Fatalf("seed tip fossil: %v", err)
+	}
+
+	ix := newTestIndexer(pool)
+	got, err := ix.resolveBlockNumber("blk-new")
+	if err != nil {
+		t.Fatalf("resolveBlockNumber: %v", err)
+	}
+	if got != 110 {
+		t.Errorf("returned %d, want 110 (MAX(109)+1)", got)
+	}
+	if tips := countCurrentTips(t, pool); tips != 1 {
+		t.Errorf("tip count = %d, want 1", tips)
+	}
+	if tip := currentTipHash(t, pool); tip != "blk-new" {
+		t.Errorf("tip = %s, want blk-new", tip)
+	}
+}
+
+// TestResolveBlockNumber_IdempotentSameHash: calling twice for the
+// same hash returns the same number both times, doesn't double-insert,
+// and the tip invariant holds.
+func TestResolveBlockNumber_IdempotentSameHash(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ix := newTestIndexer(pool)
+
+	first, err := ix.resolveBlockNumber("blk-X")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := ix.resolveBlockNumber("blk-X")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first != second {
+		t.Errorf("first=%d second=%d, want equal", first, second)
+	}
+	if rows := blockRowCount(t, pool); rows != 1 {
+		t.Errorf("row count = %d, want 1", rows)
+	}
+	if tips := countCurrentTips(t, pool); tips != 1 {
+		t.Errorf("tip count = %d, want 1", tips)
+	}
+}
+
+// TestResolveBlockNumber_ParentHashIsPriorTip: the parenthash field on
+// the newly-inserted block is set to the previous tip's blockhash.
+// (Cheap correctness check that we capture parenthash before demoting.)
+func TestResolveBlockNumber_ParentHashIsPriorTip(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ctx := context.Background()
+	ix := newTestIndexer(pool)
+
+	if _, err := ix.resolveBlockNumber("blk-A"); err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+	if _, err := ix.resolveBlockNumber("blk-B"); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+
+	var parent *string
+	if err := pool.QueryRow(ctx,
+		`SELECT parenthash FROM blocks WHERE blockhash = 'blk-B'`).Scan(&parent); err != nil {
+		t.Fatalf("read parenthash: %v", err)
+	}
+	if parent == nil || *parent != "blk-A" {
+		got := "<nil>"
+		if parent != nil {
+			got = *parent
+		}
+		t.Errorf("blk-B.parenthash = %s, want blk-A", got)
+	}
+}
+
+// TestResolveBlockNumber_NumberValueIsStoredCorrectly: the number we
+// return is the same one stored in the DB row. (Guards against an
+// off-by-one between INSERT and SELECT.)
+func TestResolveBlockNumber_NumberValueIsStoredCorrectly(t *testing.T) {
+	pool := setupBlocksTestDB(t)
+	ix := newTestIndexer(pool)
+
+	got, err := ix.resolveBlockNumber("blk-Y")
+	if err != nil {
+		t.Fatalf("resolveBlockNumber: %v", err)
+	}
+	if stored := blockNumber(t, pool, "blk-Y"); stored != got {
+		t.Errorf("returned %d, stored %d", got, stored)
+	}
+}
+


### PR DESCRIPTION
## Summary

Two intertwined fixes to make pkg/etl correct under the cutover scenario where another writer (the legacy Python discovery-provider indexer) has rows in the `blocks` table:

1. **`blocks` writes adopt-by-hash + ON CONFLICT DO NOTHING** — never crash on a pre-existing row, never drop an EM tx because of a `blocks_number_key` collision.
2. **Per-block atomic transactions** — every write performed for a block (etl_blocks, blocks, core_indexed_blocks, every entity row, every audit row) commits together or rolls back together. Each per-tx handler runs inside a SAVEPOINT so its failures roll back only that tx's writes, not the block.

(Replaces the earlier `lastEmBlock` counter with `MAX(number)+1` computed in-statement from the DB. The DB is the source of truth.)

## The bug this fixes (real prod incident)

The audius/api repo recently vendored pkg/etl (api/#840). The production cutover ran ETL in parallel with the legacy Python indexer for ~12 minutes. The interaction caused **every CometBFT block with EM activity to be silently skipped** for that window, dropping at least one user signup (`ray52726`).

### Root causes

**(a) `INSERT INTO blocks (number=...)` had no `ON CONFLICT` clause.** The legacy Python indexer writes one `blocks` row per CometBFT block, incrementing `number = prev.number + 1`. ETL initialized `e.lastEmBlock = MAX(number)` at boot then incremented locally. Python kept advancing `MAX(number)` past ETL's snapshot, so every subsequent ETL INSERT collided. The bug also persisted *after* Python was killed: Python's pre-written rows stayed as fossils ahead of ETL's stale in-memory counter, and ETL kept colliding because it never re-read MAX.

**(b) On block-insert failure, the caller skipped the entire CometBFT block:**

```go
if err := e.insertCurrentBlock(...); err != nil {
    e.lastEmBlock--
    continue   // ← skips EM dispatch for this block
}
```

Every EM tx in a "conflicted" block was dropped, even though the EM tx had nothing wrong.

**(c) Block processing was not atomic.** Even after fixing (a) and (b), each handler ran as its own auto-commit statement on the connection pool. A pod crash partway through a block could leave a partial snapshot — some entity rows for the block committed, others missing. Python's discovery-provider was atomic at the block boundary via SQLAlchemy session semantics; ETL had no equivalent.

## The fix — two parts

### Part 1: `resolveBlockNumber` (replaces `insertCurrentBlock`)

```go
// Operates on the caller's tx (or savepoint).
func (e *Indexer) resolveBlockNumber(ctx context.Context, tx pgx.Tx, blockHash string) (int64, error) {
    // 1. Snapshot prior tip for parenthash.
    // 2. Demote prior tip (UPDATE is_current=false ... AND blockhash != $1).
    // 3. INSERT MAX(number)+1 in-statement, ON CONFLICT DO NOTHING.
    // 4. Re-assert is_current on our row (covers pre-existing is_current=false).
    // 5. Return number via SELECT WHERE blockhash=$1.
}
```

- Idempotent: calling for an already-existing block returns its number and re-asserts tip.
- Tolerant of co-writers: ON CONFLICT skips on (number) collisions; the subsequent UPDATE + SELECT decide what number we landed at.
- Maintains the invariant: after every successful call, exactly one row in `blocks` has `is_current = true`, and it's the row for `blockHash`. Enforced by the existing partial unique index.

### Part 2: Per-block atomic transactions

The indexer's main loop now drives one transactional call per CometBFT block:

```go
for pb := range pf.C() {
    res, err := e.processBlock(ctx, pb)
    if err != nil { /* log + skip; block will reprocess */ continue }
    // ... progress logging ...
}

func (e *Indexer) processBlock(ctx context.Context, pb prefetchedBlock) (*blockResult, error) {
    tx, err := e.pool.Begin(ctx)
    defer tx.Rollback(ctx)  // safe no-op after commit
    q := e.db.WithTx(tx)

    // Block-level writes: etl_blocks, blocks (via resolveBlockNumber), core_indexed_blocks.
    // Any failure here returns err → defer rolls back the whole block.

    for _, t := range block.Transactions {
        sp, _ := tx.Begin(ctx)  // pgx implements this as SAVEPOINT
        qsp := e.db.WithTx(sp)
        if e.processOneTx(ctx, sp, qsp, ...) {
            sp.Commit(ctx)  // RELEASE SAVEPOINT — writes become part of outer tx
        } else {
            sp.Rollback(ctx)  // ROLLBACK TO SAVEPOINT — discard this tx's writes
        }
    }

    return tx.Commit(ctx)
}
```

**`processOneTx`** dispatches the per-tx switch. Each case:
- Performs its writes through the savepoint-scoped queries handle.
- On any hard error, calls `sp.Rollback(ctx)` and returns false → only this tx's writes are discarded.
- On ManageEntity validation error, keeps the savepoint alive (matches Python's swallow-and-continue) — the tx was on-chain but malformed; we still record its audit row.

**Audit transactions row** is always written, either through the savepoint (if it survived) or through the outer block tx (if rolled back). The on-chain tx is observable either way.

## Helpers refactored

- `calculateChallengeStatistics(...)` now takes `*db.Queries` so it reads through the in-progress block's tx.
- `processStorageProofConsensus(...)` likewise.

## Invariants after this PR

1. **Tip uniqueness**: exactly one row in `blocks` has `is_current = true`, and it's the row for the just-processed block. Enforced by the existing partial unique index, never violated within the per-block transaction.
2. **Per-block atomicity**: a CometBFT block either has all of (etl_blocks row, blocks row + tip flip, core_indexed_blocks row, every successful tx's entity writes, every tx's audit row) committed, or none of it. No partial blocks.
3. **Per-tx atomicity**: a hard handler error rolls back that tx's writes only. The rest of the block proceeds. Validation errors don't roll back (match Python's behavior).
4. **Reprocessability**: if a block's tx is rolled back due to a block-level error, `core_indexed_blocks` is not advanced for it. The next iteration of the prefetcher (or a pod restart) re-processes the block; `resolveBlockNumber`'s adopt-by-hash makes the second attempt idempotent.

## Tests

`resolve_block_number_test.go`, all behavior assertions (not internal-state):

| Test | Scenario |
|---|---|
| `TestResolveBlockNumber_EmptyTable` | Fresh table → number=1, sole tip |
| `TestResolveBlockNumber_AppendsToChain` | 3-block chain → numbers 1,2,3; tip moves with each insert; invariant holds at every step |
| `TestResolveBlockNumber_AdoptsExistingByHash` | Pre-existing row with `is_current=false` + a stale tip on another row → adopt the existing number, promote it to tip, demote the stale one, no new row inserted |
| `TestResolveBlockNumber_TipInvariantAfterFossils` | Fossil rows 100-108 + an orphaned tip at 109 (the prod failure mode) → next call lands at 110 as the unique tip |
| `TestResolveBlockNumber_IdempotentSameHash` | Two calls for same hash → same number, only one row, tip invariant holds |
| `TestResolveBlockNumber_ParentHashIsPriorTip` | New block's `parenthash` is the previous tip's `blockhash` |
| `TestResolveBlockNumber_NumberValueIsStoredCorrectly` | Returned number == stored number (no off-by-one) |

All existing `pkg/etl/...` tests still pass.

## Backwards compatibility

- `lastEmBlock` field removed from `Indexer` struct.
- `insertCurrentBlock` method removed (was lowercase, package-private).
- `resolveBlockNumber` signature changed (now takes `ctx, tx`).
- `calculateChallengeStatistics` and `processStorageProofConsensus` signatures changed (now take `ctx, *db.Queries`).

None of these were part of the exported API surface; all callers are in-tree and updated in this PR.

## Intentionally not in this PR

Adding `ON CONFLICT DO NOTHING` to entity INSERTs (`users`, `tracks`, `playlists`, etc.) for the case where two writers process the same block concurrently. With per-block atomic transactions and the cutover procedure (quiesce the legacy indexer first, then deploy ETL), this scenario is fully prevented. Defense-in-depth is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)