### PR TITLE
fix(etl): canonicalize playlist_contents entry keys on write

### DIFF
--- a/pkg/etl/processors/entity_manager/empty_playlist_contents_test.go
+++ b/pkg/etl/processors/entity_manager/empty_playlist_contents_test.go
@@ -119,6 +119,15 @@ func TestNormalizePlaylistContentsJSON(t *testing.T) {
 		{name: "legacy empty dict", raw: `{"playlist_contents":{"track_ids":[]}}`, want: `{"track_ids":[]}`},
 		{name: "bare array with entries", raw: `{"playlist_contents":[{"track":1,"time":2}]}`, want: `{"track_ids":[{"time":2,"track":1}]}`},
 		{name: "legacy dict with entries", raw: `{"playlist_contents":{"track_ids":[{"track":3,"time":4}]}}`, want: `{"track_ids":[{"time":4,"track":3}]}`},
+		// SDK alias shape: track_id / timestamp / metadata_timestamp are
+		// canonicalized onto track / time / metadata_time. This is the shape
+		// that broke Dabow's playlist — the api reader only understands `track`.
+		{name: "track_id alias", raw: `{"playlist_contents":[{"track_id":5,"timestamp":6}]}`, want: `{"track_ids":[{"time":6,"track":5}]}`},
+		{name: "track_id alias with metadata_timestamp", raw: `{"playlist_contents":[{"track_id":7,"timestamp":8,"metadata_timestamp":9}]}`, want: `{"track_ids":[{"metadata_time":9,"time":8,"track":7}]}`},
+		{name: "hashid string track", raw: `{"playlist_contents":[{"track":"LjjBL","time":10}]}`, want: `{"track_ids":[{"time":10,"track":777}]}`},
+		{name: "mixed alias and canonical", raw: `{"playlist_contents":[{"track":1,"time":2},{"track_id":3,"timestamp":4}]}`, want: `{"track_ids":[{"time":2,"track":1},{"time":4,"track":3}]}`},
+		// Entries with no resolvable track id are dropped.
+		{name: "entry without track id dropped", raw: `{"playlist_contents":[{"time":1},{"track":2,"time":3}]}`, want: `{"track_ids":[{"time":3,"track":2}]}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/etl/processors/entity_manager/playlist_row.go
+++ b/pkg/etl/processors/entity_manager/playlist_row.go
@@ -260,17 +260,22 @@ func metadataPlaylistContentsJSON(p *Params) []byte {
 }
 
 // normalizePlaylistContentsJSON returns the JSONB payload to persist to
-// playlists.playlist_contents — always `{"track_ids": [...]}` regardless
-// of input shape.
+// playlists.playlist_contents — always `{"track_ids": [{"track":..,"time":..}]}`
+// regardless of input shape.
 //
 // Accepts:
 //   - bare array form (new SDK):  [{"track":..,"time":..}, ...]  or  []
 //   - dict form (legacy):         {"track_ids": [...]}
 //   - explicit null / missing key: empty list
 //
-// Inner entries pass through as-is; only the outer wrapper is normalized.
-// The hashid-decode + dedupe + index-time logic lives at the junction-table
-// layer (updatePlaylistTracks).
+// Each inner entry is canonicalized to the `{track, time, metadata_time}`
+// schema that downstream readers (api/'s v1_playlist_tracks query, the
+// handle_playlist notification trigger, etc.) expect. The SDK historically
+// sent entries keyed by `track_id`/`timestamp`/`metadata_timestamp`; those
+// alias keys are mapped onto the canonical names here so we persist one shape.
+// Track IDs that arrive as hashid strings are decoded to integers.
+// The dedupe + junction-table logic lives at the junction-table layer
+// (updatePlaylistTracks).
 func normalizePlaylistContentsJSON(metadata map[string]any) []byte {
 	raw, ok := metadata["playlist_contents"]
 	if !ok || raw == nil {
@@ -287,12 +292,61 @@ func normalizePlaylistContentsJSON(metadata map[string]any) []byte {
 			}
 		}
 	}
-	if entries == nil {
-		entries = []any{}
+	canonical := make([]any, 0, len(entries))
+	for _, e := range entries {
+		obj, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entry, ok := canonicalizePlaylistEntry(obj); ok {
+			canonical = append(canonical, entry)
+		}
 	}
-	out, err := json.Marshal(map[string]any{"track_ids": entries})
+	out, err := json.Marshal(map[string]any{"track_ids": canonical})
 	if err != nil {
 		return []byte(`{"track_ids":[]}`)
 	}
 	return out
+}
+
+// canonicalizePlaylistEntry maps a single playlist_contents entry onto the
+// canonical `{track, time, metadata_time}` schema. Returns false when no
+// usable track id can be extracted. `track` is always an integer (hashid
+// strings are decoded via pickPlaylistTrackID). `time` / `metadata_time` are
+// only emitted when present, accepting the legacy `timestamp` /
+// `metadata_timestamp` aliases.
+func canonicalizePlaylistEntry(entry map[string]any) (map[string]any, bool) {
+	id, ok := pickPlaylistTrackID(entry)
+	if !ok {
+		return nil, false
+	}
+	out := map[string]any{"track": id}
+	if t, ok := pickJSONInt(entry, "time", "timestamp"); ok {
+		out["time"] = t
+	}
+	if mt, ok := pickJSONInt(entry, "metadata_time", "metadata_timestamp"); ok {
+		out["metadata_time"] = mt
+	}
+	return out, true
+}
+
+// pickJSONInt returns the first of keys that holds a JSON number, coerced to
+// int64. JSON unmarshals numbers as float64; we also accept int/int64 for
+// callers that build maps directly.
+func pickJSONInt(entry map[string]any, keys ...string) (int64, bool) {
+	for _, k := range keys {
+		raw, ok := entry[k]
+		if !ok {
+			continue
+		}
+		switch v := raw.(type) {
+		case float64:
+			return int64(v), true
+		case int:
+			return int64(v), true
+		case int64:
+			return v, true
+		}
+	}
+	return 0, false
 }


### PR DESCRIPTION
## Summary

The ETL indexer's `normalizePlaylistContentsJSON` previously passed `playlist_contents` entries through verbatim, normalizing only the outer `{track_ids:[...]}` wrapper. When the SDK sent entries keyed by `track_id` / `timestamp` / `metadata_timestamp` (rather than the canonical `track` / `time` / `metadata_time`), the alias keys were persisted to the JSONB column as-is.

Downstream readers only understand the `track` key:
- api/'s `v1_playlist_tracks` query — `(e.value->>'track')::int`
- the `handle_playlist` notification trigger — `(track_item->>'track')::int`
- the dbv1 `get_playlists` play-count rollup — `(e.item->>'track')::int`

So affected playlists rendered **empty** even though the `playlist_tracks` junction table was materialized correctly (`updatePlaylistTracks` / `pickPlaylistTrackID` already tolerate both shapes). Surfaced in production via a user's playlist showing no tracks after adds.

## Fix

`normalizePlaylistContentsJSON` now canonicalizes **every** entry to `{track, time, metadata_time}` on write:
- maps the `track_id` / `timestamp` / `metadata_timestamp` aliases onto the canonical names
- decodes hashid-string track ids to integers (via the existing `pickPlaylistTrackID`)
- drops entries with no resolvable track id
- only emits `time` / `metadata_time` when present

Both the update path (`mergePlaylistFromMetadata`) and the create path (`metadataPlaylistContentsJSON`) share this function, so both are fixed.

A companion one-shot backfill migration in the `api` repo repairs the already-written `is_current` rows to the same shape (deployed alongside the go.mod bump to this version).

## Test plan

- [x] `TestNormalizePlaylistContentsJSON` extended with alias-key, alias+metadata, hashid-string, mixed-shape, and dropped-entry cases — all pass
- [x] Existing canonical/empty/legacy-dict cases still pass
- [x] `go build ./...`, `go vet`, and the full `processors/entity_manager` package suite (incl. DB-backed playlist tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)