### PR TITLE
feat(etl): post-write hook for Plays transactions

### DIFF
--- a/pkg/etl/etl.go
+++ b/pkg/etl/etl.go
@@ -38,6 +38,12 @@ type Indexer struct {
 	// Pending post-hooks staged before Run(). Applied to the dispatcher
 	// once it's constructed.
 	pendingPostHooks []pendingPostHook
+
+	// playsHooks fire after the play processor writes etl_plays for a Plays
+	// transaction. Unlike entity-manager post-hooks these don't need a
+	// dispatcher, so they're held directly on the Indexer and invoked from
+	// the play branch of processOneTx. Registered before Run().
+	playsHooks []PlaysHook
 }
 
 // pendingPostHook stages a hook registration until the dispatcher exists.
@@ -114,6 +120,20 @@ func (e *Indexer) RegisterPostHook(entityType, action string, fn em.PostHook) {
 		action:     action,
 		fn:         fn,
 	})
+}
+
+// RegisterPlaysHook registers fn to fire after every successful Plays
+// transaction (after the play processor writes etl_plays). Multiple hooks
+// run in registration order. Hook errors are logged but do not fail the
+// surrounding block — see PlaysHook for full semantics.
+//
+// Must be called before Run().
+//
+// Unlike RegisterPostHook (which is keyed by entity type/action and routes
+// through the entity-manager dispatcher), plays have no ManageEntity
+// envelope, so this is a separate extension point.
+func (e *Indexer) RegisterPlaysHook(fn PlaysHook) {
+	e.playsHooks = append(e.playsHooks, fn)
 }
 
 // SetUserCreatedHook is convenience sugar for

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -816,8 +816,9 @@ func (e *Indexer) processOneTx(
 }
 
 // firePlaysHooks invokes every registered PlaysHook for a Plays transaction
-// that the play processor just wrote. Hooks share sp (the tx's savepoint),
-// so a hook's writes land atomically with the etl_plays rows.
+// that the play processor just wrote. Each hook runs in a nested savepoint
+// under sp, so a hook's writes land atomically with the etl_plays rows when
+// successful, but a hook DB error can be rolled back without poisoning sp.
 //
 // Errors are logged but not propagated: a hook failure must not roll back
 // the savepoint or fail the block. This mirrors the em.PostHook contract —
@@ -833,12 +834,28 @@ func (e *Indexer) firePlaysHooks(ctx context.Context, sp pgx.Tx, plays []*corev1
 		BlockTime:   block.Timestamp.AsTime(),
 		BlockHash:   block.Hash,
 		TxHash:      txHash,
-		DBTX:        sp,
 		Logger:      e.logger,
 	}
 	for _, hook := range e.playsHooks {
-		if err := hook(ctx, params); err != nil {
+		hookTx, err := sp.Begin(ctx)
+		if err != nil {
+			e.logger.Error("begin plays hook savepoint",
+				zap.String("hash", txHash), zap.Error(err))
+			continue
+		}
+
+		hookParams := *params
+		hookParams.DBTX = hookTx
+
+		if err := hook(ctx, &hookParams); err != nil {
+			_ = hookTx.Rollback(ctx)
 			e.logger.Error("plays hook error",
+				zap.String("hash", txHash), zap.Error(err))
+			continue
+		}
+		if err := hookTx.Commit(ctx); err != nil {
+			_ = hookTx.Rollback(ctx)
+			e.logger.Error("commit plays hook savepoint",
 				zap.String("hash", txHash), zap.Error(err))
 		}
 	}

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -535,6 +535,7 @@ func (e *Indexer) processOneTx(
 			return false
 		}
 		*insertTxParams = pr.InsertTx
+		e.firePlaysHooks(ctx, sp, signedTx.Plays.GetPlays(), block, t.Hash)
 
 	case *corev1.SignedTransaction_ManageEntity:
 		me := signedTx.ManageEntity
@@ -812,6 +813,35 @@ func (e *Indexer) processOneTx(
 	}
 
 	return true
+}
+
+// firePlaysHooks invokes every registered PlaysHook for a Plays transaction
+// that the play processor just wrote. Hooks share sp (the tx's savepoint),
+// so a hook's writes land atomically with the etl_plays rows.
+//
+// Errors are logged but not propagated: a hook failure must not roll back
+// the savepoint or fail the block. This mirrors the em.PostHook contract —
+// a buggy consumer-side hook (or a deterministic bad-data error) should not
+// be able to halt the indexer. No-ops when no hooks are registered.
+func (e *Indexer) firePlaysHooks(ctx context.Context, sp pgx.Tx, plays []*corev1.TrackPlay, block *corev1.Block, txHash string) {
+	if len(e.playsHooks) == 0 {
+		return
+	}
+	params := &PlaysParams{
+		Plays:       plays,
+		BlockHeight: block.Height,
+		BlockTime:   block.Timestamp.AsTime(),
+		BlockHash:   block.Hash,
+		TxHash:      txHash,
+		DBTX:        sp,
+		Logger:      e.logger,
+	}
+	for _, hook := range e.playsHooks {
+		if err := hook(ctx, params); err != nil {
+			e.logger.Error("plays hook error",
+				zap.String("hash", txHash), zap.Error(err))
+		}
+	}
 }
 
 // resolveBlockNumber returns the blocks.number for blockHash and ensures

--- a/pkg/etl/plays_hook.go
+++ b/pkg/etl/plays_hook.go
@@ -1,0 +1,68 @@
+package etl
+
+import (
+	"context"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+	"go.uber.org/zap"
+)
+
+// PlaysParams holds the context for a single Plays transaction, passed to
+// every registered PlaysHook after the play processor has written the
+// etl_plays rows.
+//
+// Plays do not flow through the entity-manager dispatcher (they have no
+// ManageEntity envelope and no metadata), so they cannot use the
+// em.PostHook mechanism. PlaysHook is the parallel extension point for the
+// Plays tx type: it hands consumers the decoded TrackPlay slice plus the
+// same DB transaction (DBTX) the processor wrote on, so a consumer can
+// write a derived row in the same savepoint atomically with etl_plays.
+type PlaysParams struct {
+	// Plays is the decoded list of plays in this transaction. May be empty
+	// for a plays tx that carried no entries (the processor no-ops those,
+	// and so should hooks).
+	Plays []*corev1.TrackPlay
+
+	// BlockHeight is the Core block height the plays were indexed at.
+	BlockHeight int64
+
+	// BlockTime is the block timestamp.
+	BlockTime time.Time
+
+	// BlockHash is the Core block hash.
+	BlockHash string
+
+	// TxHash is the hash of the Plays transaction.
+	TxHash string
+
+	// DBTX is the savepoint-scoped transaction the play processor wrote
+	// etl_plays on. A hook writing via this handle commits or rolls back
+	// atomically with the rest of the tx.
+	DBTX db.DBTX
+
+	// Logger is the indexer logger.
+	Logger *zap.Logger
+}
+
+// Queries returns a sqlc Queries handle bound to the hook's DBTX, for
+// consumers that want to use generated queries rather than raw SQL.
+func (p *PlaysParams) Queries() *db.Queries {
+	return db.New(p.DBTX)
+}
+
+// PlaysHook fires after the play processor has successfully written the
+// etl_plays rows for a Plays transaction. It receives the decoded plays and
+// the same DB transaction the processor used (Params.DBTX), so a consumer
+// can write a derived row in the same savepoint.
+//
+// Errors returned from a hook are logged but do NOT roll back the play
+// processor's etl_plays write or fail the surrounding block — this matches
+// the em.PostHook contract and prevents a buggy consumer-side hook (or a
+// deterministic bad-data error) from halting the indexer. Transient infra
+// failures that must be retried should instead surface through the block
+// transaction, which is reprocessed on the next pass.
+//
+// Multiple hooks may be registered; they run in registration order.
+type PlaysHook func(ctx context.Context, params *PlaysParams) error

--- a/pkg/etl/plays_hook_test.go
+++ b/pkg/etl/plays_hook_test.go
@@ -7,9 +7,64 @@ import (
 	"time"
 
 	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type fakePlaysHookTx struct {
+	beginCount    int
+	commitCount   int
+	rollbackCount int
+}
+
+func (f *fakePlaysHookTx) Begin(context.Context) (pgx.Tx, error) {
+	f.beginCount++
+	return &fakePlaysHookTx{}, nil
+}
+
+func (f *fakePlaysHookTx) Commit(context.Context) error {
+	f.commitCount++
+	return nil
+}
+
+func (f *fakePlaysHookTx) Rollback(context.Context) error {
+	f.rollbackCount++
+	return nil
+}
+
+func (*fakePlaysHookTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+
+func (*fakePlaysHookTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (*fakePlaysHookTx) LargeObjects() pgx.LargeObjects {
+	return pgx.LargeObjects{}
+}
+
+func (*fakePlaysHookTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	return nil, nil
+}
+
+func (*fakePlaysHookTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (*fakePlaysHookTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (*fakePlaysHookTx) QueryRow(context.Context, string, ...any) pgx.Row {
+	return nil
+}
+
+func (*fakePlaysHookTx) Conn() *pgx.Conn {
+	return nil
+}
 
 // TestRegisterPlaysHook_FiresInOrder verifies that hooks registered via
 // RegisterPlaysHook run in registration order and receive the decoded plays
@@ -41,7 +96,7 @@ func TestRegisterPlaysHook_FiresInOrder(t *testing.T) {
 		Timestamp: timestamppb.New(time.Unix(1000, 0)),
 	}
 
-	e.firePlaysHooks(context.Background(), nil, plays, block, "txhash")
+	e.firePlaysHooks(context.Background(), &fakePlaysHookTx{}, plays, block, "txhash")
 
 	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
 		t.Fatalf("expected hooks to fire in order [1 2], got %v", order)
@@ -73,7 +128,7 @@ func TestRegisterPlaysHook_ErrorIsNonFatal(t *testing.T) {
 	})
 
 	block := &corev1.Block{Height: 1, Timestamp: timestamppb.New(time.Unix(0, 0))}
-	e.firePlaysHooks(context.Background(), nil, nil, block, "tx")
+	e.firePlaysHooks(context.Background(), &fakePlaysHookTx{}, nil, block, "tx")
 
 	if !secondFired {
 		t.Error("second hook did not fire after first returned an error")
@@ -85,5 +140,5 @@ func TestRegisterPlaysHook_ErrorIsNonFatal(t *testing.T) {
 func TestFirePlaysHooks_NoHooks(t *testing.T) {
 	e := &Indexer{logger: zap.NewNop()}
 	block := &corev1.Block{Height: 1, Timestamp: timestamppb.New(time.Unix(0, 0))}
-	e.firePlaysHooks(context.Background(), nil, nil, block, "tx")
+	e.firePlaysHooks(context.Background(), &fakePlaysHookTx{}, nil, block, "tx")
 }

--- a/pkg/etl/plays_hook_test.go
+++ b/pkg/etl/plays_hook_test.go
@@ -1,0 +1,89 @@
+package etl
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestRegisterPlaysHook_FiresInOrder verifies that hooks registered via
+// RegisterPlaysHook run in registration order and receive the decoded plays
+// plus block context.
+func TestRegisterPlaysHook_FiresInOrder(t *testing.T) {
+	e := &Indexer{logger: zap.NewNop()}
+
+	var order []int
+	var gotPlays []*corev1.TrackPlay
+	var gotHeight int64
+	var gotHash string
+
+	e.RegisterPlaysHook(func(_ context.Context, p *PlaysParams) error {
+		order = append(order, 1)
+		gotPlays = p.Plays
+		gotHeight = p.BlockHeight
+		gotHash = p.TxHash
+		return nil
+	})
+	e.RegisterPlaysHook(func(_ context.Context, _ *PlaysParams) error {
+		order = append(order, 2)
+		return nil
+	})
+
+	plays := []*corev1.TrackPlay{{UserId: "1", TrackId: "2"}}
+	block := &corev1.Block{
+		Height:    42,
+		Hash:      "blockhash",
+		Timestamp: timestamppb.New(time.Unix(1000, 0)),
+	}
+
+	e.firePlaysHooks(context.Background(), nil, plays, block, "txhash")
+
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Fatalf("expected hooks to fire in order [1 2], got %v", order)
+	}
+	if len(gotPlays) != 1 || gotPlays[0].UserId != "1" {
+		t.Errorf("hook did not receive plays slice: %v", gotPlays)
+	}
+	if gotHeight != 42 {
+		t.Errorf("expected block height 42, got %d", gotHeight)
+	}
+	if gotHash != "txhash" {
+		t.Errorf("expected tx hash 'txhash', got %q", gotHash)
+	}
+}
+
+// TestRegisterPlaysHook_ErrorIsNonFatal verifies a hook returning an error
+// does not stop subsequent hooks from running — mirroring the em.PostHook
+// log-and-continue contract.
+func TestRegisterPlaysHook_ErrorIsNonFatal(t *testing.T) {
+	e := &Indexer{logger: zap.NewNop()}
+
+	secondFired := false
+	e.RegisterPlaysHook(func(_ context.Context, _ *PlaysParams) error {
+		return errors.New("boom")
+	})
+	e.RegisterPlaysHook(func(_ context.Context, _ *PlaysParams) error {
+		secondFired = true
+		return nil
+	})
+
+	block := &corev1.Block{Height: 1, Timestamp: timestamppb.New(time.Unix(0, 0))}
+	e.firePlaysHooks(context.Background(), nil, nil, block, "tx")
+
+	if !secondFired {
+		t.Error("second hook did not fire after first returned an error")
+	}
+}
+
+// TestFirePlaysHooks_NoHooks is a no-op fast path that must not panic when
+// no hooks are registered.
+func TestFirePlaysHooks_NoHooks(t *testing.T) {
+	e := &Indexer{logger: zap.NewNop()}
+	block := &corev1.Block{Height: 1, Timestamp: timestamppb.New(time.Unix(0, 0))}
+	e.firePlaysHooks(context.Background(), nil, nil, block, "tx")
+}


### PR DESCRIPTION
## Summary
- Plays transactions don't flow through the entity-manager dispatcher (no `ManageEntity` envelope, no metadata), so they can't use the existing `em.PostHook` mechanism (added in #317). This PR adds a parallel post-write extension point for the `Plays` tx type.
- New `PlaysParams` / `PlaysHook` types in `pkg/etl/plays_hook.go`. The hook receives the decoded `[]*corev1.TrackPlay` plus the **savepoint-scoped `DBTX`** the play processor used to write `etl_plays`, so a consumer can write a derived row atomically in the same tx (with a `Queries()` helper for sqlc access).
- `Indexer.RegisterPlaysHook(fn)` stages hooks before `Run()`; `firePlaysHooks` invokes them in the `Plays` branch of `processOneTx`, right after the processor writes `etl_plays`.

## Error semantics
Mirrors the `em.PostHook` contract: **hook errors are logged, not fatal.** A buggy consumer-side hook (or a deterministic bad-data error) must not roll back the `etl_plays` write or halt the indexer. Transient infra errors that need retry should surface through the surrounding block transaction, which is reprocessed on the next pass.

## Motivation
Lets the downstream `api.audius.co` consumer mirror the legacy Python `index_core_plays` behavior — writing the `plays` table from indexed plays — without forking ETL. (Paired API PR consumes this hook.)

## Test plan
- [x] `go build ./...` and `go vet ./...` clean in `pkg/etl`
- [x] New `plays_hook_test.go`: hooks fire in registration order, receive decoded plays + block context, error from one hook is non-fatal to the next, no-op fast path with zero hooks
- [x] Full `pkg/etl` suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)