### PR TITLE
Revert "fix(etl): halt on block indexing failure (#323)"

### DIFF
--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -307,15 +307,15 @@ func (e *Indexer) indexBlocks() error {
 
 		res, err := e.processBlock(ctx, pb)
 		if err != nil {
-			// Block-level failure rolled back the entire block's tx. Stop
-			// indexing instead of advancing past this height; skipping here can
-			// leave a hidden core_indexed_blocks gap because health checks use
-			// MAX(height). Let the supervisor restart us so we retry from the
-			// last committed height, and crashloop on persistent corruption.
+			// Block-level failure rolled back the entire block's tx — no
+			// partial state landed. Skip; the outer loop will reprocess
+			// when the prefetcher hands us this block on a future pass
+			// (or it stays unindexed if the failure is persistent and we
+			// crash-restart from MAX(core_indexed_blocks.height)).
 			e.logger.Error("processBlock failed",
 				zap.Int64("height", block.Height),
 				zap.Error(err))
-			return fmt.Errorf("process block %d: %w", block.Height, err)
+			continue
 		}
 
 		blocksProcessed++


### PR DESCRIPTION
## Summary

Reverts #323.

The halt-on-error change was correct in isolation, but **not compatible with the current dual-run state** where the legacy Python discovery-provider indexer and the `pkg/etl` indexer both write to overlapping tables in the api/ schema. Specifically, since the on-chain plays bridge from AudiusProject/api#881 doesn't ON CONFLICT-protect against rows Python has already written, the per-block savepoint fails on essentially every recent block — and #323 turned that into a hard halt instead of the silent `continue` it used to be.

Observed in prod on AudiusProject/api tonight: after #323 was consumed, the api-side ETL repeatedly halted on block 25415514 (Python had written its plays first), pod restarts re-attempted the same block, same halt. AudiusProject/api#883 (the consumer bump) and AudiusProject/api#884 (the api-side errgroup fix that would actually make the halt exit the process) are being closed/reverted in lockstep with this PR; the diagnosis there is correct, the deploy sequencing isn't.

## Plan

1. **This PR**: revert #323. Restores the silent-skip-on-failure behavior — bad for data quality, fine for keeping the indexer running while dual-run is the operating mode.
2. AudiusProject/api#885: pins `pkg/etl` back to the pre-#323 version.
3. Audit pkg/etl for every cross-writer collision point with Python — start with the plays bridge, mirror the `blocks` adopt-by-hash + ON CONFLICT pattern introduced in #319. Sweep anywhere else both writers touch the same row.
4. Re-land #323 only after step 3 has been verified end-to-end, so the halt-on-error guarantee is honest in the dual-run state.

## Test plan

- [x] `cd pkg/etl && go build ./...` clean.
- [x] `go test .` still passes (the change is back to the original `continue` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
