### PR TITLE
feat(mediorum): prune the append-only crudr ops log

### DIFF
--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -141,9 +141,9 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 	repairInterval := env.GetDuration(time.Hour, "OPENAUDIO_REPAIR_INTERVAL")
 	repairConcurrency := env.GetInt(1, "OPENAUDIO_REPAIR_CONCURRENCY")
 
-	// Op-log pruning configuration. Default retains 1 year of the append-only
-	// crudr "ops" table.
-	opsPruneEnabled := env.Get("true", "OPENAUDIO_OPS_PRUNE_ENABLED") == "true"
+	// Archive mode keeps all history (no ops pruning). Otherwise the append-only
+	// crudr "ops" table is pruned, retaining 1 year by default.
+	archive := env.Get("false", "OPENAUDIO_ARCHIVE", "archive") == "true"
 	opsRetention := env.GetDuration(365*24*time.Hour, "OPENAUDIO_OPS_RETENTION")
 	opsPruneInterval := env.GetDuration(6*time.Hour, "OPENAUDIO_OPS_PRUNE_INTERVAL")
 
@@ -176,7 +176,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		RepairEnabled:             repairEnabled,
 		RepairInterval:            repairInterval,
 		RepairConcurrency:         repairConcurrency,
-		OpsPruneEnabled:           opsPruneEnabled,
+		Archive:                   archive,
 		OpsRetention:              opsRetention,
 		OpsPruneInterval:          opsPruneInterval,
 		BlobStorageStreaming:      env.Bool("OPENAUDIO_BLOB_STORAGE_STREAMING"),

--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -141,10 +141,10 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 	repairInterval := env.GetDuration(time.Hour, "OPENAUDIO_REPAIR_INTERVAL")
 	repairConcurrency := env.GetInt(1, "OPENAUDIO_REPAIR_CONCURRENCY")
 
-	// Op-log pruning configuration. Default retains ~3 months (one quarter) of
-	// the append-only crudr "ops" table.
+	// Op-log pruning configuration. Default retains 1 year of the append-only
+	// crudr "ops" table.
 	opsPruneEnabled := env.Get("true", "OPENAUDIO_OPS_PRUNE_ENABLED") == "true"
-	opsRetention := env.GetDuration(90*24*time.Hour, "OPENAUDIO_OPS_RETENTION")
+	opsRetention := env.GetDuration(365*24*time.Hour, "OPENAUDIO_OPS_RETENTION")
 	opsPruneInterval := env.GetDuration(6*time.Hour, "OPENAUDIO_OPS_PRUNE_INTERVAL")
 
 	config := server.MediorumConfig{

--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -141,6 +141,12 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 	repairInterval := env.GetDuration(time.Hour, "OPENAUDIO_REPAIR_INTERVAL")
 	repairConcurrency := env.GetInt(1, "OPENAUDIO_REPAIR_CONCURRENCY")
 
+	// Op-log pruning configuration. Default retains ~3 months (one quarter) of
+	// the append-only crudr "ops" table.
+	opsPruneEnabled := env.Get("true", "OPENAUDIO_OPS_PRUNE_ENABLED") == "true"
+	opsRetention := env.GetDuration(90*24*time.Hour, "OPENAUDIO_OPS_RETENTION")
+	opsPruneInterval := env.GetDuration(6*time.Hour, "OPENAUDIO_OPS_PRUNE_INTERVAL")
+
 	config := server.MediorumConfig{
 		Self: registrar.Peer{
 			Host:   httputil.RemoveTrailingSlash(strings.ToLower(nodeEndpoint)),
@@ -170,6 +176,9 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		RepairEnabled:             repairEnabled,
 		RepairInterval:            repairInterval,
 		RepairConcurrency:         repairConcurrency,
+		OpsPruneEnabled:           opsPruneEnabled,
+		OpsRetention:              opsRetention,
+		OpsPruneInterval:          opsPruneInterval,
 		BlobStorageStreaming:      env.Bool("OPENAUDIO_BLOB_STORAGE_STREAMING"),
 	}
 

--- a/pkg/mediorum/server/ops_prune.go
+++ b/pkg/mediorum/server/ops_prune.go
@@ -21,8 +21,8 @@ const (
 // node's serving and indexing are unaffected.
 func (ss *MediorumServer) startOpsPruner(ctx context.Context) error {
 	logger := ss.logger.With(zap.String("task", "ops_prune"))
-	if !ss.Config.OpsPruneEnabled {
-		logger.Info("ops pruning disabled")
+	if ss.Config.Archive {
+		logger.Info("archive mode: ops pruning disabled")
 		<-ctx.Done()
 		return ctx.Err()
 	}

--- a/pkg/mediorum/server/ops_prune.go
+++ b/pkg/mediorum/server/ops_prune.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"go.uber.org/zap"
+)
+
+const (
+	opsPruneBatchSize  = 20000
+	opsPruneBatchPause = 200 * time.Millisecond
+)
+
+// The crudr op-log ("ops" table) is append-only and dominates DB size on long-lived
+// nodes, where almost all rows are superseded update snapshots. Pruning old rows only
+// affects a peer sweeping with a cursor older than the retention window (offline that
+// long, or bootstrapping from genesis); caught-up peers sweep every ~10min and never
+// read that far back. It never touches the underlying replicated tables, so this
+// node's serving and indexing are unaffected.
+func (ss *MediorumServer) startOpsPruner(ctx context.Context) error {
+	logger := ss.logger.With(zap.String("task", "ops_prune"))
+	if !ss.Config.OpsPruneEnabled {
+		logger.Info("ops pruning disabled")
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// brief startup delay before the first run, then prune on the configured interval
+	ticker := time.NewTicker(5 * time.Minute)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			ticker.Reset(ss.Config.OpsPruneInterval)
+			deleted, err := ss.pruneOps(ctx, ss.Config.OpsRetention)
+			if err != nil && ctx.Err() == nil {
+				logger.Error("ops prune failed", zap.Int64("deleted", deleted), zap.Error(err))
+			} else if deleted > 0 {
+				logger.Info("ops prune complete", zap.Int64("deleted", deleted))
+			}
+		}
+	}
+}
+
+// pruneOps deletes ops older than retention in indexed batches that each commit
+// independently, avoiding a long lock or oversized transaction. The cutoff is the
+// smallest ULID at (now - retention), so ulid < cutoff selects exactly the older rows.
+func (ss *MediorumServer) pruneOps(ctx context.Context, retention time.Duration) (int64, error) {
+	var cutoff ulid.ULID
+	if err := cutoff.SetTime(ulid.Timestamp(time.Now().Add(-retention))); err != nil {
+		return 0, err
+	}
+	cutoffStr := cutoff.String()
+
+	var total int64
+	for {
+		res := ss.crud.DB.WithContext(ctx).Exec(
+			`DELETE FROM ops WHERE ulid IN (SELECT ulid FROM ops WHERE ulid < ? ORDER BY ulid LIMIT ?)`,
+			cutoffStr, opsPruneBatchSize)
+		if res.Error != nil {
+			return total, res.Error
+		}
+		total += res.RowsAffected
+		if res.RowsAffected < opsPruneBatchSize {
+			return total, nil
+		}
+		select {
+		case <-ctx.Done():
+			return total, ctx.Err()
+		case <-time.After(opsPruneBatchPause):
+		}
+	}
+}

--- a/pkg/mediorum/server/ops_prune_test.go
+++ b/pkg/mediorum/server/ops_prune_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/mediorum/crudr"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPruneOps(t *testing.T) {
+	ss := testNetwork[0]
+	host := fmt.Sprintf("prune-test-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		require.NoError(t, ss.crud.DB.Where("host = ?", host).Delete(&crudr.Op{}).Error)
+	})
+
+	mkOp := func(at time.Time) *crudr.Op {
+		id, err := ulid.New(ulid.Timestamp(at), rand.Reader)
+		require.NoError(t, err)
+		return &crudr.Op{ULID: id.String(), Host: host, Action: "update", Table: "uploads", Data: []byte("[]")}
+	}
+
+	now := time.Now()
+	for _, age := range []time.Duration{-2 * time.Hour, -24 * time.Hour, -90 * 24 * time.Hour, -time.Minute, 0} {
+		require.NoError(t, ss.crud.DB.Create(mkOp(now.Add(age))).Error)
+	}
+
+	// retention of 1h prunes the three older ops, keeps the two within the window
+	deleted, err := ss.pruneOps(context.Background(), time.Hour)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, deleted, int64(3))
+
+	var remaining int64
+	require.NoError(t, ss.crud.DB.Model(&crudr.Op{}).Where("host = ?", host).Count(&remaining).Error)
+	require.Equal(t, int64(2), remaining)
+}

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -82,6 +82,11 @@ type MediorumConfig struct {
 	RepairInterval             time.Duration `default:"1h"`
 	RepairConcurrency          int           `default:"1"`
 
+	// Pruning for the append-only crudr "ops" table.
+	OpsPruneEnabled  bool          `default:"true"`
+	OpsRetention     time.Duration `default:"2160h"` // ~3 months (one quarter)
+	OpsPruneInterval time.Duration `default:"6h"`
+
 	ProgrammableDistributionEnabled bool
 	BlobStorageStreaming             bool
 
@@ -649,6 +654,7 @@ func (ss *MediorumServer) MustStart() error {
 		})
 	}
 
+	ss.lc.AddManagedRoutine("ops pruner", ss.startOpsPruner)
 	ss.lc.AddManagedRoutine("metrics monitor", ss.monitorMetrics)
 	ss.lc.AddManagedRoutine("peer reachability monitor", ss.monitorPeerReachability)
 	ss.lc.AddManagedRoutine("proof of storage handler", ss.startPoSHandler)

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -82,8 +82,9 @@ type MediorumConfig struct {
 	RepairInterval             time.Duration `default:"1h"`
 	RepairConcurrency          int           `default:"1"`
 
-	// Pruning for the append-only crudr "ops" table.
-	OpsPruneEnabled  bool          `default:"true"`
+	// Archive mode (OPENAUDIO_ARCHIVE) keeps all history: no core block pruning
+	// and no crudr "ops" pruning. Otherwise ops older than OpsRetention are pruned.
+	Archive          bool
 	OpsRetention     time.Duration `default:"8760h"` // 1 year
 	OpsPruneInterval time.Duration `default:"6h"`
 

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -84,7 +84,7 @@ type MediorumConfig struct {
 
 	// Pruning for the append-only crudr "ops" table.
 	OpsPruneEnabled  bool          `default:"true"`
-	OpsRetention     time.Duration `default:"2160h"` // ~3 months (one quarter)
+	OpsRetention     time.Duration `default:"8760h"` // 1 year
 	OpsPruneInterval time.Duration `default:"6h"`
 
 	ProgrammableDistributionEnabled bool


### PR DESCRIPTION
## Problem

The crudr op-log (the `ops` table) is append-only and never trimmed. On long-lived nodes — especially `StoreAll` nodes — it dominates database size. On one production node it had grown to **122 GB** (~60% of the DB / disk at ~90%), the overwhelming majority being superseded `update` snapshots that no longer reflect current state (e.g. ~34M `uploads` update ops for ~1.8M uploads).

CometBFT block pruning does not help here: it only prunes the consensus blockstore, never the Postgres `ops` table.

## Change

Adds a background **ops pruner** managed routine that deletes ops older than a retention window (**default 1 year**) in indexed, independently-committed batches — no long lock or oversized transaction, with a short pause between batches.

The cutoff is the smallest ULID at `(now - retention)`; since `ulid` is the table's primary key, `ulid < cutoff` is an indexed range delete.

Pruning is gated on the existing **`OPENAUDIO_ARCHIVE`** env var (the same flag that already disables core block pruning): archive nodes keep all history; non-archive nodes prune both core blocks and the ops log.

### Why this is safe

- The only reader of historical ops rows is the crud sweep endpoint (`WHERE ulid > after ORDER BY ulid`). Caught-up peers sweep every ~10 min, so their cursors sit far newer than any month-scale cutoff — pruning is invisible to them.
- Pruning trims only the change-feed; it never touches the underlying replicated tables (`uploads`, `qm_audio_analyses`, ...), so this node's serving and indexing are unaffected.
- `qm_cids` (content addressing) is not replicated through crudr and is bootstrapped via a separate full-table sync, so it's unaffected.
- Precedent: the codebase already prunes the op-log for `blobs` (`delete from ops where "table" = 'blobs'`), having moved that path to a bulk CSV sync.

The one tradeoff: a brand-new node bootstrapping from genesis (or a peer offline longer than the window) replays only the retained window of the op-log. Existing nodes keep every row, so the live network does not degrade. The protocol-level fix for that case (retention-gap signal + slowest-active-peer cursor floor) lives in #304 and is the planned follow-up.

> Note: deleting rows lets the table stop growing (autovacuum makes the space reusable) but does not return the existing footprint to the OS; reclaiming an already-bloated table needs a one-time `VACUUM FULL` / `pg_repack`.

## Why 1 year (not 90 days)

Measured the op-log age distribution on the affected production node:

| cutoff | rows deleted | `data` freed | `data` kept |
|---|---|---|---|
| 90 days | 64.9M (73%) | 42 GB | 55 GB |
| 365 days | 62.1M (69%) | 39 GB | 58 GB |

~57% of the data volume is younger than 90 days (recent `store_all` backfill churn), and the old tail is mostly tiny `qm_audio_analyses` ops. So a 90d vs 365d cutoff differs by only **~3 GB** of reclaim. The longer window is essentially free and makes the lagging/bootstrapping-peer skip far less likely — a peer would have to be over a year behind.

## Config

| env | default | meaning |
|---|---|---|
| `OPENAUDIO_ARCHIVE` | `false` | when `true`, keep all history (no core block or ops pruning) |
| `OPENAUDIO_OPS_RETENTION` | `8760h` (1 year) | how much ops history to keep when not archiving |
| `OPENAUDIO_OPS_PRUNE_INTERVAL` | `6h` | how often the pruner runs |

## Relationship to #304

This is the targeted "stop the bleeding" change; #304 is the broader retention framework (kept open as future work). #304's bloat-fixing path is opt-in/off by default and its dormant cleanup only drops *entirely dormant* tables, so it doesn't reduce the actively-written `uploads`/`qm_audio_analyses` footprint out of the box. Plan: ship this first, then layer #304's gap-signal + cursor-floor on top as the protocol-level safety upgrade. See the comparison comment on #304.

## Testing

- `TestPruneOps` verifies ops older than the retention window are deleted and in-window ops survive (run against a real Postgres).
- `go build` / `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)