### PR TITLE
feat(console): Improve console jailed and height status

### DIFF
--- a/cmd/openaudio/main.go
+++ b/cmd/openaudio/main.go
@@ -31,14 +31,14 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/common"
 	"github.com/OpenAudio/go-openaudio/pkg/core"
 	"github.com/OpenAudio/go-openaudio/pkg/core/config"
-	oaenv "github.com/OpenAudio/go-openaudio/pkg/env"
-	"github.com/OpenAudio/go-openaudio/pkg/explorer"
 	coreServer "github.com/OpenAudio/go-openaudio/pkg/core/server"
+	oaenv "github.com/OpenAudio/go-openaudio/pkg/env"
 	"github.com/OpenAudio/go-openaudio/pkg/eth"
 	"github.com/OpenAudio/go-openaudio/pkg/etl"
 	"github.com/OpenAudio/go-openaudio/pkg/etlserver"
-	"github.com/OpenAudio/go-openaudio/pkg/location"
+	"github.com/OpenAudio/go-openaudio/pkg/explorer"
 	"github.com/OpenAudio/go-openaudio/pkg/lifecycle"
+	"github.com/OpenAudio/go-openaudio/pkg/location"
 	aLogger "github.com/OpenAudio/go-openaudio/pkg/logger"
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum"
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/server"
@@ -662,7 +662,7 @@ func startEchoProxy(hostUrl *url.URL, logger *zap.Logger, coreService *coreServe
 	// Base route collides with console dashboard when explorer is enabled
 	if !consoleEnabled {
 		baseRoutes.GET("/", func(c echo.Context) error {
-			return c.JSON(http.StatusOK, map[string]int{"a": 440})
+			return c.Redirect(http.StatusMovedPermanently, "/console")
 		})
 	}
 	baseRoutes.GET("/console", func(c echo.Context) error {
@@ -946,7 +946,6 @@ func keyGen() (string, string) {
 	return hex.EncodeToString(privateKeyBytes), crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
 }
 
-
 func hasSuffix(domain string, suffixes []string) bool {
 	for _, suffix := range suffixes {
 		if strings.HasSuffix(domain, suffix) {
@@ -1034,4 +1033,3 @@ func getHealthCheckResponse(hostUrl *url.URL, coreService *coreServer.CoreServic
 
 	return response
 }
-

--- a/pkg/core/console/nav.go
+++ b/pkg/core/console/nav.go
@@ -14,8 +14,16 @@ func (con *Console) navChainData(c echo.Context) error {
 		return err
 	}
 
-	totalBlocks := fmt.Sprint(res.Msg.CurrentHeight)
+	totalBlocks := fmt.Sprint(con.latestKnownHeight(c.Request().Context(), res.Msg.CurrentHeight))
 	isSyncing := !res.Msg.Synced
 
 	return con.views.RenderNavChainData(c, totalBlocks, isSyncing)
+}
+
+func (con *Console) navJailedStatus(c echo.Context) error {
+	jailed, err := con.currentNodeJailed(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return con.views.RenderNavJailedStatus(c, jailed)
 }

--- a/pkg/core/console/overview.go
+++ b/pkg/core/console/overview.go
@@ -1,55 +1,66 @@
 package console
 
 import (
+	"context"
+
 	"connectrpc.com/connect"
 	v1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
 	"github.com/labstack/echo/v4"
 )
 
+func (cs *Console) getConsoleStatus(ctx context.Context) (*v1.GetStatusResponse, error) {
+	res, err := cs.core.GetStatus(ctx, &connect.Request[v1.GetStatusRequest]{})
+	if err != nil {
+		return nil, err
+	}
+	cs.applyChainHeightFallback(ctx, res.Msg)
+	return res.Msg, nil
+}
+
 func (cs *Console) overviewPage(c echo.Context) error {
-	res, err := cs.core.GetStatus(c.Request().Context(), &connect.Request[v1.GetStatusRequest]{})
+	status, err := cs.getConsoleStatus(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	return cs.views.RenderOverview(c, res.Msg)
+	return cs.views.RenderOverview(c, status)
 }
 
 func (cs *Console) overviewCriticalFragment(c echo.Context) error {
-	res, err := cs.core.GetStatus(c.Request().Context(), &connect.Request[v1.GetStatusRequest]{})
+	status, err := cs.getConsoleStatus(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	return cs.views.RenderOverviewCritical(c, res.Msg)
+	return cs.views.RenderOverviewCritical(c, status)
 }
 
 func (cs *Console) overviewProcessesFragment(c echo.Context) error {
-	res, err := cs.core.GetStatus(c.Request().Context(), &connect.Request[v1.GetStatusRequest]{})
+	status, err := cs.getConsoleStatus(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	return cs.views.RenderOverviewProcesses(c, res.Msg)
+	return cs.views.RenderOverviewProcesses(c, status)
 }
 
 func (cs *Console) overviewResourcesFragment(c echo.Context) error {
-	res, err := cs.core.GetStatus(c.Request().Context(), &connect.Request[v1.GetStatusRequest]{})
+	status, err := cs.getConsoleStatus(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	return cs.views.RenderOverviewResources(c, res.Msg)
+	return cs.views.RenderOverviewResources(c, status)
 }
 
 func (cs *Console) overviewStorageFragment(c echo.Context) error {
-	res, err := cs.core.GetStatus(c.Request().Context(), &connect.Request[v1.GetStatusRequest]{})
+	status, err := cs.getConsoleStatus(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	return cs.views.RenderOverviewStorage(c, res.Msg)
+	return cs.views.RenderOverviewStorage(c, status)
 }
 
 func (cs *Console) overviewNetworkFragment(c echo.Context) error {
-	res, err := cs.core.GetStatus(c.Request().Context(), &connect.Request[v1.GetStatusRequest]{})
+	status, err := cs.getConsoleStatus(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	return cs.views.RenderOverviewNetwork(c, res.Msg)
+	return cs.views.RenderOverviewNetwork(c, status)
 }

--- a/pkg/core/console/routes.go
+++ b/pkg/core/console/routes.go
@@ -50,6 +50,7 @@ func (c *Console) registerRoutes() {
 	g.GET("/health_check", c.getHealth)
 
 	g.GET("/fragments/nav/chain_data", c.navChainData)
+	g.GET("/fragments/nav/jailed_status", c.navJailedStatus)
 	g.GET("/fragments/overview/critical", c.overviewCriticalFragment)
 	g.GET("/fragments/overview/processes", c.overviewProcessesFragment)
 	g.GET("/fragments/overview/resources", c.overviewResourcesFragment)

--- a/pkg/core/console/status.go
+++ b/pkg/core/console/status.go
@@ -1,0 +1,84 @@
+package console
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	v1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+)
+
+func (cs *Console) applyChainHeightFallback(ctx context.Context, status *v1.GetStatusResponse) {
+	if status == nil {
+		return
+	}
+	if status.ChainInfo == nil {
+		status.ChainInfo = &v1.GetStatusResponse_ChainInfo{
+			ChainId: cs.config.GenesisFile.ChainID,
+		}
+	}
+	if status.ChainInfo.CurrentHeight > 0 && status.ChainInfo.CurrentBlockHash != "" {
+		return
+	}
+
+	latestBlock, err := cs.db.GetLatestBlock(ctx)
+	if err != nil {
+		return
+	}
+
+	if status.ChainInfo.CurrentHeight <= 0 {
+		status.ChainInfo.CurrentHeight = latestBlock.Height
+	}
+	if status.ChainInfo.CurrentHeight == latestBlock.Height && status.ChainInfo.CurrentBlockHash == "" {
+		status.ChainInfo.CurrentBlockHash = latestBlock.Hash
+	}
+}
+
+func (cs *Console) latestKnownHeight(ctx context.Context, currentHeight int64) int64 {
+	if currentHeight > 0 {
+		return currentHeight
+	}
+
+	latestBlock, err := cs.db.GetLatestBlock(ctx)
+	if err != nil {
+		return currentHeight
+	}
+	return latestBlock.Height
+}
+
+func (cs *Console) currentNodeJailed(ctx context.Context) (bool, error) {
+	if cometAddress := strings.TrimSpace(cs.config.ProposerAddress); cometAddress != "" {
+		node, err := cs.db.GetRegisteredNodeByCometAddress(ctx, cometAddress)
+		if err == nil {
+			return node.Jailed, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return false, err
+		}
+	}
+
+	if ethAddress := strings.TrimSpace(cs.config.WalletAddress); ethAddress != "" {
+		node, err := cs.db.GetRegisteredNodeByEthAddress(ctx, ethAddress)
+		if err == nil {
+			return node.Jailed, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return false, err
+		}
+	}
+
+	nodes, err := cs.db.GetAllRegisteredNodesIncludingJailed(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, node := range nodes {
+		if strings.EqualFold(node.CometAddress, cs.config.ProposerAddress) ||
+			strings.EqualFold(node.EthAddress, cs.config.WalletAddress) ||
+			normalizeEndpoint(node.Endpoint) == normalizeEndpoint(cs.config.NodeEndpoint) {
+			return node.Jailed, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/core/console/views/layout/site_frame.templ
+++ b/pkg/core/console/views/layout/site_frame.templ
@@ -24,9 +24,26 @@ templ (l *Layout) NavBlockData(totalBlocks string, syncing bool) {
 	</div>
 }
 
+templ (l *Layout) JailedStatusBanner(jailed bool) {
+	if jailed {
+		<div class="w-full border-b-2 border-red-500 bg-red-950 px-4 py-4 text-white shadow-lg md:px-8">
+			<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+				<div class="flex items-center gap-3 text-2xl font-bold">
+					@components.StatusRedLg("Jailed")
+					<span>Jailed</span>
+				</div>
+				<div class="text-sm font-semibold uppercase tracking-normal sm:text-right">
+					This node is currently jailed and will not participate as an active validator.
+				</div>
+			</div>
+		</div>
+	}
+}
+
 templ (l *Layout) SiteFrame() {
 	@l.Base() {
 		<div class="min-h-screen flex flex-col">
+			<div hx-get="/console/fragments/nav/jailed_status" hx-swap="innerHTML" hx-trigger="load, every 5s"></div>
 			<div class="flex-none space-y-4 p-4 pt-4 md:p-8 md:pt-6">
 				<div class="flex flex-col gap-4 sm:flex-row sm:justify-between sm:gap-2 sm:space-y-2">
 					<div class="uk-navbar-item flex flex-col items-start space-y-4">

--- a/pkg/core/console/views/layout/site_frame_templ.go
+++ b/pkg/core/console/views/layout/site_frame_templ.go
@@ -78,7 +78,7 @@ func (l *Layout) NavBlockData(totalBlocks string, syncing bool) templ.Component 
 	})
 }
 
-func (l *Layout) SiteFrame() templ.Component {
+func (l *Layout) JailedStatusBanner(jailed bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -99,7 +99,46 @@ func (l *Layout) SiteFrame() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		if jailed {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"w-full border-b-2 border-red-500 bg-red-950 px-4 py-4 text-white shadow-lg md:px-8\"><div class=\"flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between\"><div class=\"flex items-center gap-3 text-2xl font-bold\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = components.StatusRedLg("Jailed").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<span>Jailed</span></div><div class=\"text-sm font-semibold uppercase tracking-normal sm:text-right\">This node is currently jailed and will not participate as an active validator.</div></div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
+func (l *Layout) SiteFrame() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -111,46 +150,20 @@ func (l *Layout) SiteFrame() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"min-h-screen flex flex-col\"><div class=\"flex-none space-y-4 p-4 pt-4 md:p-8 md:pt-6\"><div class=\"flex flex-col gap-4 sm:flex-row sm:justify-between sm:gap-2 sm:space-y-2\"><div class=\"uk-navbar-item flex flex-col items-start space-y-4\"><a href=\"/console\" class=\"flex items-center\"><img src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"min-h-screen flex flex-col\"><div hx-get=\"/console/fragments/nav/jailed_status\" hx-swap=\"innerHTML\" hx-trigger=\"load, every 5s\"></div><div class=\"flex-none space-y-4 p-4 pt-4 md:p-8 md:pt-6\"><div class=\"flex flex-col gap-4 sm:flex-row sm:justify-between sm:gap-2 sm:space-y-2\"><div class=\"uk-navbar-item flex flex-col items-start space-y-4\"><a href=\"/console\" class=\"flex items-center\"><img src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(assets.OAPLogoInverse)
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(assets.OAPLogoInverse)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 34, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 51, Col: 39}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" alt=\"audius logo\" class=\"mx-2 md:mx-4 h-10 w-10 md:h-12 md:w-12 object-contain\"><h1 class=\"text-lg md:text-2xl font-bold tracking-tight\">Open Audio Console</h1></a><div class=\"space-y-4 w-full\"><ul class=\"uk-tab-alt max-w-96\"><li>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div>Overview</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				return nil
-			})
-			templ_7745c5c3_Err = l.components.Link("/overview").Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</li><li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" alt=\"audius logo\" class=\"mx-2 md:mx-4 h-10 w-10 md:h-12 md:w-12 object-contain\"><h1 class=\"text-lg md:text-2xl font-bold tracking-tight\">Open Audio Console</h1></a><div class=\"space-y-4 w-full\"><ul class=\"uk-tab-alt max-w-96\"><li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -166,13 +179,13 @@ func (l *Layout) SiteFrame() templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div>Storage</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div>Overview</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = l.components.Link("/storage").Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = l.components.Link("/overview").Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -192,13 +205,13 @@ func (l *Layout) SiteFrame() templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div>Validators</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div>Storage</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = l.components.Link("/validators").Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = l.components.Link("/storage").Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -218,17 +231,17 @@ func (l *Layout) SiteFrame() templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div>Uptime</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div>Validators</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = l.components.Link("/uptime").Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = l.components.Link("/validators").Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</li></ul></div></div><div class=\"flex space-x-2 sm:justify-end\"><div class=\"text-left sm:text-right text-sm text-secondary tracking-tight\"><div><span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</li><li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -244,70 +257,96 @@ func (l *Layout) SiteFrame() templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(l.config.GenesisFile.ChainID)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 67, Col: 46}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div>Uptime</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = l.components.Link("/genesis").Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = l.components.Link("/uptime").Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span></div><div hx-get=\"/console/fragments/nav/chain_data\" hx-swap=\"innerHTML\" hx-trigger=\"load, every 1s\"></div></div></div></div></div><div id=\"page-content\" class=\"flex-grow space-y-4 p-2 pt-4 md:p-8 md:pt-6 flex flex-col\"><div class=\"p-2 md:p-4 flex-grow flex flex-col\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</li></ul></div></div><div class=\"flex space-x-2 sm:justify-end\"><div class=\"text-left sm:text-right text-sm text-secondary tracking-tight\"><div><span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templ_7745c5c3_Var3.Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<span>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(l.config.GenesisFile.ChainID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 84, Col: 46}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = l.components.Link("/genesis").Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div></div><footer class=\"h-[3vh] w-full flex items-center justify-center p-3\"><div class=\"text-xs text-secondary flex justify-end w-full px-5\"><span>version: <a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span></div><div hx-get=\"/console/fragments/nav/chain_data\" hx-swap=\"innerHTML\" hx-trigger=\"load, every 1s\"></div></div></div></div></div><div id=\"page-content\" class=\"flex-grow space-y-4 p-2 pt-4 md:p-8 md:pt-6 flex flex-col\"><div class=\"p-2 md:p-4 flex-grow flex flex-col\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var12 templ.SafeURL
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(gitCommit)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 83, Col: 39}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			templ_7745c5c3_Err = templ_7745c5c3_Var4.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" target=\"_blank\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></div><footer class=\"h-[3vh] w-full flex items-center justify-center p-3\"><div class=\"text-xs text-secondary flex justify-end w-full px-5\"><span>version: <a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(version.Version.Version)
+			var templ_7745c5c3_Var13 templ.SafeURL
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinURLErrs(gitCommit)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 83, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 100, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</a></span></div></footer></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" target=\"_blank\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(version.Version.Version)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout/site_frame.templ`, Line: 100, Col: 83}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</a></span></div></footer></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = l.Base().Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = l.Base().Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/pkg/core/console/views/views.go
+++ b/pkg/core/console/views/views.go
@@ -25,6 +25,10 @@ func (v *Views) RenderNavChainData(c echo.Context, totalBlocks string, syncing b
 	return v.layouts.NavBlockData(totalBlocks, syncing).Render(c.Request().Context(), c.Response().Writer)
 }
 
+func (v *Views) RenderNavJailedStatus(c echo.Context, jailed bool) error {
+	return v.layouts.JailedStatusBanner(jailed).Render(c.Request().Context(), c.Response().Writer)
+}
+
 func (v *Views) RenderNodesView(c echo.Context, view *pages.NodesView) error {
 	return v.pages.NodesPageHTML(view).Render(c.Request().Context(), c.Response().Writer)
 }


### PR DESCRIPTION
## Summary
- show a prominent top-of-console jailed banner for the current node
- fall back to the latest persisted block height when console status reports height 0 after restart
- route `/` to `/console` when explorer/ETL is not serving the root page

## Tests
- `go test ./pkg/core/console/...`
- `go test ./cmd/openaudio`
- `git diff --check`