### PR TITLE
fix(CRUD): Cap CRUD sweep response memory

### DIFF
--- a/pkg/mediorum/crudr/client.go
+++ b/pkg/mediorum/crudr/client.go
@@ -164,6 +164,9 @@ func (p *PeerClient) doSweep(ctx context.Context) error {
 		return fmt.Errorf("bad status: %d", resp.StatusCode)
 	}
 
+	limited := resp.Header.Get(SweepLimitedHeader) == "true"
+	lastScannedULID := resp.Header.Get(SweepLastScannedULIDHeader)
+
 	var ops []*Op
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&ops)
@@ -171,6 +174,7 @@ func (p *PeerClient) doSweep(ctx context.Context) error {
 		return err
 	}
 
+	hadApplyError := false
 	for _, op := range ops {
 		// ignore old blobs ops
 		if op.Table == "blobs" {
@@ -185,14 +189,19 @@ func (p *PeerClient) doSweep(ctx context.Context) error {
 
 		err := p.crudr.ApplyOp(op)
 		if err != nil {
+			hadApplyError = true
 			p.logger.Error("failed to apply op", "op", op, "err", err)
 		} else {
 			lastUlid = op.ULID
 		}
 	}
 
+	if !hadApplyError && lastScannedULID > lastUlid {
+		lastUlid = lastScannedULID
+	}
+
 	// seeding is complete once there are no more ulids to sweep (or very few left)
-	if !p.Seeded && len(ops) < 10 {
+	if !p.Seeded && !limited && len(ops) < 10 {
 		p.logger.Info("seeding complete (no more ulids to sweep)")
 		p.Seeded = true
 	}
@@ -206,10 +215,10 @@ func (p *PeerClient) doSweep(ctx context.Context) error {
 		}
 	}
 
-	p.logger.Debug("backfill done", "host", host, "count", len(ops), "last_ulid", lastUlid)
+	p.logger.Debug("backfill done", "host", host, "count", len(ops), "last_ulid", lastUlid, "limited", limited, "last_scanned_ulid", lastScannedULID)
 
 	// seeding is complete if the last ulid is within the last hour
-	if !p.Seeded {
+	if !p.Seeded && !limited {
 		parsedULID, err := ulid.Parse(lastUlid)
 		if err == nil {
 			t := ulid.Time(parsedULID.Time())

--- a/pkg/mediorum/crudr/client_test.go
+++ b/pkg/mediorum/crudr/client_test.go
@@ -1,0 +1,38 @@
+package crudr
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OpenAudio/go-openaudio/pkg/lifecycle"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestDoSweepAdvancesCursorToLastScannedHeader(t *testing.T) {
+	db := SetupTestDB()
+	z := zap.NewNop()
+	c := New("https://self.example", nil, nil, db, lifecycle.NewLifecycle(context.Background(), "crudr client test", z), z, nil)
+	require.NoError(t, db.Exec("TRUNCATE ops, cursors").Error)
+
+	lastScannedULID := "01KT26A1XRE7JYJ3FQBTT4C3CX"
+	peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/internal/crud/sweep", r.URL.Path)
+		w.Header().Set(SweepLastScannedULIDHeader, lastScannedULID)
+		w.Header().Set(SweepLimitedHeader, "true")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "[]")
+	}))
+	t.Cleanup(peerServer.Close)
+
+	peer := NewPeerClient(peerServer.URL, c, "https://self.example")
+	require.NoError(t, peer.doSweep(context.Background()))
+	require.False(t, peer.Seeded)
+
+	var cursor Cursor
+	require.NoError(t, db.Where("host = ?", peer.Host).First(&cursor).Error)
+	require.Equal(t, lastScannedULID, cursor.LastULID)
+}

--- a/pkg/mediorum/crudr/sweep.go
+++ b/pkg/mediorum/crudr/sweep.go
@@ -1,0 +1,6 @@
+package crudr
+
+const (
+	SweepLastScannedULIDHeader = "X-Crud-Sweep-Last-Scanned-Ulid"
+	SweepLimitedHeader         = "X-Crud-Sweep-Limited"
+)

--- a/pkg/mediorum/server/serve_crud.go
+++ b/pkg/mediorum/server/serve_crud.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -16,6 +17,7 @@ import (
 )
 
 const PullLimit = 10000
+const crudSweepMaxResponseBytes = 64 << 20
 
 var crudStatusTables = []string{
 	"ops",
@@ -46,43 +48,106 @@ type audioAnalysisBacklogStatus struct {
 	RetryBackoffSeconds int64 `json:"retry_backoff_seconds"`
 }
 
+type crudSweepResponse struct {
+	body            []byte
+	lastScannedULID string
+	limited         bool
+	scannedRows     int
+	responseRows    int
+}
+
 func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	ss.crudSweepMutex.Lock()
 	defer ss.crudSweepMutex.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(c.Request().Context(), 1*time.Minute)
 	defer cancel()
 
-	after := c.QueryParam("after")
-	var ops []*crudr.Op
-	err := ss.crud.DB.
-		WithContext(ctx).
-		Where("ulid > ?", after).
-		Limit(PullLimit).
-		Order("ulid asc").
-		Find(&ops).
-		Error
+	sweep, err := ss.buildCrudSweepResponse(ctx, c.QueryParam("after"), crudSweepMaxResponseBytes)
 	if err != nil {
-		return c.String(500, fmt.Sprintf("Failed to query ops: %v", err))
-	}
-
-	// some peers can't talk to each other, so we do some gossip
-	// before we'd send all ops to all peers gossip style
-	// but this is a bit excessive what with the bandwidth
-	// so we only forward ops for which we are an orig upload mirror
-	// thus using rendezvous for gossip forwarding
-	filteredOps := make([]*crudr.Op, 0, len(ops)/2)
-	myHost := []byte(ss.Config.Self.Host)
-	for _, op := range ops {
-		// if our host doesn't appear in the record, we are not a mirror
-		if op.Table == "uploads" && !bytes.Contains(op.Data, myHost) {
-			continue
-		}
-		filteredOps = append(filteredOps, op)
+		return c.String(500, fmt.Sprintf("Failed to build crud sweep: %v", err))
 	}
 
 	c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=300")
-	return c.JSON(200, filteredOps)
+	if sweep.lastScannedULID != "" {
+		c.Response().Header().Set(crudr.SweepLastScannedULIDHeader, sweep.lastScannedULID)
+	}
+	if sweep.limited {
+		c.Response().Header().Set(crudr.SweepLimitedHeader, "true")
+	}
+	return c.Blob(200, echo.MIMEApplicationJSONCharsetUTF8, sweep.body)
+}
+
+func (ss *MediorumServer) buildCrudSweepResponse(ctx context.Context, after string, maxResponseBytes int) (crudSweepResponse, error) {
+	if maxResponseBytes <= 0 {
+		maxResponseBytes = crudSweepMaxResponseBytes
+	}
+
+	rows, err := ss.crud.DB.
+		WithContext(ctx).
+		Model(&crudr.Op{}).
+		Select("ulid, host, action, \"table\", data").
+		Where("ulid > ?", after).
+		Limit(PullLimit).
+		Order("ulid asc").
+		Rows()
+	if err != nil {
+		return crudSweepResponse{}, err
+	}
+	defer rows.Close()
+
+	var sweep crudSweepResponse
+	var body bytes.Buffer
+	body.WriteByte('[')
+
+	myHost := []byte(ss.Config.Self.Host)
+	for rows.Next() {
+		var op crudr.Op
+		if err := ss.crud.DB.ScanRows(rows, &op); err != nil {
+			return crudSweepResponse{}, err
+		}
+		sweep.scannedRows++
+
+		// Some peers can't talk to each other, so only forward upload ops for
+		// which this node is an original upload mirror.
+		if op.Table == "uploads" && !bytes.Contains(op.Data, myHost) {
+			sweep.lastScannedULID = op.ULID
+			continue
+		}
+
+		payload, err := json.Marshal(&op)
+		if err != nil {
+			return crudSweepResponse{}, err
+		}
+
+		nextBytes := len(payload)
+		if sweep.responseRows > 0 {
+			nextBytes++ // comma separator
+		}
+		if sweep.responseRows > 0 && body.Len()+nextBytes+1 > maxResponseBytes {
+			sweep.limited = true
+			break
+		}
+
+		if sweep.responseRows > 0 {
+			body.WriteByte(',')
+		}
+		body.Write(payload)
+		sweep.responseRows++
+		sweep.lastScannedULID = op.ULID
+	}
+	if err := rows.Err(); err != nil {
+		return crudSweepResponse{}, err
+	}
+
+	if sweep.scannedRows == PullLimit {
+		sweep.limited = true
+	}
+
+	body.WriteByte(']')
+	sweep.body = body.Bytes()
+
+	return sweep, nil
 }
 
 func (ss *MediorumServer) serveCrudStatus(c echo.Context) error {
@@ -103,10 +168,12 @@ func (ss *MediorumServer) serveCrudStatus(c echo.Context) error {
 	return c.JSON(http.StatusOK, struct {
 		*crudr.Status
 		PullLimit            int                        `json:"pull_limit"`
+		MaxResponseBytes     int                        `json:"max_response_bytes"`
 		AudioAnalysisBacklog audioAnalysisBacklogStatus `json:"audio_analysis_backlog"`
 	}{
 		Status:               status,
 		PullLimit:            PullLimit,
+		MaxResponseBytes:     crudSweepMaxResponseBytes,
 		AudioAnalysisBacklog: backlog,
 	})
 }

--- a/pkg/mediorum/server/serve_crud_test.go
+++ b/pkg/mediorum/server/serve_crud_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,95 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/server/signature"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBuildCrudSweepResponseCapsBytesAndReportsCursor(t *testing.T) {
+	ss := testNetwork[0]
+	ctx := context.Background()
+	prefix := fmt.Sprintf("zz-crud-sweep-cap-%d-", time.Now().UnixNano())
+	cleanup := func() {
+		require.NoError(t, ss.crud.DB.Where("ulid LIKE ?", prefix+"%").Delete(&crudr.Op{}).Error)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ops := []crudr.Op{
+		{
+			ULID:   prefix + "01",
+			Host:   ss.Config.Self.Host,
+			Action: crudr.ActionCreate,
+			Table:  "uploads",
+			Data:   json.RawMessage(`[{"mirrors":["https://not-this-host.example"]}]`),
+		},
+		{
+			ULID:   prefix + "02",
+			Host:   ss.Config.Self.Host,
+			Action: crudr.ActionCreate,
+			Table:  "storage_and_db_sizes",
+			Data:   json.RawMessage(`[{"host":"small","size":1}]`),
+		},
+		{
+			ULID:   prefix + "03",
+			Host:   ss.Config.Self.Host,
+			Action: crudr.ActionCreate,
+			Table:  "storage_and_db_sizes",
+			Data:   json.RawMessage(fmt.Sprintf(`[{"host":"%s","size":2}]`, strings.Repeat("x", 512))),
+		},
+	}
+	require.NoError(t, ss.crud.DB.Create(&ops).Error)
+
+	firstPayload, err := json.Marshal(&ops[1])
+	require.NoError(t, err)
+	sweep, err := ss.buildCrudSweepResponse(ctx, prefix+"00", len(firstPayload)+2)
+	require.NoError(t, err)
+
+	require.True(t, sweep.limited)
+	require.Equal(t, prefix+"02", sweep.lastScannedULID)
+	require.Equal(t, 3, sweep.scannedRows)
+	require.Equal(t, 1, sweep.responseRows)
+
+	var returned []crudr.Op
+	require.NoError(t, json.Unmarshal(sweep.body, &returned))
+	require.Len(t, returned, 1)
+	require.Equal(t, prefix+"02", returned[0].ULID)
+}
+
+func TestBuildCrudSweepResponseAdvancesPastFilteredUploads(t *testing.T) {
+	ss := testNetwork[0]
+	ctx := context.Background()
+	prefix := fmt.Sprintf("zz-crud-sweep-filter-%d-", time.Now().UnixNano())
+	cleanup := func() {
+		require.NoError(t, ss.crud.DB.Where("ulid LIKE ?", prefix+"%").Delete(&crudr.Op{}).Error)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ops := []crudr.Op{
+		{
+			ULID:   prefix + "01",
+			Host:   ss.Config.Self.Host,
+			Action: crudr.ActionCreate,
+			Table:  "uploads",
+			Data:   json.RawMessage(`[{"mirrors":["https://not-this-host.example"]}]`),
+		},
+		{
+			ULID:   prefix + "02",
+			Host:   ss.Config.Self.Host,
+			Action: crudr.ActionCreate,
+			Table:  "uploads",
+			Data:   json.RawMessage(`[{"mirrors":["https://also-not-this-host.example"]}]`),
+		},
+	}
+	require.NoError(t, ss.crud.DB.Create(&ops).Error)
+
+	sweep, err := ss.buildCrudSweepResponse(ctx, prefix+"00", 1024)
+	require.NoError(t, err)
+
+	require.False(t, sweep.limited)
+	require.Equal(t, prefix+"02", sweep.lastScannedULID)
+	require.Equal(t, 2, sweep.scannedRows)
+	require.Equal(t, 0, sweep.responseRows)
+	require.JSONEq(t, `[]`, string(sweep.body))
+}
 
 func TestServeCrudStatus(t *testing.T) {
 	statusServer := testNetwork[0]
@@ -33,11 +123,13 @@ func TestServeCrudStatus(t *testing.T) {
 
 	var payload struct {
 		crudr.Status
-		PullLimit int `json:"pull_limit"`
+		PullLimit        int `json:"pull_limit"`
+		MaxResponseBytes int `json:"max_response_bytes"`
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
 
 	require.Equal(t, PullLimit, payload.PullLimit)
+	require.Equal(t, crudSweepMaxResponseBytes, payload.MaxResponseBytes)
 	require.Contains(t, payload.Tables, "ops")
 	require.Contains(t, payload.Tables, "uploads")
 	require.Contains(t, payload.Tables, "qm_audio_analyses")


### PR DESCRIPTION
## What is happening

`creatornode2.audius.co` appears to be flapping because the process is running out of memory while serving `/internal/crud/sweep` requests.

This does **not** look like the registry watchdog/jailing path being the primary issue.

## Evidence from prod

On `creator-2/audiusd-0`:

- Kubernetes showed recent container exits as `OOMKilled` / exit code `137`.
- The pod climbed back to tens of GiB of memory shortly after restart.
- Previous-container logs showed `/internal/crud/sweep` requests taking 3-13 minutes, often ending in `502` or `broken pipe`.
- Heap profiling showed ~14GB live Go heap dominated by:

  `bytes.growSlice -> encoding/json -> echo.Context.JSON -> serveCrudSweep`

So the hot path is building a very large JSON sweep response in memory.

A sampled old-cursor sweep on `creatornode2` could produce multi-GB response data. By contrast, `creatornode.audius.co` was serving recent-cursor sweep requests around ~19MB in ~1-2s, which matches why it does not show the same behavior.

## What this PR changes

This PR bounds the memory used by `/internal/crud/sweep`.

Server side:

- Builds the JSON response incrementally instead of loading/filtering a full slice and passing it to Echo's JSON encoder.
- Caps each sweep response at `64MiB`.
- Returns two headers:
  - `X-Crud-Sweep-Last-Scanned-Ulid`
  - `X-Crud-Sweep-Limited`

Client side:

- Reads those headers after a sweep.
- Advances its cursor to the server's last scanned ULID when the response was successfully applied.
- Does not mark a peer as fully seeded when the response was capped/truncated.

## Will peers still get all data?

Yes, updated peers still get all eligible sweep data, but they may receive it over multiple bounded responses instead of one giant response.

The flow is:

1. Peer requests `/internal/crud/sweep?after=<cursor>`.
2. Server scans forward and returns as much eligible data as fits under `64MiB`.
3. Server includes `X-Crud-Sweep-Last-Scanned-Ulid`.
4. Client stores that ULID as its cursor.
5. Next sweep resumes after that cursor.

Upload ops that do not include this node as an original upload mirror are still intentionally filtered out by the existing gossip rule. The new cursor header is what lets clients advance past those filtered rows safely.

## Tradeoff

A very far-behind peer may take multiple sweeps to catch up. Since the existing sweeper interval is 10 minutes, this can be slower than returning one huge response, but it avoids taking the serving node down with an OOM.

A possible follow-up would be bounded immediate pagination: when `X-Crud-Sweep-Limited: true`, the client could fetch a few more pages in the same sweep run, capped by total pages or bytes.

## Testing

Passed:

```sh
git diff --check
USE_CONTAINER=true scripts/go-test-wrapper.sh test ./pkg/mediorum/crudr -run TestDoSweepAdvancesCursorToLastScannedHeader -count=1
```

Attempted:

```sh
USE_CONTAINER=true scripts/go-test-wrapper.sh test ./pkg/mediorum/server -run 'TestBuildCrudSweepResponse|TestServeCrudStatus' -count=1
```

That run did not reach the new assertions because the existing mediorum server `TestMain` 9-node bootstrap timed out with:

```text
test network did not become healthy: 3/9 servers ready
```
