### PR TITLE
feat(etl): emit info line per indexed entity-manager row

### DIFF
--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -584,8 +584,16 @@ func (e *Indexer) processOneTx(
 				return false
 			}
 		} else {
-			e.logger.Debug("tx indexed",
-				zap.String("type", "manage_entity"),
+			// One info line per successfully indexed entity-manager row,
+			// mirroring the field set of the "validation rejected" / "dispatch
+			// error" logs so a single grep on hash/entity_id shows the full
+			// lifecycle (indexed vs rejected vs errored) of every EM tx.
+			e.logger.Info("entity manager indexed",
+				zap.String("entity_type", me.GetEntityType()),
+				zap.String("action", me.GetAction()),
+				zap.Int64("entity_id", me.GetEntityId()),
+				zap.Int64("user_id", me.GetUserId()),
+				zap.Int64("block", block.Height),
 				zap.String("hash", t.Hash),
 				zap.Duration("elapsed", time.Since(txStart)),
 			)


### PR DESCRIPTION
## Summary
- The entity-manager success path in `pkg/etl/indexer.go` logged at **Debug** with only `type`/`hash`/`elapsed`, so in production (Info level) there was no per-row signal that an EM transaction indexed successfully.
- Promote it to an **Info** line `"entity manager indexed"` carrying `entity_type`, `action`, `entity_id`, `user_id`, and `block`, mirroring the field set of the existing `"entity manager validation rejected"` (Warn) and `"entity manager dispatch error"` (Error) logs.
- A single grep on `hash` or `entity_id` now shows the full lifecycle — indexed vs rejected vs errored — of every entity-manager transaction.

## Motivation
During the Python → ETL cutover we had no way to confirm from logs that individual EM rows were landing; the only visible signals were failures. This closes that gap so success is observable at the same granularity as failure.

## Test plan
- [x] `go build ./...` in `pkg/etl`
- [x] `go vet ./...` in `pkg/etl`
- [ ] Confirm the `entity manager indexed` line appears at Info in a deployed indexer once released

🤖 Generated with [Claude Code](https://claude.com/claude-code)