### PR TITLE
perf(etl): stop maintaining blocks is_current

### DIFF
--- a/pkg/etl/db/models.go
+++ b/pkg/etl/db/models.go
@@ -33,7 +33,6 @@ type AssociatedWallet struct {
 type Block struct {
 	Blockhash  string      `json:"blockhash"`
 	Parenthash pgtype.Text `json:"parenthash"`
-	IsCurrent  pgtype.Bool `json:"is_current"`
 	Number     pgtype.Int4 `json:"number"`
 }
 

--- a/pkg/etl/db/sql/migrations/0002_entity_manager_tables.up.sql
+++ b/pkg/etl/db/sql/migrations/0002_entity_manager_tables.up.sql
@@ -22,13 +22,10 @@ END $$;
 CREATE TABLE IF NOT EXISTS blocks (
   blockhash character varying NOT NULL,
   parenthash character varying,
-  is_current boolean,
   number integer,
   CONSTRAINT blocks_pkey PRIMARY KEY (blockhash),
   CONSTRAINT blocks_number_key UNIQUE (number)
 );
-
-CREATE UNIQUE INDEX IF NOT EXISTS blocks_is_current_idx ON blocks (is_current) WHERE is_current IS TRUE;
 
 -- users
 

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -364,8 +364,8 @@ type blockResult struct {
 
 // processBlock indexes one CometBFT block atomically.
 //
-// All writes for the block — etl_blocks, blocks (chain head row + tip
-// promotion), core_indexed_blocks, and every entity-table write performed
+// All writes for the block — etl_blocks, blocks (chain head row),
+// core_indexed_blocks, and every entity-table write performed
 // by the per-tx handlers — share a single pgx.Tx and commit together or
 // roll back together. On any block-level error (e.g. failure to insert
 // etl_blocks, failure to resolve blocks.number even after a retry),
@@ -869,16 +869,14 @@ func (e *Indexer) firePlaysHooks(ctx context.Context, sp pgx.Tx, plays []*corev1
 	}
 }
 
-// resolveBlockNumber returns the blocks.number for blockHash and ensures
-// the row for blockHash is the unique tip (is_current = true), all within
-// the caller-supplied transaction.
+// resolveBlockNumber returns the blocks.number for blockHash, inserting a
+// blocks row if needed, all within the caller-supplied transaction.
 //
 // Idempotent and tolerant of co-existing writers (e.g. the legacy Python
 // indexer during a cutover): if a row for blockHash already exists, its
-// number is adopted and is_current is re-asserted. If not, a new row is
-// inserted at MAX(number)+1 computed in-statement. The DB is the source
-// of truth; no in-memory counter to drift from concurrent writers or
-// stale snapshots.
+// number is adopted. If not, a new row is inserted at MAX(number)+1
+// computed in-statement. The DB is the source of truth; no in-memory
+// counter to drift from concurrent writers or stale snapshots.
 //
 // On a number-collision race with another writer (our INSERT no-op'd
 // because some other hash claimed MAX+1 first), the final SELECT returns
@@ -888,48 +886,28 @@ func (e *Indexer) firePlaysHooks(ctx context.Context, sp pgx.Tx, plays []*corev1
 // Operates on the caller's tx (or savepoint) so the block-row work
 // commits atomically with the rest of the block's entity writes.
 func (e *Indexer) resolveBlockNumber(ctx context.Context, tx pgx.Tx, blockHash string) (int64, error) {
-	// Snapshot the prior tip's hash for our parenthash. nil when the table
-	// is empty or has no current row (e.g. mid-recovery after an interrupted
-	// writer left no is_current=true).
-	var parentHash *string
-	err := tx.QueryRow(ctx,
-		"SELECT blockhash FROM blocks WHERE is_current IS TRUE").Scan(&parentHash)
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return 0, fmt.Errorf("read prev tip: %w", err)
-	}
-
-	// Demote the prior tip — but not ourselves, so idempotent re-processing
-	// of the same block doesn't briefly flip its row to is_current=false.
-	if _, err := tx.Exec(ctx,
-		"UPDATE blocks SET is_current = false WHERE is_current IS TRUE AND blockhash != $1",
-		blockHash); err != nil {
-		return 0, fmt.Errorf("demote prev tip: %w", err)
-	}
-
-	// Insert with MAX(number)+1 computed atomically. If a row for blockHash
-	// already exists (we're re-processing, or another writer beat us), or
-	// if another writer claimed MAX+1 with a different hash, ON CONFLICT
-	// silently no-ops. The subsequent UPDATE + SELECT then decide what
+	// Insert after the highest-numbered block. If a row for blockHash
+	// already exists (we're re-processing, or another writer beat us), or if
+	// another writer claimed the next number with a different hash,
+	// ON CONFLICT silently no-ops. The subsequent SELECT then decides what
 	// happened.
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO blocks (blockhash, parenthash, number, is_current)
-		SELECT $1, $2, COALESCE((SELECT MAX(number) FROM blocks), 0) + 1, true
+		INSERT INTO blocks (blockhash, parenthash, number)
+		SELECT $1, prev.blockhash, COALESCE(prev.number, 0) + 1
+		FROM (SELECT 1) seed
+		LEFT JOIN LATERAL (
+			SELECT blockhash, number
+			FROM blocks
+			ORDER BY number DESC
+			LIMIT 1
+		) prev ON true
 		ON CONFLICT DO NOTHING`,
-		blockHash, parentHash); err != nil {
+		blockHash); err != nil {
 		return 0, fmt.Errorf("insert block: %w", err)
 	}
 
-	// Re-assert is_current on the row for blockHash. If we just inserted
-	// it, the INSERT already set is_current=true and this is a no-op. If
-	// the row pre-existed with is_current=false, this promotes it to tip.
-	if _, err := tx.Exec(ctx,
-		"UPDATE blocks SET is_current = true WHERE blockhash = $1 AND is_current IS FALSE",
-		blockHash); err != nil {
-		return 0, fmt.Errorf("re-assert is_current: %w", err)
-	}
-
 	var num int64
-	err = tx.QueryRow(ctx,
+	err := tx.QueryRow(ctx,
 		"SELECT number FROM blocks WHERE blockhash = $1", blockHash).Scan(&num)
 	if err != nil {
 		// No row for our hash: we lost a (number) race with a different

--- a/pkg/etl/processors/entity_manager/testutil_test.go
+++ b/pkg/etl/processors/entity_manager/testutil_test.go
@@ -23,8 +23,8 @@ import (
 func seedBlock(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	if _, err := pool.Exec(context.Background(), `
-		INSERT INTO blocks (blockhash, parenthash, is_current, number)
-		VALUES ($1, $2, true, 100)
+		INSERT INTO blocks (blockhash, parenthash, number)
+		VALUES ($1, $2, 100)
 		ON CONFLICT (blockhash) DO NOTHING
 	`, "test-block-100", ""); err != nil {
 		t.Fatalf("seedBlock: %v", err)

--- a/pkg/etl/resolve_block_number_test.go
+++ b/pkg/etl/resolve_block_number_test.go
@@ -2,8 +2,8 @@ package etl
 
 import (
 	"context"
+	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
@@ -61,31 +61,6 @@ func callResolveBlockNumber(t *testing.T, pool *pgxpool.Pool, ix *Indexer, block
 	return num, nil
 }
 
-// countCurrentTips counts how many blocks have is_current = true. The
-// partial unique index guarantees this is at most 1 in steady state;
-// we use it to assert the tip invariant after every resolveBlockNumber call.
-func countCurrentTips(t *testing.T, pool *pgxpool.Pool) int {
-	t.Helper()
-	var n int
-	if err := pool.QueryRow(context.Background(),
-		`SELECT COUNT(*) FROM blocks WHERE is_current IS TRUE`).Scan(&n); err != nil {
-		t.Fatalf("count tips: %v", err)
-	}
-	return n
-}
-
-// currentTipHash returns the blockhash of the unique is_current=true row.
-// Fails the test if zero or more than one row matches.
-func currentTipHash(t *testing.T, pool *pgxpool.Pool) string {
-	t.Helper()
-	var h string
-	if err := pool.QueryRow(context.Background(),
-		`SELECT blockhash FROM blocks WHERE is_current IS TRUE`).Scan(&h); err != nil {
-		t.Fatalf("read current tip hash: %v", err)
-	}
-	return h
-}
-
 // blockNumber returns the number stored for a given blockhash, failing the
 // test if no row exists.
 func blockNumber(t *testing.T, pool *pgxpool.Pool, hash string) int64 {
@@ -111,7 +86,7 @@ func blockRowCount(t *testing.T, pool *pgxpool.Pool) int {
 }
 
 // TestResolveBlockNumber_EmptyTable: on a fresh table, the first call
-// inserts the block at number=1 and marks it the unique tip.
+// inserts the block at number=1.
 func TestResolveBlockNumber_EmptyTable(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ix := newTestIndexer(pool)
@@ -123,17 +98,13 @@ func TestResolveBlockNumber_EmptyTable(t *testing.T) {
 	if got != 1 {
 		t.Errorf("returned number = %d, want 1", got)
 	}
-	if tips := countCurrentTips(t, pool); tips != 1 {
-		t.Errorf("is_current=true count = %d, want 1 (tip invariant)", tips)
-	}
-	if tip := currentTipHash(t, pool); tip != "blk-genesis" {
-		t.Errorf("tip hash = %s, want blk-genesis", tip)
+	if rows := blockRowCount(t, pool); rows != 1 {
+		t.Errorf("row count = %d, want 1", rows)
 	}
 }
 
 // TestResolveBlockNumber_AppendsToChain: with an existing chain, the
-// next call increments the number, demotes the prior tip, and promotes
-// the new block. Tip invariant holds throughout.
+// next call increments the number without inserting duplicates.
 func TestResolveBlockNumber_AppendsToChain(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ix := newTestIndexer(pool)
@@ -147,30 +118,25 @@ func TestResolveBlockNumber_AppendsToChain(t *testing.T) {
 		if want := int64(i + 1); n != want {
 			t.Errorf("step %d returned %d, want %d", i, n, want)
 		}
-		if tips := countCurrentTips(t, pool); tips != 1 {
-			t.Errorf("step %d tip count = %d, want 1", i, tips)
-		}
-		if tip := currentTipHash(t, pool); tip != hash {
-			t.Errorf("step %d tip = %s, want %s", i, tip, hash)
-		}
+	}
+	if rows := blockRowCount(t, pool); rows != 3 {
+		t.Errorf("row count = %d, want 3", rows)
 	}
 }
 
 // TestResolveBlockNumber_AdoptsExistingByHash: when a row already
 // exists for this hash (e.g. another writer wrote it during a cutover),
-// the function adopts its number without inserting a new row and
-// promotes it to the tip.
+// the function adopts its number without inserting a new row.
 func TestResolveBlockNumber_AdoptsExistingByHash(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ctx := context.Background()
 
-	// Simulate a co-existing writer's row at number=42, is_current=false.
-	// Plus a separate "stale tip" at number=43 with is_current=true,
-	// which our call should demote.
+	// Simulate a co-existing writer's row at number=42, plus a newer row
+	// at number=43.
 	if _, err := pool.Exec(ctx, `
-		INSERT INTO blocks (blockhash, parenthash, number, is_current) VALUES
-		  ('blk-prewritten', NULL, 42, false),
-		  ('blk-stale-tip', NULL, 43, true)
+		INSERT INTO blocks (blockhash, parenthash, number) VALUES
+		  ('blk-prewritten', NULL, 42),
+		  ('blk-newer', NULL, 43)
 	`); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -186,38 +152,28 @@ func TestResolveBlockNumber_AdoptsExistingByHash(t *testing.T) {
 	if rows := blockRowCount(t, pool); rows != 2 {
 		t.Errorf("row count = %d, want 2 (no new row inserted)", rows)
 	}
-	if tips := countCurrentTips(t, pool); tips != 1 {
-		t.Errorf("tip count = %d, want 1", tips)
-	}
-	if tip := currentTipHash(t, pool); tip != "blk-prewritten" {
-		t.Errorf("tip = %s, want blk-prewritten (promoted from is_current=false)", tip)
-	}
 }
 
-// TestResolveBlockNumber_TipInvariantAfterFossils: a co-running writer
-// left "fossil" rows ahead of where we last knew MAX(number) to be —
-// possibly with one of them still flagged is_current=true — then died.
-// We must skip past all fossils, insert at the true MAX+1, and end up
-// as the unique tip. This is the production failure mode that dropped
-// ray52726.
-func TestResolveBlockNumber_TipInvariantAfterFossils(t *testing.T) {
+// TestResolveBlockNumber_AppendsAfterFossils: a co-running writer left
+// "fossil" rows ahead of where we last knew MAX(number) to be, then died.
+// We must skip past all fossils and insert at the true MAX+1.
+func TestResolveBlockNumber_AppendsAfterFossils(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ctx := context.Background()
 
-	// Fossils 100..109, with the last one still flagged as the tip — as
-	// if the prior writer was killed mid-stream after marking 109 current.
+	// Fossils 100..109, as if the prior writer was killed mid-stream.
 	for i := 100; i <= 108; i++ {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO blocks (blockhash, parenthash, number, is_current)
-			 VALUES ($1, NULL, $2, false)`,
-			"fossil-"+strconv.Itoa(i), i); err != nil {
+			`INSERT INTO blocks (blockhash, parenthash, number)
+			 VALUES ($1, NULL, $2)`,
+			fmt.Sprintf("fossil-%d", i), i); err != nil {
 			t.Fatalf("seed fossil %d: %v", i, err)
 		}
 	}
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO blocks (blockhash, parenthash, number, is_current)
-		 VALUES ('fossil-109-tip', NULL, 109, true)`); err != nil {
-		t.Fatalf("seed tip fossil: %v", err)
+		`INSERT INTO blocks (blockhash, parenthash, number)
+		 VALUES ('fossil-109', NULL, 109)`); err != nil {
+		t.Fatalf("seed fossil 109: %v", err)
 	}
 
 	ix := newTestIndexer(pool)
@@ -228,17 +184,13 @@ func TestResolveBlockNumber_TipInvariantAfterFossils(t *testing.T) {
 	if got != 110 {
 		t.Errorf("returned %d, want 110 (MAX(109)+1)", got)
 	}
-	if tips := countCurrentTips(t, pool); tips != 1 {
-		t.Errorf("tip count = %d, want 1", tips)
-	}
-	if tip := currentTipHash(t, pool); tip != "blk-new" {
-		t.Errorf("tip = %s, want blk-new", tip)
+	if rows := blockRowCount(t, pool); rows != 11 {
+		t.Errorf("row count = %d, want 11", rows)
 	}
 }
 
 // TestResolveBlockNumber_IdempotentSameHash: calling twice for the
-// same hash returns the same number both times, doesn't double-insert,
-// and the tip invariant holds.
+// same hash returns the same number both times and doesn't double-insert.
 func TestResolveBlockNumber_IdempotentSameHash(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ix := newTestIndexer(pool)
@@ -257,15 +209,12 @@ func TestResolveBlockNumber_IdempotentSameHash(t *testing.T) {
 	if rows := blockRowCount(t, pool); rows != 1 {
 		t.Errorf("row count = %d, want 1", rows)
 	}
-	if tips := countCurrentTips(t, pool); tips != 1 {
-		t.Errorf("tip count = %d, want 1", tips)
-	}
 }
 
-// TestResolveBlockNumber_ParentHashIsPriorTip: the parenthash field on
-// the newly-inserted block is set to the previous tip's blockhash.
-// (Cheap correctness check that we capture parenthash before demoting.)
-func TestResolveBlockNumber_ParentHashIsPriorTip(t *testing.T) {
+// TestResolveBlockNumber_ParentHashIsHighestNumberedBlock: the parenthash
+// field on the newly-inserted block is set to the previous highest-numbered
+// block's hash.
+func TestResolveBlockNumber_ParentHashIsHighestNumberedBlock(t *testing.T) {
 	pool := setupBlocksTestDB(t)
 	ctx := context.Background()
 	ix := newTestIndexer(pool)
@@ -306,4 +255,3 @@ func TestResolveBlockNumber_NumberValueIsStoredCorrectly(t *testing.T) {
 		t.Errorf("returned %d, stored %d", got, stored)
 	}
 }
-

--- a/pkg/etl/scheduled_release_publisher_test.go
+++ b/pkg/etl/scheduled_release_publisher_test.go
@@ -32,7 +32,7 @@ func TestScheduledReleasePublisher_PublishesPastDueTrack(t *testing.T) {
 	pool := setupPublisherDB(t)
 	ctx := context.Background()
 	if _, err := pool.Exec(ctx, `
-		INSERT INTO blocks (blockhash, parenthash, is_current, number) VALUES ('blk-pub', '', true, 100)
+		INSERT INTO blocks (blockhash, parenthash, number) VALUES ('blk-pub', '', 100)
 		ON CONFLICT (blockhash) DO NOTHING
 	`); err != nil {
 		t.Fatalf("seed block: %v", err)
@@ -83,7 +83,7 @@ func TestScheduledReleasePublisher_PublishesPastDueAlbum(t *testing.T) {
 	pool := setupPublisherDB(t)
 	ctx := context.Background()
 	if _, err := pool.Exec(ctx, `
-		INSERT INTO blocks (blockhash, parenthash, is_current, number) VALUES ('blk-alb', '', true, 100)
+		INSERT INTO blocks (blockhash, parenthash, number) VALUES ('blk-alb', '', 100)
 		ON CONFLICT (blockhash) DO NOTHING
 	`); err != nil {
 		t.Fatalf("seed block: %v", err)


### PR DESCRIPTION
## Summary
- stop reading/updating `blocks.is_current` in ETL block-number resolution
- append block rows using the highest existing `blocks.number` and preserve parenthash from that row
- remove `blocks.is_current` and its partial index from fresh ETL schemas
- update ETL fixtures/tests for the schema shape without `blocks.is_current`

## Why
The API DB shows `UPDATE blocks SET is_current = false ...` with very high latency variance. Removing this write path lets API deployments later drop the bloated `blocks.is_current` indexes and avoids per-block boolean tip churn.

## Rollout
Deploy this library change before dropping `blocks.is_current` from the API database schema.

## Tests
- `cd pkg/etl && go test ./...`
