### PR TITLE
fix(etl): default release_date to created_at when unset

### DIFF
--- a/pkg/etl/processors/entity_manager/playlist_create.go
+++ b/pkg/etl/processors/entity_manager/playlist_create.go
@@ -2,8 +2,6 @@ package entity_manager
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type playlistCreateHandler struct{}
@@ -71,10 +69,7 @@ func insertPlaylistAndRoute(ctx context.Context, params *Params) error {
 	copyrightLine := metadataJSONRaw(params, "copyright_line")
 	producerCopyrightLine := metadataJSONRaw(params, "producer_copyright_line")
 
-	var releaseDate pgtype.Timestamp
-	if rd, ok := parseReleaseDate(params.MetadataString("release_date")); ok {
-		releaseDate = rd
-	}
+	releaseDate := releaseDateOrDefault(params.MetadataString("release_date"), params.BlockTime)
 
 	row := &playlistRow{
 		PlaylistID:                  params.EntityID,

--- a/pkg/etl/processors/entity_manager/release_date.go
+++ b/pkg/etl/processors/entity_manager/release_date.go
@@ -1,36 +1,52 @@
 package entity_manager
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// releaseDateLayouts are the date formats clients have historically sent in
-// entity-manager metadata. They are tried in order. The earlier strict
-// RFC3339-only parsing dropped any value that did not carry a timezone (or was
-// date-only), which left release_date NULL and surfaced as "Invalid Date" in
-// clients. Keep the timezone-bearing layouts first so an explicit offset wins.
+// releaseDateLayouts mirror the formats the legacy Python indexer's
+// parse_release_date accepted, in the same order:
+//   - JavaScript Date.toString(), e.g. "Thu May 01 2026 00:00:00 GMT-0700"
+//   - ISO 8601 with a timezone (with or without fractional seconds)
+//
+// A bare Unix-seconds integer is handled separately below. Anything else
+// (date-only, timezone-less, etc.) is treated as "no usable date", matching
+// Python returning None — the caller then falls back to the block time.
 var releaseDateLayouts = []string{
-	time.RFC3339Nano,        // 2026-05-01T00:00:00.000Z / with offset
-	time.RFC3339,            // 2026-05-01T00:00:00Z / with offset
-	"2006-01-02T15:04:05",   // ISO-ish, no timezone
-	"2006-01-02 15:04:05Z07:00",
-	"2006-01-02 15:04:05",   // space separated, no timezone
-	"2006-01-02",            // date only
+	"Mon Jan 02 2006 15:04:05 GMT-0700",
+	time.RFC3339Nano,
+	time.RFC3339,
 }
 
-// parseReleaseDate parses a release_date metadata string using the set of
-// formats clients are known to emit. The bool reports whether parsing
-// succeeded; on failure the caller should leave the column NULL.
+// parseReleaseDate parses a release_date metadata string. The bool reports
+// whether a usable date was found; the time is normalized to UTC to match the
+// legacy indexer, which stored release_date as a UTC timestamp.
 func parseReleaseDate(s string) (pgtype.Timestamp, bool) {
 	if s == "" {
 		return pgtype.Timestamp{}, false
 	}
 	for _, layout := range releaseDateLayouts {
 		if t, err := time.Parse(layout, s); err == nil {
-			return pgtype.Timestamp{Time: t, Valid: true}, true
+			return pgtype.Timestamp{Time: t.UTC(), Valid: true}, true
 		}
 	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return pgtype.Timestamp{Time: time.Unix(n, 0).UTC(), Valid: true}, true
+	}
 	return pgtype.Timestamp{}, false
+}
+
+// releaseDateOrDefault resolves the release_date for a newly created track or
+// playlist. The legacy Python indexer seeds release_date to the block time and
+// only overrides it when metadata carries a parseable value, so a missing or
+// unparseable release_date defaults to the creation time rather than NULL
+// (a NULL release_date surfaces as "Invalid Date" in clients).
+func releaseDateOrDefault(raw string, blockTime time.Time) pgtype.Timestamp {
+	if rd, ok := parseReleaseDate(raw); ok {
+		return rd
+	}
+	return pgtype.Timestamp{Time: blockTime, Valid: true}
 }

--- a/pkg/etl/processors/entity_manager/release_date_test.go
+++ b/pkg/etl/processors/entity_manager/release_date_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseReleaseDate(t *testing.T) {
-	want := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	want := time.Date(2026, 5, 1, 7, 0, 0, 0, time.UTC)
 
 	tests := []struct {
 		name      string
@@ -16,11 +16,14 @@ func TestParseReleaseDate(t *testing.T) {
 		wantOK    bool
 		wantValue time.Time
 	}{
-		{name: "rfc3339 utc", in: "2026-05-01T00:00:00Z", wantOK: true, wantValue: want},
-		{name: "rfc3339 nano", in: "2026-05-01T00:00:00.000Z", wantOK: true, wantValue: want},
-		{name: "timezoneless T separator", in: "2026-05-01T00:00:00", wantOK: true, wantValue: want},
-		{name: "space separated", in: "2026-05-01 00:00:00", wantOK: true, wantValue: want},
-		{name: "date only", in: "2026-05-01", wantOK: true, wantValue: want},
+		{name: "js date toString", in: "Fri May 01 2026 00:00:00 GMT-0700", wantOK: true, wantValue: want},
+		{name: "iso millis utc", in: "2026-05-01T07:00:00.000Z", wantOK: true, wantValue: want},
+		{name: "iso no millis utc", in: "2026-05-01T07:00:00Z", wantOK: true, wantValue: want},
+		{name: "iso with offset", in: "2026-05-01T00:00:00-07:00", wantOK: true, wantValue: want},
+		{name: "unix seconds", in: "1777618800", wantOK: true, wantValue: want},
+		// Formats the legacy indexer rejected (-> falls back to block time).
+		{name: "date only", in: "2026-05-01", wantOK: false},
+		{name: "timezoneless", in: "2026-05-01T00:00:00", wantOK: false},
 		{name: "empty", in: "", wantOK: false},
 		{name: "garbage", in: "not a date", wantOK: false},
 	}
@@ -47,28 +50,51 @@ func TestParseReleaseDate(t *testing.T) {
 	}
 }
 
-// Regression test: a timezone-less release_date (the format that surfaced as
-// "Invalid Date" in clients) must now be indexed instead of dropped to NULL.
-func TestTrackCreate_TimezonelessReleaseDate(t *testing.T) {
+func TestReleaseDateOrDefault(t *testing.T) {
+	blockTime := time.Date(2026, 6, 2, 3, 53, 4, 0, time.UTC)
+
+	// Parseable metadata wins.
+	got := releaseDateOrDefault("2026-05-01T07:00:00.000Z", blockTime)
+	if !got.Valid || !got.Time.UTC().Equal(time.Date(2026, 5, 1, 7, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected parsed metadata date, got %+v", got)
+	}
+
+	// Missing or unparseable metadata falls back to the block time (created_at),
+	// never NULL.
+	for _, raw := range []string{"", "2026-05-01", "garbage"} {
+		got := releaseDateOrDefault(raw, blockTime)
+		if !got.Valid {
+			t.Fatalf("expected default release_date for %q, got NULL", raw)
+		}
+		if !got.Time.UTC().Equal(blockTime) {
+			t.Errorf("releaseDateOrDefault(%q) = %v, want block time %v", raw, got.Time.UTC(), blockTime)
+		}
+	}
+}
+
+// Regression test: a track created with no release_date in its metadata must
+// default to its created_at (block time) instead of being left NULL, which is
+// what surfaced as "Invalid Date" in clients.
+func TestTrackCreate_DefaultsReleaseDateToCreatedAt(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)
-	tid := int64(TrackIDOffset + 750)
-	seedUser(t, pool, uid, "0xtzowner", "tzowner")
+	tid := int64(TrackIDOffset + 760)
+	seedUser(t, pool, uid, "0xnoreldate", "noreldate")
 
-	meta := `{"owner_id":3000001,"title":"Backdated Live Set","release_date":"2026-05-01T00:00:00"}`
-	params := buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xTzOwner", meta)
+	meta := `{"owner_id":3000001,"title":"No Release Date Provided"}`
+	params := buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xNoRelDate", meta)
 	mustHandle(t, TrackCreate(), params)
 
-	var releaseDate sql.NullTime
+	var releaseDate, createdAt sql.NullTime
 	err := pool.QueryRow(context.Background(),
-		"SELECT release_date FROM tracks WHERE track_id = $1 AND is_current = true", tid).Scan(&releaseDate)
+		"SELECT release_date, created_at FROM tracks WHERE track_id = $1 AND is_current = true", tid).Scan(&releaseDate, &createdAt)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
 	if !releaseDate.Valid {
-		t.Fatal("expected release_date to be set for timezone-less input")
+		t.Fatal("expected release_date to default to created_at, got NULL")
 	}
-	if got := releaseDate.Time.UTC(); !got.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
-		t.Errorf("release_date = %v, want 2026-05-01T00:00:00Z", got)
+	if !releaseDate.Time.Equal(createdAt.Time) {
+		t.Errorf("release_date = %v, want created_at %v", releaseDate.Time, createdAt.Time)
 	}
 }

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -3,8 +3,6 @@ package entity_manager
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type trackCreateHandler struct{}
@@ -113,10 +111,7 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 		aiAttr = &v
 	}
 
-	var releaseDate pgtype.Timestamp
-	if rd, ok := parseReleaseDate(params.MetadataString("release_date")); ok {
-		releaseDate = rd
-	}
+	releaseDate := releaseDateOrDefault(params.MetadataString("release_date"), params.BlockTime)
 
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO tracks (


### PR DESCRIPTION
## Summary

Follow-up to #332, which was merged before this commit landed. #332 only shipped the parser-leniency change; this PR adds the actual fix for the "Invalid Date" reports.

The reported tracks have **no** `release_date` in their chain metadata at all — the parser was a red herring. The legacy Python indexer seeds `release_date` to the block time on create and only overrides it when metadata carries a parseable value, so `release_date` was never NULL. The Go ETL left it NULL, which the API omits and clients render as `new Date(undefined)` → "Invalid Date".

- Default track/playlist `release_date` to `block_time` (== `created_at`) on create, overriding only when metadata provides a parseable value.
- Align `parseReleaseDate` with the legacy indexer's accepted formats: JS `Date.toString()` (GMT+offset), ISO-8601 with timezone, and Unix seconds. Date-only / timezone-less strings fall back to `created_at`, matching Python returning `None`.

This prevents recurrence for all newly-indexed content. The historical NULL rows are repaired separately via the backfill SQL.

## Test plan

- [x] `go build ./...` in `pkg/etl`
- [x] `go test ./processors/entity_manager/` passes
- [x] `TestParseReleaseDate` covers JS-toString / ISO / unix / date-only / timezone-less / empty / garbage
- [x] `TestReleaseDateOrDefault` covers parseable-wins and fallback-to-block-time
- [x] `TestTrackCreate_DefaultsReleaseDateToCreatedAt` verifies a create with no release_date stores created_at

🤖 Generated with [Claude Code](https://claude.com/claude-code)