### PR TITLE
fix(etl): persist track bpm/musical_key/audio_upload_id

### DIFF
--- a/pkg/etl/processors/entity_manager/handler.go
+++ b/pkg/etl/processors/entity_manager/handler.go
@@ -206,6 +206,27 @@ func (p *Params) MetadataInt64(key string) (int64, bool) {
 	return 0, false
 }
 
+// MetadataFloat64 returns a float64 from parsed metadata (supports number and
+// integer JSON values). Returns ok=false when the key is absent or not numeric.
+func (p *Params) MetadataFloat64(key string) (float64, bool) {
+	if p.Metadata == nil {
+		return 0, false
+	}
+	v, ok := p.Metadata[key]
+	if !ok {
+		return 0, false
+	}
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	}
+	return 0, false
+}
+
 // MetadataBool returns a bool from parsed metadata.
 func (p *Params) MetadataBool(key string) (bool, bool) {
 	if p.Metadata == nil {

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -91,6 +91,23 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 	isPlaylistUpload := params.MetadataBoolOr("is_playlist_upload", false)
 	ddexApp := params.MetadataString("ddex_app")
 	isAvailable := params.MetadataBoolOr("is_available", true)
+	isCustomBpm := params.MetadataBoolOr("is_custom_bpm", false)
+	isCustomMusicalKey := params.MetadataBoolOr("is_custom_musical_key", false)
+	audioUploadID := params.MetadataString("audio_upload_id")
+
+	// musical_key: only persist recognized keys (mirrors apps' is_valid_musical_key).
+	// An invalid/empty key leaves the column NULL on create.
+	musicalKey := params.MetadataString("musical_key")
+	if !isValidMusicalKey(musicalKey) {
+		musicalKey = ""
+	}
+
+	// bpm: any nonzero number persists; 0/absent/non-numeric leaves it NULL
+	// (mirrors apps' track.py `bpm_float != 0` check).
+	var bpm *float64
+	if v, ok := params.MetadataFloat64("bpm"); ok && v != 0 {
+		bpm = &v
+	}
 
 	fieldVisibility := metadataJSONRaw(params, "field_visibility")
 	remixOf := metadataJSONRaw(params, "remix_of")
@@ -125,6 +142,7 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 			track_cid, preview_cid, orig_file_cid, duration,
 			is_downloadable, is_download_gated, download_conditions, is_stream_gated, stream_conditions,
 			release_date, is_scheduled_release, ai_attribution_user_id, is_playlist_upload, ddex_app, ddex_release_ids,
+			bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id,
 			is_available, route_id, track_segments, created_at, updated_at, txhash, blocknumber
 		) VALUES (
 			$1, $2, true, false, $3, $4, $5, $6, $7,
@@ -132,7 +150,8 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22,
 			$23, $24, $25, $26, $27, $28,
-			$29, $30, '[]'::jsonb, $31, $31, $32, $33
+			$29, $30, $31, $32, $33,
+			$34, $35, '[]'::jsonb, $36, $36, $37, $38
 		)
 	`,
 		params.EntityID,
@@ -163,6 +182,11 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 		isPlaylistUpload,
 		nullString(ddexApp),
 		ddexReleaseIDs,
+		bpm,
+		nullString(musicalKey),
+		isCustomBpm,
+		isCustomMusicalKey,
+		nullString(audioUploadID),
 		isAvailable,
 		routeID,
 		params.BlockTime,

--- a/pkg/etl/processors/entity_manager/track_create_test.go
+++ b/pkg/etl/processors/entity_manager/track_create_test.go
@@ -2,6 +2,7 @@ package entity_manager
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -157,6 +158,66 @@ func TestTrackCreate_Success(t *testing.T) {
 	}
 	if slug == "" {
 		t.Error("expected non-empty slug")
+	}
+}
+
+func TestTrackCreate_PersistsBpmAndKey(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 43)
+	seedUser(t, pool, uid, "0xbpmowner", "bpmowner")
+	meta := `{"owner_id":3000001,"title":"Keyed","genre":"Electronic","bpm":128.5,"musical_key":"D flat minor","is_custom_bpm":true,"is_custom_musical_key":true,"audio_upload_id":"upload-abc"}`
+	params := buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xBpmOwner", meta)
+	mustHandle(t, TrackCreate(), params)
+
+	var bpm float64
+	var key, uploadID string
+	var customBpm, customKey bool
+	err := pool.QueryRow(context.Background(),
+		"SELECT bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id FROM tracks WHERE track_id = $1 AND is_current = true", tid).
+		Scan(&bpm, &key, &customBpm, &customKey, &uploadID)
+	if err != nil {
+		t.Fatalf("query track: %v", err)
+	}
+	if bpm != 128.5 {
+		t.Errorf("bpm = %v, want 128.5", bpm)
+	}
+	if key != "D flat minor" {
+		t.Errorf("musical_key = %q, want %q", key, "D flat minor")
+	}
+	if !customBpm || !customKey {
+		t.Errorf("is_custom_bpm = %v, is_custom_musical_key = %v, want both true", customBpm, customKey)
+	}
+	if uploadID != "upload-abc" {
+		t.Errorf("audio_upload_id = %q, want %q", uploadID, "upload-abc")
+	}
+}
+
+// TestTrackCreate_RejectsInvalidMusicalKey mirrors apps' is_valid_musical_key:
+// an unrecognized key (here a sharp, which the enum does not use) is dropped,
+// leaving musical_key NULL rather than persisting the bad value.
+func TestTrackCreate_RejectsInvalidMusicalKey(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 44)
+	seedUser(t, pool, uid, "0xbadkey", "badkey")
+	meta := `{"owner_id":3000001,"title":"BadKey","genre":"Electronic","bpm":0,"musical_key":"C# minor"}`
+	params := buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xBadKey", meta)
+	mustHandle(t, TrackCreate(), params)
+
+	var bpm sql.NullFloat64
+	var key sql.NullString
+	err := pool.QueryRow(context.Background(),
+		"SELECT bpm, musical_key FROM tracks WHERE track_id = $1 AND is_current = true", tid).
+		Scan(&bpm, &key)
+	if err != nil {
+		t.Fatalf("query track: %v", err)
+	}
+	if key.Valid {
+		t.Errorf("musical_key = %q, want NULL for invalid key", key.String)
+	}
+	if bpm.Valid {
+		t.Errorf("bpm = %v, want NULL for zero bpm", bpm.Float64)
 	}
 }
 

--- a/pkg/etl/processors/entity_manager/track_row.go
+++ b/pkg/etl/processors/entity_manager/track_row.go
@@ -42,6 +42,11 @@ type trackRow struct {
 	IsPlaylistUpload     bool
 	DdexApp              *string
 	DdexReleaseIDs       []byte
+	Bpm                  *float64
+	MusicalKey           *string
+	IsCustomBpm          bool
+	IsCustomMusicalKey   bool
+	AudioUploadID        *string
 	IsAvailable          bool
 	TrackSegments        []byte
 	CreatedAt            time.Time
@@ -49,9 +54,10 @@ type trackRow struct {
 
 func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*trackRow, error) {
 	var r trackRow
-	var title, genre, mood, tags, desc, cover, coverSz, tcid, pcid, ofcid, ddex sql.NullString
+	var title, genre, mood, tags, desc, cover, coverSz, tcid, pcid, ofcid, ddex, musicalKey, audioUploadID sql.NullString
 	var fieldVis, remix, stem, dlCond, streamCond, ddexRel, segments []byte
 	var aiAttr sql.NullInt64
+	var bpm sql.NullFloat64
 	var releaseDate pgtype.Timestamp
 
 	err := dbtx.QueryRow(ctx, `
@@ -60,6 +66,7 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 			track_cid, preview_cid, orig_file_cid, duration,
 			is_downloadable, is_download_gated, download_conditions, is_stream_gated, stream_conditions,
 			release_date, is_scheduled_release, ai_attribution_user_id, is_playlist_upload, ddex_app, ddex_release_ids,
+			bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id,
 			is_available, track_segments, created_at
 		FROM tracks WHERE track_id = $1 AND is_current = true AND is_delete = false LIMIT 1
 	`, trackID).Scan(
@@ -68,6 +75,7 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 		&tcid, &pcid, &ofcid, &r.Duration,
 		&r.IsDownloadable, &r.IsDownloadGated, &dlCond, &r.IsStreamGated, &streamCond,
 		&releaseDate, &r.IsScheduledRelease, &aiAttr, &r.IsPlaylistUpload, &ddex, &ddexRel,
+		&bpm, &musicalKey, &r.IsCustomBpm, &r.IsCustomMusicalKey, &audioUploadID,
 		&r.IsAvailable, &segments, &r.CreatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -101,6 +109,9 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 	r.AiAttributionUserID = nullInt64Ptr(aiAttr)
 	r.DdexApp = nullStrPtr(ddex)
 	r.DdexReleaseIDs = ddexRel
+	r.Bpm = nullFloat64Ptr(bpm)
+	r.MusicalKey = nullStrPtr(musicalKey)
+	r.AudioUploadID = nullStrPtr(audioUploadID)
 	r.TrackSegments = segments
 	if len(r.TrackSegments) == 0 {
 		r.TrackSegments = []byte("[]")
@@ -121,6 +132,14 @@ func nullInt64Ptr(ni sql.NullInt64) *int64 {
 		return nil
 	}
 	v := ni.Int64
+	return &v
+}
+
+func nullFloat64Ptr(nf sql.NullFloat64) *float64 {
+	if !nf.Valid {
+		return nil
+	}
+	v := nf.Float64
 	return &v
 }
 
@@ -152,6 +171,38 @@ func mergeTrackFromMetadata(p *Params, base *trackRow) *trackRow {
 	mergeStrPtr("preview_cid", &out.PreviewCID)
 	mergeStrPtr("orig_file_cid", &out.OrigFileCID)
 	mergeStrPtr("ddex_app", &out.DdexApp)
+	// audio_upload_id is a generic passthrough field in apps' indexer (set via
+	// the catch-all setattr branch), needed by the audio-analysis repair job.
+	mergeStrPtr("audio_upload_id", &out.AudioUploadID)
+
+	// bpm semantics mirror apps' track.py: explicit null clears; a nonzero
+	// number sets; zero or a non-numeric value is ignored (existing kept).
+	if raw, ok := p.Metadata["bpm"]; ok {
+		if raw == nil {
+			out.Bpm = nil
+		} else if v, ok2 := p.MetadataFloat64("bpm"); ok2 && v != 0 {
+			cp := v
+			out.Bpm = &cp
+		}
+	}
+
+	// musical_key semantics mirror apps' track.py: explicit null clears; a
+	// recognized key sets; an invalid value is ignored (existing kept).
+	if raw, ok := p.Metadata["musical_key"]; ok {
+		if raw == nil {
+			out.MusicalKey = nil
+		} else if s, ok2 := raw.(string); ok2 && isValidMusicalKey(s) {
+			cp := s
+			out.MusicalKey = &cp
+		}
+	}
+
+	if v, ok := p.MetadataBool("is_custom_bpm"); ok {
+		out.IsCustomBpm = v
+	}
+	if v, ok := p.MetadataBool("is_custom_musical_key"); ok {
+		out.IsCustomMusicalKey = v
+	}
 
 	if v, ok := p.MetadataBool("is_unlisted"); ok {
 		out.IsUnlisted = v
@@ -223,6 +274,13 @@ func strPtrVal(p *string) any {
 	return *p
 }
 
+func floatPtrVal(p *float64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
 func updateTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime time.Time, txHash string, blockNumber int64) error {
 	_, err := dbtx.Exec(ctx, `
 		UPDATE tracks SET
@@ -232,8 +290,9 @@ func updateTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 			duration = $16, is_downloadable = $17, is_download_gated = $18, download_conditions = $19,
 			is_stream_gated = $20, stream_conditions = $21, release_date = $22, is_scheduled_release = $23,
 			ai_attribution_user_id = $24, is_playlist_upload = $25, ddex_app = $26, ddex_release_ids = $27,
-			is_available = $28,
-			updated_at = $29, txhash = $30, blocknumber = $31
+			bpm = $28, musical_key = $29, is_custom_bpm = $30, is_custom_musical_key = $31, audio_upload_id = $32,
+			is_available = $33,
+			updated_at = $34, txhash = $35, blocknumber = $36
 		WHERE track_id = $1 AND is_current = true
 	`,
 		r.TrackID,
@@ -263,6 +322,11 @@ func updateTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 		r.IsPlaylistUpload,
 		strPtrVal(r.DdexApp),
 		r.DdexReleaseIDs,
+		floatPtrVal(r.Bpm),
+		strPtrVal(r.MusicalKey),
+		r.IsCustomBpm,
+		r.IsCustomMusicalKey,
+		strPtrVal(r.AudioUploadID),
 		r.IsAvailable,
 		blockTime,
 		txHash,
@@ -279,6 +343,7 @@ func insertTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 			track_cid, preview_cid, orig_file_cid, duration,
 			is_downloadable, is_download_gated, download_conditions, is_stream_gated, stream_conditions,
 			release_date, is_scheduled_release, ai_attribution_user_id, is_playlist_upload, ddex_app, ddex_release_ids,
+			bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id,
 			is_available, track_segments, created_at, updated_at, txhash, blocknumber
 		) VALUES (
 			$1, $2, true, false, $3, $4, $5, $6, $7,
@@ -286,7 +351,8 @@ func insertTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22,
 			$23, $24, $25, $26, $27, $28,
-			$29, $30, $31, $32, $33, $34
+			$29, $30, $31, $32, $33,
+			$34, $35, $36, $37, $38, $39
 		)
 	`,
 		r.TrackID,
@@ -317,6 +383,11 @@ func insertTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 		r.IsPlaylistUpload,
 		strPtrVal(r.DdexApp),
 		r.DdexReleaseIDs,
+		floatPtrVal(r.Bpm),
+		strPtrVal(r.MusicalKey),
+		r.IsCustomBpm,
+		r.IsCustomMusicalKey,
+		strPtrVal(r.AudioUploadID),
 		r.IsAvailable,
 		r.TrackSegments,
 		r.CreatedAt,

--- a/pkg/etl/processors/entity_manager/track_update_test.go
+++ b/pkg/etl/processors/entity_manager/track_update_test.go
@@ -29,6 +29,73 @@ func TestTrackUpdate_Success(t *testing.T) {
 	}
 }
 
+func TestTrackUpdate_PersistsBpmAndKey(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 62)
+	seedUser(t, pool, uid, "0xowner", "ou")
+	seedTrackFull(t, pool, tid, uid, "Old Title")
+	meta := `{"title":"Old Title","bpm":90.0,"musical_key":"A major","is_custom_bpm":true,"is_custom_musical_key":false,"audio_upload_id":"up-xyz"}`
+	params := buildParams(t, pool, EntityTypeTrack, ActionUpdate, uid, tid, "0xOwner", meta)
+	mustHandle(t, TrackUpdate(), params)
+
+	var bpm float64
+	var key, uploadID string
+	var customBpm, customKey bool
+	err := pool.QueryRow(context.Background(),
+		"SELECT bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id FROM tracks WHERE track_id = $1 AND is_current = true", tid).
+		Scan(&bpm, &key, &customBpm, &customKey, &uploadID)
+	if err != nil {
+		t.Fatalf("query track: %v", err)
+	}
+	if bpm != 90.0 {
+		t.Errorf("bpm = %v, want 90.0", bpm)
+	}
+	if key != "A major" {
+		t.Errorf("musical_key = %q, want %q", key, "A major")
+	}
+	if !customBpm || customKey {
+		t.Errorf("is_custom_bpm = %v (want true), is_custom_musical_key = %v (want false)", customBpm, customKey)
+	}
+	if uploadID != "up-xyz" {
+		t.Errorf("audio_upload_id = %q, want %q", uploadID, "up-xyz")
+	}
+}
+
+// TestTrackUpdate_KeepsBpmKeyOnZeroOrInvalid verifies the apps-parity "keep"
+// behavior: an update carrying bpm=0 or an invalid musical_key must NOT
+// overwrite previously-set values (only an explicit null clears them).
+func TestTrackUpdate_KeepsBpmKeyOnZeroOrInvalid(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 63)
+	seedUser(t, pool, uid, "0xowner", "ou")
+	seedTrackFull(t, pool, tid, uid, "Old Title")
+
+	// First, set valid values.
+	set := `{"title":"Old Title","bpm":120.0,"musical_key":"C minor"}`
+	mustHandle(t, TrackUpdate(), buildParams(t, pool, EntityTypeTrack, ActionUpdate, uid, tid, "0xOwner", set))
+
+	// Then an update with bpm=0 and an invalid key must leave them unchanged.
+	noop := `{"title":"Old Title","bpm":0,"musical_key":"H sharp"}`
+	mustHandle(t, TrackUpdate(), buildParams(t, pool, EntityTypeTrack, ActionUpdate, uid, tid, "0xOwner", noop))
+
+	var bpm float64
+	var key string
+	err := pool.QueryRow(context.Background(),
+		"SELECT bpm, musical_key FROM tracks WHERE track_id = $1 AND is_current = true", tid).
+		Scan(&bpm, &key)
+	if err != nil {
+		t.Fatalf("query track: %v", err)
+	}
+	if bpm != 120.0 {
+		t.Errorf("bpm = %v, want 120.0 (unchanged)", bpm)
+	}
+	if key != "C minor" {
+		t.Errorf("musical_key = %q, want %q (unchanged)", key, "C minor")
+	}
+}
+
 func TestTrackUpdate_NotFound(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)

--- a/pkg/etl/processors/entity_manager/validate.go
+++ b/pkg/etl/processors/entity_manager/validate.go
@@ -136,6 +136,32 @@ func getUserWallet(ctx context.Context, dbtx db.DBTX, userID int64) (string, err
 	return wallet, nil
 }
 
+// validMusicalKeys mirrors the apps indexer's MusicalKey enum
+// (src/tasks/metadata.py). Note: flats only, no sharps — "C# minor" is NOT a
+// valid key; the equivalent is "D flat minor".
+var validMusicalKeys = map[string]bool{
+	"A major": true, "A minor": true,
+	"B flat major": true, "B flat minor": true,
+	"B major": true, "B minor": true,
+	"C major": true, "C minor": true,
+	"D flat major": true, "D flat minor": true,
+	"D major": true, "D minor": true,
+	"E flat major": true, "E flat minor": true,
+	"E major": true, "E minor": true,
+	"F major": true, "F minor": true,
+	"G flat major": true, "G flat minor": true,
+	"G major": true, "G minor": true,
+	"A flat major": true, "A flat minor": true,
+	"Silence": true,
+}
+
+// isValidMusicalKey reports whether s is one of the recognized musical keys.
+// Mirrors apps' is_valid_musical_key (src/tasks/metadata.py): an invalid key
+// is ignored by the indexer (existing value is preserved), not an error.
+func isValidMusicalKey(s string) bool {
+	return validMusicalKeys[s]
+}
+
 // ValidateGenre checks genre is in the allowlist.
 func ValidateGenre(genre string) error {
 	if genre == "" {


### PR DESCRIPTION
## Summary

The go-etl entity-manager track create/update handlers never persisted `bpm`, `musical_key`, `is_custom_bpm`, `is_custom_musical_key`, or `audio_upload_id`. Tracks indexed by go-etl therefore lost these fields entirely (root cause of "tracks uploaded today are missing key/bpm"). This restores parity with apps' discovery-provider `populate_track_record_metadata`.

Semantics matched 1:1 to `apps/.../tasks/entity_manager/entities/track.py`:

- **bpm**: present + `null` → clear; present + nonzero number → set; present + `0`/non-numeric, or absent → keep existing.
- **musical_key**: present + `null` → clear; present + valid `MusicalKey` enum value → set; present + invalid → keep existing. Validated against the flats-only enum (`"C# minor"` is invalid; `"D flat minor"` is valid).
- **is_custom_bpm / is_custom_musical_key / audio_upload_id**: set when present in metadata, otherwise unchanged.

`audio_upload_id` is also the key the companion `repair_audio_analyses` backfill job uses to fetch a track's analysis from the content node.

## Changes
- `handler.go`: add `MetadataFloat64` accessor (bpm arrives as a JSON number).
- `validate.go`: add `validMusicalKeys` map + `isValidMusicalKey` (mirrors `is_valid_musical_key`).
- `track_create.go`: persist the five fields on insert, with invalid-key → NULL and zero/absent bpm → NULL.
- `track_row.go`: load/merge/update/insert the five fields with the keep-on-zero/keep-on-invalid merge semantics.

## Test plan
- [x] `go build ./...` + `go vet` clean (pkg/etl module)
- [x] Full `entity_manager` suite green against ephemeral Postgres (sequential `-count=1 -p 1`, 181s)
- [x] New tests: `TestTrackCreate_PersistsBpmAndKey`, `TestTrackCreate_RejectsInvalidMusicalKey`, `TestTrackUpdate_PersistsBpmAndKey`, `TestTrackUpdate_KeepsBpmKeyOnZeroOrInvalid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)