### PR TITLE
fix(etl): upsert explicit subscription writes

### DIFF
--- a/pkg/etl/processors/entity_manager/social_subscription.go
+++ b/pkg/etl/processors/entity_manager/social_subscription.go
@@ -69,18 +69,23 @@ func validateUnsubscribe(ctx context.Context, params *Params) error {
 }
 
 func insertSubscription(ctx context.Context, params *Params, isDelete bool) error {
-	_, err := params.DBTX.Exec(ctx,
-		"UPDATE subscriptions SET is_current = false WHERE subscriber_id = $1 AND user_id = $2 AND is_current = true",
-		params.UserID, params.EntityID)
-	if err != nil {
-		return err
-	}
-
-	_, err = params.DBTX.Exec(ctx, `
+	// Upsert the single current row in place (arbiter: subscriptions_current_uniq_idx),
+	// matching the Follow auto-subscribe path in social_follow.go. The prior
+	// demote-then-insert was a two-statement write: between the demote and the
+	// insert another subscription writer could land a second current row, which
+	// is how duplicate is_current rows accumulated here but not in the
+	// single-writer reposts/saves/follows tables.
+	_, err := params.DBTX.Exec(ctx, `
 		INSERT INTO subscriptions (
 			subscriber_id, user_id, is_current, is_delete,
 			created_at, txhash, blocknumber
 		) VALUES ($1, $2, true, $3, $4, $5, $6)
+		ON CONFLICT (subscriber_id, user_id) WHERE is_current = true
+		DO UPDATE SET
+			is_delete = EXCLUDED.is_delete,
+			created_at = EXCLUDED.created_at,
+			txhash = EXCLUDED.txhash,
+			blocknumber = EXCLUDED.blocknumber
 	`, params.UserID, params.EntityID, isDelete, params.BlockTime, params.TxHash, params.BlockNumber)
 	return err
 }


### PR DESCRIPTION
## Root cause

`subscriptions` is the only one of the four social tables (`reposts`/`saves`/`follows`/`subscriptions`) with **two independent writers**:

1. **Explicit** Subscribe/Unsubscribe → `social_subscription.go` → **demote-then-insert** (`UPDATE … is_current=false` then a plain `INSERT`).
2. **Implicit** Follow/Unfollow auto-subscribe → `social_follow.go` → **`ON CONFLICT` upsert**.

The other three tables have a single writer each. Demote-then-insert is a two-statement write: between the `UPDATE` and the `INSERT`, the other subscription writer can land a second `is_current` row — and the table had no uniqueness constraint to stop it. Over time that accumulated duplicate `is_current` rows in `subscriptions` (92 of them in prod), which the partial unique index added in #331 (`subscriptions_current_uniq_idx`) was not equipped to coexist with.

#331 (`24084d2`) converted `follow`/`repost`/`save` to upserts and added the four arbiter indexes, but **never touched `social_subscription.go`** (last modified by an unrelated rename in #300). So subscriptions got an arbiter index while one of its two writers still used the demote-then-insert pattern that can violate it.

## Fix

Convert `insertSubscription` to the same single-statement `ON CONFLICT` upsert used by the Follow path. Both subscription writers now go through the arbiter atomically, so the unique index fully enforces one-current-row-per-identity and duplicates can't recur.

## Scope

Code-only. The pre-existing duplicate rows were already cleaned up out-of-band in the single deployment that had them, and golang-migrate tracks version number only (it won't re-run `0030`), so no migration-side dedupe/backfill is included here — `0030` is unchanged.

## Test plan

- [x] `go build ./...` and `go vet` in `pkg/etl`
- [x] `go test ./processors/entity_manager/` (DB-backed: runs migrations + exercises subscribe/follow/contest paths) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)