### PR TITLE
fix(etl): count runes not bytes in name/bio/handle/description limits

### DIFF
--- a/pkg/etl/processors/entity_manager/comment_create.go
+++ b/pkg/etl/processors/entity_manager/comment_create.go
@@ -2,6 +2,7 @@ package entity_manager
 
 import (
 	"context"
+	"unicode/utf8"
 )
 
 type commentCreateHandler struct{}
@@ -147,7 +148,7 @@ func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) er
 	if body == "" {
 		return NewValidationError("comment body is empty")
 	}
-	if len(body) > CharacterLimitCommentBody {
+	if utf8.RuneCountInString(body) > CharacterLimitCommentBody {
 		return NewValidationError("comment body exceeds %d character limit", CharacterLimitCommentBody)
 	}
 

--- a/pkg/etl/processors/entity_manager/developer_app_create.go
+++ b/pkg/etl/processors/entity_manager/developer_app_create.go
@@ -3,6 +3,7 @@ package entity_manager
 import (
 	"context"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -31,12 +32,12 @@ func validateDeveloperAppCreate(ctx context.Context, params *Params) error {
 	if name == "" {
 		return NewValidationError("name is required for developer app")
 	}
-	if len(name) > CharacterLimitAppName {
+	if utf8.RuneCountInString(name) > CharacterLimitAppName {
 		return NewValidationError("name exceeds %d character limit", CharacterLimitAppName)
 	}
 
 	if desc := params.MetadataString("description"); desc != "" {
-		if len(desc) > CharacterLimitAppDescription {
+		if utf8.RuneCountInString(desc) > CharacterLimitAppDescription {
 			return NewValidationError("description exceeds %d character limit", CharacterLimitAppDescription)
 		}
 	}

--- a/pkg/etl/processors/entity_manager/developer_app_update.go
+++ b/pkg/etl/processors/entity_manager/developer_app_update.go
@@ -3,6 +3,7 @@ package entity_manager
 import (
 	"context"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
 )
@@ -28,11 +29,11 @@ func validateDeveloperAppUpdate(ctx context.Context, params *Params) error {
 	if name == "" {
 		return NewValidationError("name is required for developer app")
 	}
-	if len(name) > CharacterLimitAppName {
+	if utf8.RuneCountInString(name) > CharacterLimitAppName {
 		return NewValidationError("name exceeds %d character limit", CharacterLimitAppName)
 	}
 	if desc := params.MetadataString("description"); desc != "" {
-		if len(desc) > CharacterLimitAppDescription {
+		if utf8.RuneCountInString(desc) > CharacterLimitAppDescription {
 			return NewValidationError("description exceeds %d character limit", CharacterLimitAppDescription)
 		}
 	}

--- a/pkg/etl/processors/entity_manager/validate.go
+++ b/pkg/etl/processors/entity_manager/validate.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
 	"github.com/jackc/pgx/v5"
@@ -38,7 +39,7 @@ func ValidateHandle(handle string) error {
 	if !handleRegexp.MatchString(handle) {
 		return NewValidationError("handle %q contains illegal characters", handle)
 	}
-	if len(handle) > CharacterLimitHandle {
+	if utf8.RuneCountInString(handle) > CharacterLimitHandle {
 		return NewValidationError("handle %q exceeds %d character limit", handle, CharacterLimitHandle)
 	}
 	if reservedHandles[handle] {
@@ -52,7 +53,7 @@ func ValidateUserName(name string) error {
 	if name == "" {
 		return nil
 	}
-	if len(name) > CharacterLimitUserName {
+	if utf8.RuneCountInString(name) > CharacterLimitUserName {
 		return NewValidationError("name exceeds %d character limit", CharacterLimitUserName)
 	}
 	return nil
@@ -63,7 +64,7 @@ func ValidateBio(bio string) error {
 	if bio == "" {
 		return nil
 	}
-	if len(bio) > CharacterLimitUserBio {
+	if utf8.RuneCountInString(bio) > CharacterLimitUserBio {
 		return NewValidationError("bio exceeds %d character limit", CharacterLimitUserBio)
 	}
 	return nil
@@ -74,7 +75,7 @@ func ValidateDescription(desc string) error {
 	if desc == "" {
 		return nil
 	}
-	if len(desc) > CharacterLimitDescription {
+	if utf8.RuneCountInString(desc) > CharacterLimitDescription {
 		return NewValidationError("description exceeds %d character limit", CharacterLimitDescription)
 	}
 	return nil

--- a/pkg/etl/processors/entity_manager/validate_test.go
+++ b/pkg/etl/processors/entity_manager/validate_test.go
@@ -1,0 +1,43 @@
+package entity_manager
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Regression: name/bio/description/handle limits are CHARACTER limits, not byte
+// limits. A value with multi-byte runes (e.g. emoji) that is within the rune
+// limit must pass even when its UTF-8 byte length exceeds the limit. Previously
+// these checks used len(), which counts bytes, so a valid profile was silently
+// rejected -- and because setting an artist pick re-submits the whole user
+// profile (including the unchanged name), that rejection blocked every user
+// update, not just the name change.
+func TestValidateUserName_CountsRunesNotBytes(t *testing.T) {
+	// Real-world name that triggered the bug: 31 runes, 34 bytes (🖤 is 4 bytes),
+	// within the 32-character limit but over it when counted as bytes.
+	name := "g1ld3dd (artist/producer) PHL 🖤"
+	if rc, bc := utf8.RuneCountInString(name), len(name); rc > CharacterLimitUserName || bc <= CharacterLimitUserName {
+		t.Fatalf("fixture invalid: runes=%d bytes=%d limit=%d (want runes<=limit<bytes)", rc, bc, CharacterLimitUserName)
+	}
+	if err := ValidateUserName(name); err != nil {
+		t.Errorf("ValidateUserName(%q) = %v, want nil (31 runes within %d-char limit)", name, err, CharacterLimitUserName)
+	}
+
+	// Exactly at the rune limit passes; one rune over fails.
+	if err := ValidateUserName(strings.Repeat("é", CharacterLimitUserName)); err != nil {
+		t.Errorf("name of %d multi-byte runes should pass: %v", CharacterLimitUserName, err)
+	}
+	if err := ValidateUserName(strings.Repeat("é", CharacterLimitUserName+1)); err == nil {
+		t.Errorf("name of %d runes should exceed %d-char limit", CharacterLimitUserName+1, CharacterLimitUserName)
+	}
+}
+
+func TestValidateBio_CountsRunesNotBytes(t *testing.T) {
+	if err := ValidateBio(strings.Repeat("🎵", CharacterLimitUserBio)); err != nil {
+		t.Errorf("bio of %d runes should pass: %v", CharacterLimitUserBio, err)
+	}
+	if err := ValidateBio(strings.Repeat("🎵", CharacterLimitUserBio+1)); err == nil {
+		t.Errorf("bio of %d runes should exceed %d-char limit", CharacterLimitUserBio+1, CharacterLimitUserBio)
+	}
+}


### PR DESCRIPTION
## Summary

User-profile and related validators advertise a **character** limit but check `len(value)`, which in Go counts **UTF-8 bytes**. Any value within the character limit but over it in bytes — e.g. a display name with an emoji — is rejected.

Because setting an **artist pick** re-submits the full user profile (including the unchanged `name`), this rejection blocks **every** profile update for affected users, not just the name field.

## Reported case

Artist `g1ld3dd` (user `609847193`) could not add a track to her artist pick. Her display name:

```
g1ld3dd (artist/producer) PHL 🖤   →  31 characters, 34 bytes  (🖤 = 4 bytes)
```

Indexer logs showed her `User/Update` transactions rejected with `reason:"name exceeds 32 character limit"` — even though the name is 31 characters, within the 32-character limit. The 34-byte length tripped the check, so `artist_pick_track_id` never persisted (confirmed `NULL` in prod).

## Why it's a regression
The legacy Python indexer counted characters (`len(str)` = code points), so the name indexed fine and has been stored for ages. The Go ETL counts bytes, so re-submitting the same profile now fails.

## Fix
Switch all length checks from `len()` to `utf8.RuneCountInString()`, matching the advertised "character limit" wording and the legacy code-point semantics. Covers every advertised character limit in the entity manager:

| validator | field |
|---|---|
| `ValidateUserName` | user name |
| `ValidateBio` | user bio |
| `ValidateHandle` | handle (ASCII-only, no-op but consistent) |
| `ValidateDescription` | track / playlist description |
| `validateCommentWrite` | comment body |
| developer app create/update | name, description |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./processors/entity_manager/` clean
- [x] New `TestValidateUserName_CountsRunesNotBytes` / `TestValidateBio_CountsRunesNotBytes` pass — uses the exact name from the report (asserts 31 runes ≤ 32 < 34 bytes), plus rune-boundary cases
- [x] Existing `TestUserUpdate_StatelessValidation` (incl. `name_too_long`, `bio_too_long`) still passes — over-limit ASCII is still rejected

## Unblock for the reported user
Independent of this fix, she can shorten her display name by a couple of bytes (drop the 🖤) and the update — and the artist pick — will go through. The fix removes the need to do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)