### PR TITLE
fix(etl): persist dropped track + comment fields on write

### DIFF
--- a/pkg/etl/processors/entity_manager/comment_update.go
+++ b/pkg/etl/processors/entity_manager/comment_update.go
@@ -16,12 +16,24 @@ func (h *commentUpdateHandler) Handle(ctx context.Context, params *Params) error
 
 	body := params.MetadataString("body")
 
+	// video_url is set on create but was dropped on edit, silently removing an
+	// attached video. Only overwrite when the edit includes the key (COALESCE
+	// keeps the stored value when the bound parameter is NULL), so a text-only
+	// edit preserves the existing video. (is_members_only is intentionally left
+	// to the create path: it's a FanClub-gated flag, not edited here.)
+	var videoURL *string
+	if _, ok := params.Metadata["video_url"]; ok {
+		v := params.MetadataString("video_url")
+		videoURL = &v
+	}
+
 	_, err := params.DBTX.Exec(ctx, `
 		UPDATE comments SET
-			text = $1, is_edited = true, updated_at = $2,
-			txhash = $3, blocknumber = $4
+			text = $1, is_edited = true,
+			video_url = COALESCE($6::varchar, video_url),
+			updated_at = $2, txhash = $3, blocknumber = $4
 		WHERE comment_id = $5
-	`, body, params.BlockTime, params.TxHash, params.BlockNumber, params.EntityID)
+	`, body, params.BlockTime, params.TxHash, params.BlockNumber, params.EntityID, videoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/etl/processors/entity_manager/dropped_fields_test.go
+++ b/pkg/etl/processors/entity_manager/dropped_fields_test.go
@@ -1,0 +1,110 @@
+package entity_manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// Regression: track CREATE must persist rights/licensing + preview metadata
+// that was previously dropped (license, isrc, iswc, preview_start_seconds,
+// comments_disabled, no_ai_use, cover_original_*).
+func TestTrackCreate_PersistsRightsAndPreviewFields(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 77)
+	seedUser(t, pool, uid, "0xrights", "rightsowner")
+	meta := `{"owner_id":3000001,"title":"Rights Song","license":"All rights reserved",` +
+		`"isrc":"USX9P1234567","iswc":"T-123.456.789-0","preview_start_seconds":12.5,` +
+		`"comments_disabled":true,"no_ai_use":true,` +
+		`"cover_original_song_title":"Original","cover_original_artist":"Someone"}`
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, uid, tid, "0xRights", meta))
+
+	var license, isrc, iswc, coverSong, coverArtist string
+	var previewStart float64
+	var commentsDisabled, noAIUse bool
+	err := pool.QueryRow(context.Background(),
+		`SELECT license, isrc, iswc, preview_start_seconds, comments_disabled, no_ai_use,
+			cover_original_song_title, cover_original_artist
+		 FROM tracks WHERE track_id=$1 AND is_current=true`, tid).
+		Scan(&license, &isrc, &iswc, &previewStart, &commentsDisabled, &noAIUse, &coverSong, &coverArtist)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if license != "All rights reserved" || isrc != "USX9P1234567" || iswc != "T-123.456.789-0" {
+		t.Errorf("rights = license:%q isrc:%q iswc:%q", license, isrc, iswc)
+	}
+	if previewStart != 12.5 || !commentsDisabled || !noAIUse {
+		t.Errorf("preview=%v commentsDisabled=%v noAIUse=%v", previewStart, commentsDisabled, noAIUse)
+	}
+	if coverSong != "Original" || coverArtist != "Someone" {
+		t.Errorf("cover orig = %q / %q", coverSong, coverArtist)
+	}
+}
+
+// Regression: track UPDATE must persist the same fields (previously dropped).
+func TestTrackUpdate_PersistsRightsAndPreviewFields(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	tid := int64(TrackIDOffset + 78)
+	seedUser(t, pool, uid, "0xrights2", "rightsowner2")
+	seedTrackFull(t, pool, tid, uid, "Editable")
+	meta := `{"license":"CC BY 4.0","isrc":"USX9P7654321","preview_start_seconds":5,"comments_disabled":true}`
+	mustHandle(t, TrackUpdate(), buildParams(t, pool, EntityTypeTrack, ActionUpdate, uid, tid, "0xRights2", meta))
+
+	var license, isrc string
+	var previewStart float64
+	var commentsDisabled bool
+	err := pool.QueryRow(context.Background(),
+		`SELECT license, isrc, preview_start_seconds, comments_disabled
+		 FROM tracks WHERE track_id=$1 AND is_current=true`, tid).
+		Scan(&license, &isrc, &previewStart, &commentsDisabled)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if license != "CC BY 4.0" || isrc != "USX9P7654321" || previewStart != 5 || !commentsDisabled {
+		t.Errorf("got license:%q isrc:%q preview:%v commentsDisabled:%v", license, isrc, previewStart, commentsDisabled)
+	}
+}
+
+// Regression: comment UPDATE must keep video_url on a text-only edit
+// (previously dropped → video silently removed), and still update it when the
+// edit provides a new value.
+func TestCommentUpdate_PreservesAndUpdatesVideo(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	trackID := int64(TrackIDOffset + 1)
+	commentID := int64(CommentIDOffset + 50)
+	seedUser(t, pool, uid, "0xcommenter2", "commenter2")
+	seedTrack(t, pool, trackID, uid)
+
+	createMeta := fmt.Sprintf(`{"body":"orig","entity_id":%d,"entity_type":"Track",`+
+		`"video_url":"https://v.example/a.mp4"}`, trackID)
+	mustHandle(t, CommentCreate(), buildParams(t, pool, EntityTypeComment, ActionCreate, uid, commentID, "0xCommenter2", createMeta))
+
+	// Text-only edit must preserve video_url.
+	editMeta := fmt.Sprintf(`{"body":"edited","entity_id":%d,"entity_type":"Track"}`, trackID)
+	mustHandle(t, CommentUpdate(), buildParams(t, pool, EntityTypeComment, ActionUpdate, uid, commentID, "0xCommenter2", editMeta))
+	var text, videoURL string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT text, video_url FROM comments WHERE comment_id=$1", commentID).Scan(&text, &videoURL); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if text != "edited" {
+		t.Errorf("text=%q, want edited", text)
+	}
+	if videoURL != "https://v.example/a.mp4" {
+		t.Errorf("preserve failed: video=%q", videoURL)
+	}
+
+	// An edit that provides a new video_url must update it.
+	editMeta2 := fmt.Sprintf(`{"body":"edited2","entity_id":%d,"entity_type":"Track","video_url":"https://v.example/b.mp4"}`, trackID)
+	mustHandle(t, CommentUpdate(), buildParams(t, pool, EntityTypeComment, ActionUpdate, uid, commentID, "0xCommenter2", editMeta2))
+	if err := pool.QueryRow(context.Background(),
+		"SELECT video_url FROM comments WHERE comment_id=$1", commentID).Scan(&videoURL); err != nil {
+		t.Fatalf("query2: %v", err)
+	}
+	if videoURL != "https://v.example/b.mp4" {
+		t.Errorf("update failed: video=%q", videoURL)
+	}
+}

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -92,6 +92,18 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 	isCustomBpm := params.MetadataBoolOr("is_custom_bpm", false)
 	isCustomMusicalKey := params.MetadataBoolOr("is_custom_musical_key", false)
 	audioUploadID := params.MetadataString("audio_upload_id")
+	license := params.MetadataString("license")
+	isrc := params.MetadataString("isrc")
+	iswc := params.MetadataString("iswc")
+	coverOriginalSongTitle := params.MetadataString("cover_original_song_title")
+	coverOriginalArtist := params.MetadataString("cover_original_artist")
+	commentsDisabled := params.MetadataBoolOr("comments_disabled", false)
+	noAIUse := params.MetadataBoolOr("no_ai_use", false)
+
+	var previewStartSeconds *float64
+	if v, ok := params.MetadataFloat64("preview_start_seconds"); ok {
+		previewStartSeconds = &v
+	}
 
 	// musical_key: only persist recognized keys (mirrors apps' is_valid_musical_key).
 	// An invalid/empty key leaves the column NULL on create.
@@ -138,7 +150,9 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 			is_downloadable, is_download_gated, download_conditions, is_stream_gated, stream_conditions,
 			release_date, is_scheduled_release, ai_attribution_user_id, is_playlist_upload, ddex_app, ddex_release_ids,
 			bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id,
-			is_available, route_id, track_segments, created_at, updated_at, txhash, blocknumber
+			is_available, license, isrc, iswc, preview_start_seconds, comments_disabled,
+			cover_original_song_title, cover_original_artist, no_ai_use,
+			route_id, track_segments, created_at, updated_at, txhash, blocknumber
 		) VALUES (
 			$1, $2, true, false, $3, $4, $5, $6, $7,
 			$8, $9, $10, $11, $12, $13,
@@ -146,7 +160,9 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 			$18, $19, $20, $21, $22,
 			$23, $24, $25, $26, $27, $28,
 			$29, $30, $31, $32, $33,
-			$34, $35, '[]'::jsonb, $36, $36, $37, $38
+			$34, $35, $36, $37, $38, $39,
+			$40, $41, $42,
+			$43, '[]'::jsonb, $44, $44, $45, $46
 		)
 	`,
 		params.EntityID,
@@ -183,6 +199,14 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 		isCustomMusicalKey,
 		nullString(audioUploadID),
 		isAvailable,
+		nullString(license),
+		nullString(isrc),
+		nullString(iswc),
+		previewStartSeconds,
+		commentsDisabled,
+		nullString(coverOriginalSongTitle),
+		nullString(coverOriginalArtist),
+		noAIUse,
 		routeID,
 		params.BlockTime,
 		params.TxHash,

--- a/pkg/etl/processors/entity_manager/track_row.go
+++ b/pkg/etl/processors/entity_manager/track_row.go
@@ -14,50 +14,59 @@ import (
 
 // trackRow holds columns we read/write for track create/update parity.
 type trackRow struct {
-	TrackID              int64
-	OwnerID              int64
-	Title                string
-	Genre                *string
-	Mood                 *string
-	Tags                 *string
-	Description          *string
-	CoverArt             *string
-	CoverArtSizes        *string
-	IsUnlisted           bool
-	FieldVisibility      []byte
-	RemixOf              []byte
-	StemOf               []byte
-	TrackCID             *string
-	PreviewCID           *string
-	OrigFileCID          *string
-	Duration             int
-	IsDownloadable       bool
-	IsDownloadGated      bool
-	DownloadConditions   []byte
-	IsStreamGated        bool
-	StreamConditions     []byte
-	ReleaseDate          pgtype.Timestamp
-	IsScheduledRelease   bool
-	AiAttributionUserID  *int64
-	IsPlaylistUpload     bool
-	DdexApp              *string
-	DdexReleaseIDs       []byte
-	Bpm                  *float64
-	MusicalKey           *string
-	IsCustomBpm          bool
-	IsCustomMusicalKey   bool
-	AudioUploadID        *string
-	IsAvailable          bool
-	TrackSegments        []byte
-	CreatedAt            time.Time
+	TrackID                int64
+	OwnerID                int64
+	Title                  string
+	Genre                  *string
+	Mood                   *string
+	Tags                   *string
+	Description            *string
+	CoverArt               *string
+	CoverArtSizes          *string
+	IsUnlisted             bool
+	FieldVisibility        []byte
+	RemixOf                []byte
+	StemOf                 []byte
+	TrackCID               *string
+	PreviewCID             *string
+	OrigFileCID            *string
+	Duration               int
+	IsDownloadable         bool
+	IsDownloadGated        bool
+	DownloadConditions     []byte
+	IsStreamGated          bool
+	StreamConditions       []byte
+	ReleaseDate            pgtype.Timestamp
+	IsScheduledRelease     bool
+	AiAttributionUserID    *int64
+	IsPlaylistUpload       bool
+	DdexApp                *string
+	DdexReleaseIDs         []byte
+	Bpm                    *float64
+	MusicalKey             *string
+	IsCustomBpm            bool
+	IsCustomMusicalKey     bool
+	AudioUploadID          *string
+	IsAvailable            bool
+	License                *string
+	ISRC                   *string
+	ISWC                   *string
+	PreviewStartSeconds    *float64
+	CommentsDisabled       bool
+	CoverOriginalSongTitle *string
+	CoverOriginalArtist    *string
+	NoAIUse                bool
+	TrackSegments          []byte
+	CreatedAt              time.Time
 }
 
 func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*trackRow, error) {
 	var r trackRow
 	var title, genre, mood, tags, desc, cover, coverSz, tcid, pcid, ofcid, ddex, musicalKey, audioUploadID sql.NullString
+	var license, isrc, iswc, coverOrigSong, coverOrigArtist sql.NullString
 	var fieldVis, remix, stem, dlCond, streamCond, ddexRel, segments []byte
 	var aiAttr sql.NullInt64
-	var bpm sql.NullFloat64
+	var bpm, previewStart sql.NullFloat64
 	var releaseDate pgtype.Timestamp
 
 	err := dbtx.QueryRow(ctx, `
@@ -67,7 +76,8 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 			is_downloadable, is_download_gated, download_conditions, is_stream_gated, stream_conditions,
 			release_date, is_scheduled_release, ai_attribution_user_id, is_playlist_upload, ddex_app, ddex_release_ids,
 			bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id,
-			is_available, track_segments, created_at
+			is_available, license, isrc, iswc, preview_start_seconds, comments_disabled,
+			cover_original_song_title, cover_original_artist, no_ai_use, track_segments, created_at
 		FROM tracks WHERE track_id = $1 AND is_current = true AND is_delete = false LIMIT 1
 	`, trackID).Scan(
 		&r.TrackID, &r.OwnerID, &title, &genre, &mood, &tags, &desc,
@@ -76,7 +86,8 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 		&r.IsDownloadable, &r.IsDownloadGated, &dlCond, &r.IsStreamGated, &streamCond,
 		&releaseDate, &r.IsScheduledRelease, &aiAttr, &r.IsPlaylistUpload, &ddex, &ddexRel,
 		&bpm, &musicalKey, &r.IsCustomBpm, &r.IsCustomMusicalKey, &audioUploadID,
-		&r.IsAvailable, &segments, &r.CreatedAt,
+		&r.IsAvailable, &license, &isrc, &iswc, &previewStart, &r.CommentsDisabled,
+		&coverOrigSong, &coverOrigArtist, &r.NoAIUse, &segments, &r.CreatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Track was soft-deleted between validation and now (validateTrackUpdate
@@ -112,6 +123,12 @@ func loadCurrentTrackRow(ctx context.Context, dbtx db.DBTX, trackID int64) (*tra
 	r.Bpm = nullFloat64Ptr(bpm)
 	r.MusicalKey = nullStrPtr(musicalKey)
 	r.AudioUploadID = nullStrPtr(audioUploadID)
+	r.License = nullStrPtr(license)
+	r.ISRC = nullStrPtr(isrc)
+	r.ISWC = nullStrPtr(iswc)
+	r.PreviewStartSeconds = nullFloat64Ptr(previewStart)
+	r.CoverOriginalSongTitle = nullStrPtr(coverOrigSong)
+	r.CoverOriginalArtist = nullStrPtr(coverOrigArtist)
 	r.TrackSegments = segments
 	if len(r.TrackSegments) == 0 {
 		r.TrackSegments = []byte("[]")
@@ -174,6 +191,26 @@ func mergeTrackFromMetadata(p *Params, base *trackRow) *trackRow {
 	// audio_upload_id is a generic passthrough field in apps' indexer (set via
 	// the catch-all setattr branch), needed by the audio-analysis repair job.
 	mergeStrPtr("audio_upload_id", &out.AudioUploadID)
+	mergeStrPtr("license", &out.License)
+	mergeStrPtr("isrc", &out.ISRC)
+	mergeStrPtr("iswc", &out.ISWC)
+	mergeStrPtr("cover_original_song_title", &out.CoverOriginalSongTitle)
+	mergeStrPtr("cover_original_artist", &out.CoverOriginalArtist)
+
+	if raw, ok := p.Metadata["preview_start_seconds"]; ok {
+		if raw == nil {
+			out.PreviewStartSeconds = nil
+		} else if v, ok2 := p.MetadataFloat64("preview_start_seconds"); ok2 {
+			cp := v
+			out.PreviewStartSeconds = &cp
+		}
+	}
+	if v, ok := p.MetadataBool("comments_disabled"); ok {
+		out.CommentsDisabled = v
+	}
+	if v, ok := p.MetadataBool("no_ai_use"); ok {
+		out.NoAIUse = v
+	}
 
 	// bpm semantics mirror apps' track.py: explicit null clears; a nonzero
 	// number sets; zero or a non-numeric value is ignored (existing kept).
@@ -292,7 +329,9 @@ func updateTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 			ai_attribution_user_id = $24, is_playlist_upload = $25, ddex_app = $26, ddex_release_ids = $27,
 			bpm = $28, musical_key = $29, is_custom_bpm = $30, is_custom_musical_key = $31, audio_upload_id = $32,
 			is_available = $33,
-			updated_at = $34, txhash = $35, blocknumber = $36
+			license = $34, isrc = $35, iswc = $36, preview_start_seconds = $37, comments_disabled = $38,
+			cover_original_song_title = $39, cover_original_artist = $40, no_ai_use = $41,
+			updated_at = $42, txhash = $43, blocknumber = $44
 		WHERE track_id = $1 AND is_current = true
 	`,
 		r.TrackID,
@@ -328,6 +367,14 @@ func updateTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 		r.IsCustomMusicalKey,
 		strPtrVal(r.AudioUploadID),
 		r.IsAvailable,
+		strPtrVal(r.License),
+		strPtrVal(r.ISRC),
+		strPtrVal(r.ISWC),
+		floatPtrVal(r.PreviewStartSeconds),
+		r.CommentsDisabled,
+		strPtrVal(r.CoverOriginalSongTitle),
+		strPtrVal(r.CoverOriginalArtist),
+		r.NoAIUse,
 		blockTime,
 		txHash,
 		blockNumber,
@@ -344,7 +391,9 @@ func insertTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 			is_downloadable, is_download_gated, download_conditions, is_stream_gated, stream_conditions,
 			release_date, is_scheduled_release, ai_attribution_user_id, is_playlist_upload, ddex_app, ddex_release_ids,
 			bpm, musical_key, is_custom_bpm, is_custom_musical_key, audio_upload_id,
-			is_available, track_segments, created_at, updated_at, txhash, blocknumber
+			is_available, license, isrc, iswc, preview_start_seconds, comments_disabled,
+			cover_original_song_title, cover_original_artist, no_ai_use,
+			track_segments, created_at, updated_at, txhash, blocknumber
 		) VALUES (
 			$1, $2, true, false, $3, $4, $5, $6, $7,
 			$8, $9, $10, $11, $12, $13,
@@ -352,7 +401,9 @@ func insertTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 			$18, $19, $20, $21, $22,
 			$23, $24, $25, $26, $27, $28,
 			$29, $30, $31, $32, $33,
-			$34, $35, $36, $37, $38, $39
+			$34, $35, $36, $37, $38, $39,
+			$40, $41, $42,
+			$43, $44, $45, $46, $47
 		)
 	`,
 		r.TrackID,
@@ -389,6 +440,14 @@ func insertTrackRow(ctx context.Context, dbtx db.DBTX, r *trackRow, blockTime ti
 		r.IsCustomMusicalKey,
 		strPtrVal(r.AudioUploadID),
 		r.IsAvailable,
+		strPtrVal(r.License),
+		strPtrVal(r.ISRC),
+		strPtrVal(r.ISWC),
+		floatPtrVal(r.PreviewStartSeconds),
+		r.CommentsDisabled,
+		strPtrVal(r.CoverOriginalSongTitle),
+		strPtrVal(r.CoverOriginalArtist),
+		r.NoAIUse,
 		r.TrackSegments,
 		r.CreatedAt,
 		blockTime,


### PR DESCRIPTION
## Summary

Same bug class as the user social-links fix (#341): entity-manager handlers silently dropped columns that exist on the table and arrive in transaction metadata. Found by auditing all write handlers after that fix.

### Track — `track_create.go` / `track_row.go`
Create/update never wrote these columns, so new uploads lost them and edits silently dropped them:

| field | tracks with it set (prod) |
|---|---|
| `license` | **642,291** |
| `isrc` | 94,894 |
| `preview_start_seconds` | 31,615 |
| `iswc` | 11,375 |
| `comments_disabled` | 1,175 |
| `cover_original_song_title/artist`, `no_ai_use` | small / 0 |

`license` alone is on 642K tracks (the legacy Python indexer wrote it; the Go ETL wrote it on zero). Now merged + written on both paths — threaded through `trackRow`; create's inline INSERT updated to match.

### Comment — `comment_update.go`
Editing a comment dropped `video_url`, silently removing an attached video. Now preserved/updated via `COALESCE` (a text-only edit keeps the stored video; an edit that includes `video_url` updates it).

**Scoped out:** `is_members_only`. Verifying showed it's gated by `entity_type=="FanClub"` on create, so honoring it ungated on update would be inconsistent — and it's only 12 rows in prod, not part of the report. Left to the create path.

## No migration needed
All columns already exist in migration `0002` (confirmed), so this is **code-only** — no schema change, no special rollout.

## Test plan
- [x] `go build ./...`, `go vet`, gofmt clean
- [x] **DB-backed regression tests against a real Postgres** (`dropped_fields_test.go`): track create + update round-trip license/isrc/iswc/preview_start_seconds/comments_disabled/no_ai_use/cover_original_*; comment edit preserves then updates `video_url`
- [x] Existing track + comment DB suites pass against real Postgres (validates the INSERT/UPDATE placeholder renumbering — the risky part)
- Testing also surfaced two real constraints now respected (comment edits require `entity_id`; `is_members_only` is FanClub-gated)

## Audit notes
Playlists, events, grants, and the other entities were audited and are clean (symmetric writes, no schema gaps). This PR covers the only confirmed drops with meaningful production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)