### PR TITLE
feat(examples): local ETL harness (stream/poll + tx load + resume)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,28 @@ up: down docker-dev
 		--profile=openaudio-dev \
 		up -d
 
+# ---- Local ETL harness (see examples/etl/README.md) ----
+# Reads node1 (devnet) blocks into a throwaway Postgres so you can exercise the
+# indexer: stream vs poll, feed entity-manager txs, kill/restart for resume.
+ETL_DB_URL ?= postgres://etl:etl@localhost:5454/etl?sslmode=disable
+ETL_RPC ?= http://localhost:50051
+
+.PHONY: etl-db-up etl-db-down etl-poll etl-stream etl-load
+etl-db-up:
+	@docker compose --file='dev/etl-harness.docker-compose.yml' --project-name='etl-harness' up -d
+
+etl-db-down:
+	@docker compose --file='dev/etl-harness.docker-compose.yml' --project-name='etl-harness' down -v
+
+etl-poll:
+	go run ./examples/etl --rpc '$(ETL_RPC)' --db '$(ETL_DB_URL)'
+
+etl-stream:
+	go run ./examples/etl --rpc '$(ETL_RPC)' --db '$(ETL_DB_URL)' --stream
+
+etl-load:
+	go run ./examples/loadgen --rpc https://node1.oap.devnet --insecure
+
 .PHONY: run-prod
 run-prod: docker-dev
 	@docker rm -f openaudio-prod-ss 2>/dev/null || true

--- a/dev/etl-harness.docker-compose.yml
+++ b/dev/etl-harness.docker-compose.yml
@@ -1,0 +1,22 @@
+# Throwaway Postgres for the local ETL harness (see examples/etl/README.md).
+# Kept separate from dev/docker-compose.yml so `make up` is unaffected.
+#
+#   make etl-db-up      # start it (host port 5454)
+#   make etl-db-down    # stop + wipe
+services:
+  etl-postgres:
+    image: postgres:15-alpine
+    container_name: etl-harness-postgres
+    environment:
+      POSTGRES_USER: etl
+      POSTGRES_PASSWORD: etl
+      POSTGRES_DB: etl
+    ports:
+      - "5454:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U etl"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/examples/etl/README.md
+++ b/examples/etl/README.md
@@ -31,3 +31,36 @@ go run ./examples/etl \
 | `--rpc` | `ETL_RPC_URL` | Core RPC endpoint |
 | `--db` | `ETL_DB_URL` | Postgres connection string |
 | `--start` | — | Starting block height (0 = resume from last indexed) |
+| `--end` | — | Ending block height (0 = run forever) |
+| `--stream` | — | Consume blocks via the gRPC `StreamBlocks` stream instead of polling |
+| `--insecure` | — | Skip TLS verification (self-signed devnet cert over https) |
+| `--skip-migrations` | — | Skip running migrations (pre-existing schema) |
+
+## Local devnet harness
+
+Exercise the indexer end to end against the local devnet — stream vs poll, feed
+transactions, kill/restart for resume. Convenience `make` targets:
+
+```bash
+make up           # 4-node devnet (node1 exposes gRPC h2c on :50051)
+make etl-db-up    # throwaway Postgres on localhost:5454
+
+make etl-stream   # index via gRPC StreamBlocks   (node1 :50051)
+make etl-poll     # index via GetBlocks polling    (for comparison)
+
+make etl-load     # fire a batch of entity-manager txs at node1
+```
+
+Kill the ETL (`Ctrl-C`) and re-run `make etl-stream`: it resumes from its
+`etl_blocks` cursor with no gap/dup (catch-up + resume under test). Do it while
+`make etl-load` runs to confirm blocks committed during downtime are backfilled
+on reconnect.
+
+To test the prod-like nginx 443 path instead of the direct h2c port:
+
+```bash
+go run ./examples/etl --rpc https://node1.oap.devnet --db "$ETL_DB_URL" --stream --insecure
+```
+
+See `examples/loadgen` for the transaction generator and its flags
+(`--users`, `--tracks`, `--social`). Tear down with `make etl-db-down` and `make down`.

--- a/examples/etl/main.go
+++ b/examples/etl/main.go
@@ -1,35 +1,53 @@
-// etl runs the ETL indexer against a production RPC and local Postgres.
+// etl runs the ETL indexer against an RPC endpoint and a local Postgres.
 //
 // It creates all necessary tables via migrations, then indexes blocks and prints
 // each transaction's payload before processing and a completion message after.
 //
-// Usage:
+// Against production (valid TLS, polling):
 //
 //	go run ./examples/etl \
 //	  --rpc https://core.audius.co \
 //	  --db "postgres://localhost:5432/etl_local?sslmode=disable"
 //
+// Against the local devnet over the gRPC block stream (node1's h2c port):
+//
+//	go run ./examples/etl \
+//	  --rpc http://localhost:50051 \
+//	  --db "postgres://etl:etl@localhost:5454/etl?sslmode=disable" \
+//	  --stream
+//
+// Or exercise the nginx 443 path (self-signed TLS) with --insecure:
+//
+//	go run ./examples/etl --rpc https://node1.oap.devnet --db ... --stream --insecure
+//
 // Environment variables ETL_RPC_URL and ETL_DB_URL are used as fallbacks.
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"flag"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
 
-	etl "github.com/OpenAudio/go-openaudio/pkg/etl"
+	"connectrpc.com/connect"
 	corev1connect "github.com/OpenAudio/go-openaudio/pkg/api/core/v1/v1connect"
+	etl "github.com/OpenAudio/go-openaudio/pkg/etl"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 )
 
 func main() {
-	rpcURL := flag.String("rpc", "", "Core RPC endpoint (e.g. https://core.audius.co)")
+	rpcURL := flag.String("rpc", "", "Core RPC endpoint (e.g. https://core.audius.co, http://localhost:50051)")
 	dbURL := flag.String("db", "", "Postgres connection string (e.g. postgres://localhost:5432/etl_local?sslmode=disable)")
 	startBlock := flag.Int64("start", 0, "Starting block height (0 = resume from last indexed)")
 	endBlock := flag.Int64("end", 0, "Ending block height (0 = run forever)")
 	skipMigrations := flag.Bool("skip-migrations", false, "Skip running database migrations (use with pre-existing schemas)")
+	stream := flag.Bool("stream", false, "Consume blocks via the gRPC StreamBlocks stream instead of polling GetBlocks")
+	insecure := flag.Bool("insecure", false, "Skip TLS verification (for the self-signed devnet cert over https)")
 	verbose := flag.Bool("v", false, "Enable debug logging")
 	flag.Parse()
 
@@ -57,14 +75,32 @@ func main() {
 		log.Fatalf("failed to create logger: %v", err)
 	}
 
-	coreClient := corev1connect.NewCoreServiceClient(http.DefaultClient, *rpcURL)
+	// The block stream is a gRPC server stream, so the client must speak HTTP/2.
+	// For http:// (e.g. node1's :50051) that's h2c; for https:// it's TLS h2.
+	httpClient := http.DefaultClient
+	var clientOpts []connect.ClientOption
+	// http:// endpoints (e.g. node1's :50051) are h2c-only; --insecure/--stream
+	// also need an HTTP/2-capable client. Plain https stays on the default client.
+	if *stream || *insecure || strings.HasPrefix(*rpcURL, "http://") {
+		httpClient = buildH2Client(*rpcURL, *insecure)
+	}
+	if *stream {
+		clientOpts = append(clientOpts, connect.WithGRPC())
+	}
+
+	coreClient := corev1connect.NewCoreServiceClient(httpClient, *rpcURL, clientOpts...)
 
 	indexer := etl.New(coreClient, logger)
 	indexer.SetDBURL(*dbURL)
-	indexer.SetConfig(etl.Config{
+	etlCfg := etl.Config{
 		EnableMaterializedViewRefresh: false,
 		EnablePgNotifyListener:        false,
-	})
+	}
+	if *stream {
+		etlCfg.BlockStreamEnabled = true
+		indexer.SetBlockStreamClient(coreClient)
+	}
+	indexer.SetConfig(etlCfg)
 	if *startBlock > 0 {
 		indexer.SetStartingBlockHeight(*startBlock)
 	}
@@ -78,10 +114,32 @@ func main() {
 	logger.Info("starting ETL local runner",
 		zap.String("rpc", *rpcURL),
 		zap.String("db", *dbURL),
+		zap.Bool("stream", *stream),
 		zap.Int64("start_block", *startBlock),
 	)
 
 	if err := indexer.Run(); err != nil {
 		logger.Fatal("indexer exited with error", zap.Error(err))
 	}
+}
+
+// buildH2Client returns an HTTP/2-capable client: h2c (cleartext) for http://
+// endpoints like node1's :50051, or TLS h2 (optionally skipping verification of
+// the self-signed devnet cert) for https://.
+func buildH2Client(rpcURL string, insecure bool) *http.Client {
+	if strings.HasPrefix(rpcURL, "http://") {
+		return &http.Client{
+			Transport: &http2.Transport{
+				AllowHTTP: true,
+				DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, network, addr)
+				},
+			},
+		}
+	}
+	tr := &http.Transport{ForceAttemptHTTP2: true}
+	if insecure {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return &http.Client{Transport: tr}
 }

--- a/examples/loadgen/main.go
+++ b/examples/loadgen/main.go
@@ -1,0 +1,187 @@
+// loadgen fires a batch of entity-manager transactions at a local devnet node
+// to exercise the indexer (users, tracks, follows, subscribes, reposts, saves,
+// comments, user updates). Each user is minted with its own ECDSA key so the
+// "wallet already in use" / signer-authorization checks pass.
+//
+//	make up                       # start the devnet
+//	go run ./examples/loadgen --rpc https://node1.oap.devnet --insecure --users 5 --social 200
+//
+// Then watch your ETL index the resulting blocks.
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"connectrpc.com/connect"
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/OpenAudio/go-openaudio/pkg/core/config"
+	"github.com/OpenAudio/go-openaudio/pkg/core/server"
+	"github.com/OpenAudio/go-openaudio/pkg/sdk"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+)
+
+const (
+	userIDOffset  = 3_000_000
+	trackIDOffset = 2_000_000
+)
+
+type user struct {
+	id  int64
+	key *ecdsa.PrivateKey
+}
+
+func main() {
+	rpcURL := flag.String("rpc", "https://node1.oap.devnet", "Core RPC endpoint")
+	insecure := flag.Bool("insecure", true, "Skip TLS verification (self-signed devnet cert)")
+	numUsers := flag.Int("users", 5, "How many users to create")
+	numTracks := flag.Int("tracks", 3, "How many tracks to create (spread across users)")
+	numSocial := flag.Int("social", 100, "How many random social actions to fire")
+	pause := flag.Duration("pause", 1500*time.Millisecond, "Pause after each dependency stage to let blocks commit")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	httpClient := http.DefaultClient
+	if *insecure {
+		httpClient = &http.Client{
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+			Timeout:   30 * time.Second,
+		}
+	}
+	auds := sdk.NewOpenAudioSDKWithClient(*rpcURL, httpClient)
+	if err := auds.Init(ctx); err != nil {
+		log.Fatalf("init SDK: %v", err)
+	}
+	cfg := &config.Config{
+		AcdcEntityManagerAddress: config.DevAcdcAddress,
+		AcdcChainID:              config.DevAcdcChainID,
+	}
+
+	// Unique per-run base so reruns don't collide on user/track ids or handles.
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	base := int64(rng.Intn(900_000)) * 100
+
+	send := newSender(ctx, auds, cfg)
+
+	// 1. Users — each with its own wallet.
+	users := make([]user, 0, *numUsers)
+	for i := 0; i < *numUsers; i++ {
+		key, _ := crypto.GenerateKey()
+		id := userIDOffset + base + int64(i)
+		meta := fmt.Sprintf(`{"handle":"lg_%d_%d","name":"Loadgen User %d"}`, base, i, i)
+		if send("User", "Create", id, id, meta, key) {
+			users = append(users, user{id: id, key: key})
+		}
+	}
+	if len(users) == 0 {
+		log.Fatal("no users created; aborting")
+	}
+	log.Printf("created %d users; waiting for commit", len(users))
+	time.Sleep(*pause)
+
+	// 2. Tracks — owned by random users.
+	tracks := make([]int64, 0, *numTracks)
+	for j := 0; j < *numTracks; j++ {
+		owner := users[rng.Intn(len(users))]
+		id := trackIDOffset + base + int64(j)
+		meta := fmt.Sprintf(`{"title":"Loadgen Track %d","genre":"Electronic","cid":"Qm-loadgen-%d-%d"}`, j, base, j)
+		if send("Track", "Create", owner.id, id, meta, owner.key) {
+			tracks = append(tracks, id)
+		}
+	}
+	log.Printf("created %d tracks; waiting for commit", len(tracks))
+	time.Sleep(*pause)
+
+	// 3. Random social actions among the created users/tracks.
+	sent, ok := 0, 0
+	for i := 0; i < *numSocial; i++ {
+		actor := users[rng.Intn(len(users))]
+		var entityType, action string
+		var entityID int64
+		switch rng.Intn(6) {
+		case 0, 1: // follow / subscribe another user
+			target := users[rng.Intn(len(users))]
+			if target.id == actor.id {
+				continue
+			}
+			entityType, entityID = "User", target.id
+			action = []string{"Follow", "Subscribe"}[rng.Intn(2)]
+		case 2: // repost a track
+			if len(tracks) == 0 {
+				continue
+			}
+			entityType, entityID, action = "Track", tracks[rng.Intn(len(tracks))], "Repost"
+		case 3: // save a track
+			if len(tracks) == 0 {
+				continue
+			}
+			entityType, entityID, action = "Track", tracks[rng.Intn(len(tracks))], "Save"
+		case 4: // comment on a track
+			if len(tracks) == 0 {
+				continue
+			}
+			cid := int64(4_000_000) + base + int64(i)
+			meta := fmt.Sprintf(`{"body":"loadgen comment %d","entity_id":%d,"entity_type":"Track"}`, i, tracks[rng.Intn(len(tracks))])
+			sent++
+			if send("Comment", "Create", actor.id, cid, meta, actor.key) {
+				ok++
+			}
+			continue
+		default: // update profile
+			entityType, entityID, action = "User", actor.id, "Update"
+			meta := fmt.Sprintf(`{"name":"Loadgen User %d v%d"}`, actor.id, i)
+			sent++
+			if send(entityType, action, actor.id, entityID, meta, actor.key) {
+				ok++
+			}
+			continue
+		}
+		sent++
+		if send(entityType, action, actor.id, entityID, "{}", actor.key) {
+			ok++
+		}
+	}
+	log.Printf("done: %d/%d social actions accepted (rejections are expected for dup follows/saves)", ok, sent)
+}
+
+// newSender returns a closure that signs and submits one ManageEntity tx,
+// logging the outcome and returning whether it was accepted.
+func newSender(ctx context.Context, auds *sdk.OpenAudioSDK, cfg *config.Config) func(entityType, action string, userID, entityID int64, metadata string, key *ecdsa.PrivateKey) bool {
+	var nonce int64
+	return func(entityType, action string, userID, entityID int64, metadata string, key *ecdsa.PrivateKey) bool {
+		nonce++
+		em := &corev1.ManageEntityLegacy{
+			UserId:     userID,
+			EntityType: entityType,
+			EntityId:   entityID,
+			Action:     action,
+			Metadata:   metadata,
+			Nonce:      fmt.Sprintf("0x%064x", time.Now().UnixNano()+nonce),
+		}
+		if err := server.SignManageEntity(cfg, em, key); err != nil {
+			log.Printf("  sign %s/%s e%d: %v", entityType, action, entityID, err)
+			return false
+		}
+		_, err := auds.Core.SendTransaction(ctx, connect.NewRequest(&corev1.SendTransactionRequest{
+			Transaction: &corev1.SignedTransaction{
+				RequestId:   uuid.NewString(),
+				Transaction: &corev1.SignedTransaction_ManageEntity{ManageEntity: em},
+			},
+		}))
+		if err != nil {
+			log.Printf("  send %s/%s e%d: %v", entityType, action, entityID, err)
+			return false
+		}
+		log.Printf("  %s/%s user=%d entity=%d", entityType, action, userID, entityID)
+		return true
+	}
+}


### PR DESCRIPTION
Stacked on #342 (base = `feat/stream-blocks-indexer`) — review/merge that first.

## What this adds

A local harness to drive the exact loop for testing the streaming work: spin up devnet → point an ETL at it → feed entity-manager txs → kill/restart to verify catch-up + resume.

### `examples/etl` — now does stream **or** poll
- `--stream` consumes blocks via the gRPC `StreamBlocks` stream (sets `BlockStreamEnabled` + `SetBlockStreamClient`). Builds an HTTP/2 client automatically: **h2c** for `http://` (node1's `:50051`), **TLS h2** for `https://`.
- `--insecure` skips verification of the self-signed devnet cert.
- Polling stays the default — existing prod usage unchanged.

### `examples/loadgen` — new tx generator
Fires a configurable batch of entity-manager txs: creates users (each with **its own freshly-minted ECDSA wallet**, so the `wallet already in use` / signer-authorization checks pass), then tracks, then random follows / subscribes / reposts / saves / comments / profile updates. Dup follows/saves get rejected by validation — intentional, exercises the rejection path too.

### `dev/etl-harness.docker-compose.yml` — throwaway Postgres
Postgres on `localhost:5454`, `tmpfs`-backed. Kept **separate** from `dev/docker-compose.yml` so `make up` is untouched.

### `make` targets + runbook
```
make up && make etl-db-up
make etl-stream     # gRPC StreamBlocks (node1 :50051)
make etl-poll       # GetBlocks polling (comparison)
make etl-load       # fire entity-manager txs
```
`Ctrl-C` the ETL and re-run `make etl-stream` → resumes from the `etl_blocks` cursor with no gap/dup. Full steps in `examples/etl/README.md`.

## Why this shape
- **Direct `:50051` h2c** as the default stream target is the most reliable local gRPC path (no TLS, guaranteed HTTP/2). `https://node1.oap.devnet --insecure` is documented for exercising the prod-like nginx 443 path (the Phase-0 proxy question).
- **Per-user wallets** are required: `validateUserCreate` rejects a second user from the same signer wallet (`walletExists`), so one shared key can't create a population.
- **Separate compose + non-default flags** keep `make up` and the prod `examples/etl` invocation byte-for-byte unchanged.

## Test plan
- [x] `go build ./examples/...` + `go vet` clean
- [x] `docker compose -f dev/etl-harness.docker-compose.yml config` validates
- [ ] Manual: `make up && make etl-db-up && make etl-stream` + `make etl-load`, then kill/restart the ETL and confirm gap-free resume (this is the harness's own acceptance test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)