### PR TITLE
feat(etl): add TrackCollaborator to the entity manager spec

### DIFF
--- a/pkg/etl/db/sql/migrations/0033_track_collaborators.down.sql
+++ b/pkg/etl/db/sql/migrations/0033_track_collaborators.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS track_collaborators;

--- a/pkg/etl/db/sql/migrations/0033_track_collaborators.up.sql
+++ b/pkg/etl/db/sql/migrations/0033_track_collaborators.up.sql
@@ -1,0 +1,32 @@
+-- track_collaborators stores collaborator invites on tracks.
+--
+-- The track owner tags collaborators in track Create/Update metadata
+-- (`collaborators: [user_id, ...]`), which the track handlers reconcile into
+-- 'pending' rows here. A collaborator then accepts/declines via a
+-- TrackCollaborator Approve/Reject ManageEntity tx, flipping status to
+-- 'accepted'/'rejected'. Only 'accepted' rows surface a track on the
+-- collaborator's profile and merged dashboard.
+--
+-- Modeled on the manager-invite (grants) flow: pending -> accepted/rejected.
+
+CREATE TABLE IF NOT EXISTS track_collaborators (
+  track_id integer NOT NULL,
+  collaborator_user_id integer NOT NULL,
+  invited_by integer NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  created_at timestamp without time zone NOT NULL,
+  updated_at timestamp without time zone NOT NULL,
+  txhash character varying NOT NULL,
+  blocknumber integer,
+  CONSTRAINT track_collaborators_pkey PRIMARY KEY (track_id, collaborator_user_id),
+  CONSTRAINT track_collaborators_status_check CHECK (status IN ('pending', 'accepted', 'rejected'))
+);
+
+-- Profile / dashboard merge (hot path): fetch a user's accepted collaborations
+-- fast. Covering (track_id included) so the lookup is index-only.
+CREATE INDEX IF NOT EXISTS idx_track_collaborators_collaborator
+  ON track_collaborators (collaborator_user_id, status, track_id);
+
+-- Track render: list a track's collaborators.
+CREATE INDEX IF NOT EXISTS idx_track_collaborators_track
+  ON track_collaborators (track_id);

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -84,6 +84,8 @@ func (e *Indexer) Run() error {
 		e.dispatcher.Register(em.TrackDownload())
 		e.dispatcher.Register(em.TrackMute())
 		e.dispatcher.Register(em.TrackUnmute())
+		e.dispatcher.Register(em.TrackCollaboratorApprove())
+		e.dispatcher.Register(em.TrackCollaboratorReject())
 	}
 	if e.config.IsDataTypeEnabled(em.EntityTypePlaylist) {
 		e.dispatcher.Register(em.PlaylistCreate())

--- a/pkg/etl/processors/entity_manager/handler.go
+++ b/pkg/etl/processors/entity_manager/handler.go
@@ -46,6 +46,7 @@ const (
 	EntityTypeEmailAccess               = "EmailAccess"
 	EntityTypeEvent                     = "Event"
 	EntityTypeShare                     = "Share"
+	EntityTypeTrackCollaborator         = "TrackCollaborator"
 )
 
 // Action constants.

--- a/pkg/etl/processors/entity_manager/track_collaborator_approve.go
+++ b/pkg/etl/processors/entity_manager/track_collaborator_approve.go
@@ -1,0 +1,73 @@
+package entity_manager
+
+import (
+	"context"
+
+	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+)
+
+// A collaborator accepts or declines a track invite via a TrackCollaborator
+// Approve/Reject ManageEntity tx: entity_id = track_id, and the signing
+// user_id is the collaborator. Mirrors the Grant Approve/Reject flow — only a
+// 'pending' invite can transition, and only by the invited collaborator.
+
+type trackCollaboratorApproveHandler struct{}
+
+func (h *trackCollaboratorApproveHandler) EntityType() string { return EntityTypeTrackCollaborator }
+func (h *trackCollaboratorApproveHandler) Action() string     { return ActionApprove }
+
+func (h *trackCollaboratorApproveHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateTrackCollaboratorPending(ctx, params); err != nil {
+		return err
+	}
+	return setTrackCollaboratorStatus(ctx, params, "accepted")
+}
+
+type trackCollaboratorRejectHandler struct{}
+
+func (h *trackCollaboratorRejectHandler) EntityType() string { return EntityTypeTrackCollaborator }
+func (h *trackCollaboratorRejectHandler) Action() string     { return ActionReject }
+
+func (h *trackCollaboratorRejectHandler) Handle(ctx context.Context, params *Params) error {
+	if err := validateTrackCollaboratorPending(ctx, params); err != nil {
+		return err
+	}
+	return setTrackCollaboratorStatus(ctx, params, "rejected")
+}
+
+func validateTrackCollaboratorPending(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+	status, err := getTrackCollaboratorStatus(ctx, params.DBTX, params.EntityID, params.UserID)
+	if err != nil {
+		return NewValidationError("no collaborator invite for track %d and user %d", params.EntityID, params.UserID)
+	}
+	if status != "pending" {
+		return NewValidationError("collaborator invite for track %d and user %d is not pending (status=%s)", params.EntityID, params.UserID, status)
+	}
+	return nil
+}
+
+func getTrackCollaboratorStatus(ctx context.Context, dbtx db.DBTX, trackID, collaboratorUserID int64) (string, error) {
+	var status string
+	err := dbtx.QueryRow(ctx,
+		"SELECT status FROM track_collaborators WHERE track_id = $1 AND collaborator_user_id = $2",
+		trackID, collaboratorUserID).Scan(&status)
+	return status, err
+}
+
+func setTrackCollaboratorStatus(ctx context.Context, params *Params, status string) error {
+	_, err := params.DBTX.Exec(ctx, `
+		UPDATE track_collaborators
+		SET status = $3, updated_at = $4
+		WHERE track_id = $1 AND collaborator_user_id = $2
+	`, params.EntityID, params.UserID, status, params.BlockTime)
+	return err
+}
+
+// TrackCollaboratorApprove returns the TrackCollaborator Approve handler.
+func TrackCollaboratorApprove() Handler { return &trackCollaboratorApproveHandler{} }
+
+// TrackCollaboratorReject returns the TrackCollaborator Reject handler.
+func TrackCollaboratorReject() Handler { return &trackCollaboratorRejectHandler{} }

--- a/pkg/etl/processors/entity_manager/track_collaborator_test.go
+++ b/pkg/etl/processors/entity_manager/track_collaborator_test.go
@@ -1,0 +1,215 @@
+package entity_manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestTrackCollaboratorApprove_TxType(t *testing.T) {
+	h := TrackCollaboratorApprove()
+	if h.EntityType() != EntityTypeTrackCollaborator {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeTrackCollaborator)
+	}
+	if h.Action() != ActionApprove {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionApprove)
+	}
+}
+
+func TestTrackCollaboratorReject_TxType(t *testing.T) {
+	h := TrackCollaboratorReject()
+	if h.EntityType() != EntityTypeTrackCollaborator {
+		t.Errorf("EntityType() = %q, want %q", h.EntityType(), EntityTypeTrackCollaborator)
+	}
+	if h.Action() != ActionReject {
+		t.Errorf("Action() = %q, want %q", h.Action(), ActionReject)
+	}
+}
+
+// getCollaboratorUserIDs is pure (no DB), so this runs without ETL_TEST_DB_URL.
+func TestGetCollaboratorUserIDs(t *testing.T) {
+	owner := int64(UserIDOffset + 1)
+	tests := []struct {
+		name string
+		meta map[string]any
+		want []int64
+	}{
+		{"nil metadata", nil, nil},
+		{"absent key", map[string]any{"title": "x"}, nil},
+		{"not an array", map[string]any{"collaborators": "nope"}, nil},
+		{
+			"numeric ids, excludes owner + dedups",
+			map[string]any{"collaborators": []any{float64(owner), float64(UserIDOffset + 2), float64(UserIDOffset + 2), float64(UserIDOffset + 3)}},
+			[]int64{UserIDOffset + 2, UserIDOffset + 3},
+		},
+		{
+			"object entries with user_id",
+			map[string]any{"collaborators": []any{
+				map[string]any{"user_id": float64(UserIDOffset + 5)},
+				map[string]any{"user_id": float64(UserIDOffset + 6)},
+			}},
+			[]int64{UserIDOffset + 5, UserIDOffset + 6},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getCollaboratorUserIDs(tc.meta, owner)
+			if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// statusOf returns the stored status, or "" if absent.
+func statusOf(t *testing.T, pool *pgxpool.Pool, trackID, collaboratorUserID int64) string {
+	t.Helper()
+	var status string
+	err := pool.QueryRow(context.Background(),
+		"SELECT status FROM track_collaborators WHERE track_id = $1 AND collaborator_user_id = $2",
+		trackID, collaboratorUserID).Scan(&status)
+	if err != nil {
+		return ""
+	}
+	return status
+}
+
+func TestTrackCollaborators_CreateInsertsPending(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	c1 := int64(UserIDOffset + 2)
+	c2 := int64(UserIDOffset + 3)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, c1, "0xc1", "collab1")
+	seedUser(t, pool, c2, "0xc2", "collab2")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song","collaborators":[%d,%d]}`, owner, c1, c2)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	if got := statusOf(t, pool, tid, c1); got != "pending" {
+		t.Errorf("c1 status = %q, want pending", got)
+	}
+	if got := statusOf(t, pool, tid, c2); got != "pending" {
+		t.Errorf("c2 status = %q, want pending", got)
+	}
+	// Owner is never recorded as a collaborator of their own track.
+	if got := statusOf(t, pool, tid, owner); got != "" {
+		t.Errorf("owner should not be a collaborator, got %q", got)
+	}
+}
+
+func TestTrackCollaborator_ApproveAndReject(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	c1 := int64(UserIDOffset + 2)
+	c2 := int64(UserIDOffset + 3)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, c1, "0xc1", "collab1")
+	seedUser(t, pool, c2, "0xc2", "collab2")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song","collaborators":[%d,%d]}`, owner, c1, c2)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	// c1 accepts.
+	mustHandle(t, TrackCollaboratorApprove(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionApprove, c1, tid, "0xc1", ""))
+	if got := statusOf(t, pool, tid, c1); got != "accepted" {
+		t.Errorf("c1 status = %q, want accepted", got)
+	}
+
+	// c2 declines.
+	mustHandle(t, TrackCollaboratorReject(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionReject, c2, tid, "0xc2", ""))
+	if got := statusOf(t, pool, tid, c2); got != "rejected" {
+		t.Errorf("c2 status = %q, want rejected", got)
+	}
+}
+
+func TestTrackCollaborator_ApproveWithoutInviteRejected(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	stranger := int64(UserIDOffset + 9)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, stranger, "0xstranger", "stranger")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song"}`, owner)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	mustReject(t, TrackCollaboratorApprove(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionApprove, stranger, tid, "0xstranger", ""),
+		"no collaborator invite")
+}
+
+func TestTrackCollaborator_AlreadyAcceptedNotPending(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	c1 := int64(UserIDOffset + 2)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, c1, "0xc1", "collab1")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song","collaborators":[%d]}`, owner, c1)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	mustHandle(t, TrackCollaboratorApprove(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionApprove, c1, tid, "0xc1", ""))
+	// A second approve must fail — the invite is no longer pending.
+	mustReject(t, TrackCollaboratorApprove(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionApprove, c1, tid, "0xc1", ""),
+		"not pending")
+}
+
+func TestTrackCollaborators_UpdateReconciles(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	c1 := int64(UserIDOffset + 2)
+	c2 := int64(UserIDOffset + 3)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, c1, "0xc1", "collab1")
+	seedUser(t, pool, c2, "0xc2", "collab2")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song","collaborators":[%d,%d]}`, owner, c1, c2)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	// c1 accepts.
+	mustHandle(t, TrackCollaboratorApprove(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionApprove, c1, tid, "0xc1", ""))
+
+	// Owner edits the track, dropping c2 and keeping c1.
+	updateMeta := fmt.Sprintf(`{"owner_id":%d,"collaborators":[%d]}`, owner, c1)
+	mustHandle(t, TrackUpdate(), buildParams(t, pool, EntityTypeTrack, ActionUpdate, owner, tid, "0xowner", updateMeta))
+
+	// c1's accepted status is preserved; c2 is removed.
+	if got := statusOf(t, pool, tid, c1); got != "accepted" {
+		t.Errorf("c1 status = %q, want accepted (preserved)", got)
+	}
+	if got := statusOf(t, pool, tid, c2); got != "" {
+		t.Errorf("c2 should be removed, got %q", got)
+	}
+}
+
+func TestTrackCollaborators_UpdateWithoutKeyLeavesRowsUntouched(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	c1 := int64(UserIDOffset + 2)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, c1, "0xc1", "collab1")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song","collaborators":[%d]}`, owner, c1)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	// Unrelated edit (no collaborators key) must not clear collaborators.
+	updateMeta := fmt.Sprintf(`{"owner_id":%d,"mood":"Energizing"}`, owner)
+	mustHandle(t, TrackUpdate(), buildParams(t, pool, EntityTypeTrack, ActionUpdate, owner, tid, "0xowner", updateMeta))
+
+	if got := statusOf(t, pool, tid, c1); got != "pending" {
+		t.Errorf("c1 status = %q, want pending (untouched)", got)
+	}
+}

--- a/pkg/etl/processors/entity_manager/track_collaborators.go
+++ b/pkg/etl/processors/entity_manager/track_collaborators.go
@@ -1,0 +1,88 @@
+package entity_manager
+
+import (
+	"context"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
+)
+
+// updateTrackCollaboratorsTable reconciles a track's collaborator invites
+// against the `collaborators` list in track metadata. Newly listed users are
+// inserted as 'pending'; existing rows keep their status (an already-'accepted'
+// collaborator is NOT reset to 'pending'); users dropped from the list are
+// removed.
+//
+// Callers must only invoke this when the metadata explicitly carries the
+// `collaborators` key (always on Create; on Update only when present), so that
+// unrelated track edits never clear collaborators. The owner is never recorded
+// as a collaborator of their own track.
+func updateTrackCollaboratorsTable(ctx context.Context, dbtx db.DBTX, trackID, ownerID int64, metadata map[string]any, blockTime time.Time, txHash string, blockNumber int64) error {
+	desired := getCollaboratorUserIDs(metadata, ownerID)
+
+	// Remove collaborators the owner no longer lists.
+	if len(desired) == 0 {
+		_, err := dbtx.Exec(ctx, "DELETE FROM track_collaborators WHERE track_id = $1", trackID)
+		return err
+	}
+	if _, err := dbtx.Exec(ctx,
+		"DELETE FROM track_collaborators WHERE track_id = $1 AND collaborator_user_id <> ALL($2::int[])",
+		trackID, desired); err != nil {
+		return err
+	}
+
+	// Upsert each desired collaborator as pending, preserving any existing
+	// status (DO NOTHING leaves an already accepted/rejected row untouched).
+	for _, uid := range desired {
+		if _, err := dbtx.Exec(ctx, `
+			INSERT INTO track_collaborators (
+				track_id, collaborator_user_id, invited_by, status,
+				created_at, updated_at, txhash, blocknumber
+			) VALUES ($1, $2, $3, 'pending', $4, $4, $5, $6)
+			ON CONFLICT (track_id, collaborator_user_id) DO NOTHING
+		`, trackID, uid, ownerID, blockTime, txHash, blockNumber); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getCollaboratorUserIDs extracts collaborator user IDs from track metadata's
+// `collaborators` array, excluding the owner and de-duplicating. Array entries
+// may be bare numeric IDs or objects carrying a `user_id` field.
+func getCollaboratorUserIDs(metadata map[string]any, ownerID int64) []int64 {
+	if metadata == nil {
+		return nil
+	}
+	raw, ok := metadata["collaborators"]
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	seen := make(map[int64]bool)
+	var ids []int64
+	for _, item := range list {
+		var id int64
+		switch v := item.(type) {
+		case float64:
+			id = int64(v)
+		case int:
+			id = int64(v)
+		case int64:
+			id = v
+		case map[string]any:
+			if n, ok := metadataMapInt64(v, "user_id"); ok {
+				id = n
+			}
+		}
+		if id == 0 || id == ownerID || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/pkg/etl/processors/entity_manager/track_create.go
+++ b/pkg/etl/processors/entity_manager/track_create.go
@@ -198,6 +198,9 @@ func insertTrackAndRoute(ctx context.Context, params *Params) error {
 	if err := updateRemixesTable(ctx, params.DBTX, params.EntityID, params.Metadata); err != nil {
 		return err
 	}
+	if err := updateTrackCollaboratorsTable(ctx, params.DBTX, params.EntityID, params.UserID, params.Metadata, params.BlockTime, params.TxHash, params.BlockNumber); err != nil {
+		return err
+	}
 	if err := autoSubscribeToContestOnSubmission(ctx, params); err != nil {
 		return err
 	}

--- a/pkg/etl/processors/entity_manager/track_update.go
+++ b/pkg/etl/processors/entity_manager/track_update.go
@@ -78,6 +78,13 @@ func updateTrack(ctx context.Context, params *Params) error {
 			return err
 		}
 	}
+	// Only reconcile collaborators when the owner explicitly sends the list,
+	// so unrelated metadata edits never clear existing collaborators.
+	if _, ok := params.Metadata["collaborators"]; ok {
+		if err := updateTrackCollaboratorsTable(ctx, params.DBTX, params.EntityID, merged.OwnerID, params.Metadata, params.BlockTime, params.TxHash, params.BlockNumber); err != nil {
+			return err
+		}
+	}
 	if err := updateTrackPriceHistory(ctx, params.DBTX, params.EntityID, params.BlockNumber, params.BlockTime, params.Metadata); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Add `TrackCollaborator` to the entity manager spec

Introduces **collaborative tracks** as a first-class concept in the OpenAudio entity manager. A track can credit multiple collaborating artists, and each credited artist explicitly **accepts or declines** the credit — a pending → accepted/rejected handshake, modeled on existing pending/approved patterns in the entity manager (e.g. grants).

This is a self-contained indexing addition: it defines the on-chain entity semantics and the indexed data model. Any consumer of the ETL database can read accepted collaborations however it chooses.

### Entity manager semantics
- **Invite (owner-driven):** the track owner lists collaborators in Track `Create`/`Update` metadata as `collaborators: [user_id, ...]`. The Track handlers reconcile that list into `track_collaborators` rows with status `pending`.
- **Accept / decline (collaborator-driven):** a new `TrackCollaborator` entity type with `Approve` and `Reject` actions, signed by the invited collaborator (`entity_id = track_id`). Only a `pending` invite can transition, and only by the invitee.
- **Reconciliation rules:** an already-`accepted` collaborator is preserved across unrelated track edits; on `Update`, reconciliation runs only when the `collaborators` key is present (the same guard the remix list uses); the owner is never recorded as a collaborator of their own track.

### Data model
`track_collaborators` (migration `0033`): `(track_id, collaborator_user_id, invited_by, status, …)` with `status ∈ {pending, accepted, rejected}`. Indexes:
- covering `(collaborator_user_id, status, track_id)` — index-only lookup of a user's accepted collaborations;
- `(track_id)` — per-track collaborator reads.

### Why no core changes
`validateManageEntity` passes arbitrary entity types/actions through to the chain (`pkg/core/server/manage_entity.go`); the entity manager interprets them at index time. So a new entity type is purely an ETL/indexing concern.

### Tests
`pkg/etl/processors/entity_manager/track_collaborator_test.go` covers: create inserts pending, approve/reject transitions, approve-without-invite rejected, double-approve rejected, update reconcile (drop preserves accepted), and update-without-key leaves rows untouched. The full `entity_manager` suite passes against Postgres 15.