### PR TITLE
refactor(etl): tighten track_collaborators reconcile

### DIFF
--- a/pkg/etl/db/sql/migrations/0033_track_collaborators.up.sql
+++ b/pkg/etl/db/sql/migrations/0033_track_collaborators.up.sql
@@ -22,11 +22,8 @@ CREATE TABLE IF NOT EXISTS track_collaborators (
   CONSTRAINT track_collaborators_status_check CHECK (status IN ('pending', 'accepted', 'rejected'))
 );
 
--- Profile / dashboard merge (hot path): fetch a user's accepted collaborations
--- fast. Covering (track_id included) so the lookup is index-only.
+-- Fetch a user's accepted collaborations fast. Covering (track_id included) so
+-- the lookup is index-only. Per-track reads (WHERE track_id = ?) are already
+-- served by the primary key, whose leading column is track_id.
 CREATE INDEX IF NOT EXISTS idx_track_collaborators_collaborator
   ON track_collaborators (collaborator_user_id, status, track_id);
-
--- Track render: list a track's collaborators.
-CREATE INDEX IF NOT EXISTS idx_track_collaborators_track
-  ON track_collaborators (track_id);

--- a/pkg/etl/processors/entity_manager/handler.go
+++ b/pkg/etl/processors/entity_manager/handler.go
@@ -96,6 +96,11 @@ const (
 	CharacterLimitCommentBody = 400
 )
 
+// MaxTrackCollaborators bounds how many collaborators a single track may invite,
+// so a malformed or hostile metadata blob can't enqueue an unbounded number of
+// rows. Excess entries beyond the cap are ignored.
+const MaxTrackCollaborators = 50
+
 // ValidationError indicates a transaction should be skipped (not a fatal indexing error).
 type ValidationError struct {
 	msg string

--- a/pkg/etl/processors/entity_manager/track_collaborator_test.go
+++ b/pkg/etl/processors/entity_manager/track_collaborator_test.go
@@ -63,6 +63,18 @@ func TestGetCollaboratorUserIDs(t *testing.T) {
 	}
 }
 
+func TestGetCollaboratorUserIDs_Capped(t *testing.T) {
+	owner := int64(UserIDOffset + 1)
+	var raw []any
+	for i := 0; i < MaxTrackCollaborators+10; i++ {
+		raw = append(raw, float64(UserIDOffset+100+i))
+	}
+	got := getCollaboratorUserIDs(map[string]any{"collaborators": raw}, owner)
+	if len(got) != MaxTrackCollaborators {
+		t.Errorf("len(got) = %d, want capped at %d", len(got), MaxTrackCollaborators)
+	}
+}
+
 // statusOf returns the stored status, or "" if absent.
 func statusOf(t *testing.T, pool *pgxpool.Pool, trackID, collaboratorUserID int64) string {
 	t.Helper()

--- a/pkg/etl/processors/entity_manager/track_collaborators.go
+++ b/pkg/etl/processors/entity_manager/track_collaborators.go
@@ -18,33 +18,32 @@ import (
 // unrelated track edits never clear collaborators. The owner is never recorded
 // as a collaborator of their own track.
 func updateTrackCollaboratorsTable(ctx context.Context, dbtx db.DBTX, trackID, ownerID int64, metadata map[string]any, blockTime time.Time, txHash string, blockNumber int64) error {
+	// Non-nil so an empty list encodes as '{}' (not NULL) below, which clears
+	// all collaborators rather than matching nothing.
 	desired := getCollaboratorUserIDs(metadata, ownerID)
-
-	// Remove collaborators the owner no longer lists.
-	if len(desired) == 0 {
-		_, err := dbtx.Exec(ctx, "DELETE FROM track_collaborators WHERE track_id = $1", trackID)
-		return err
+	if desired == nil {
+		desired = []int64{}
 	}
+
+	// Drop collaborators the owner no longer lists.
 	if _, err := dbtx.Exec(ctx,
 		"DELETE FROM track_collaborators WHERE track_id = $1 AND collaborator_user_id <> ALL($2::int[])",
 		trackID, desired); err != nil {
 		return err
 	}
 
-	// Upsert each desired collaborator as pending, preserving any existing
-	// status (DO NOTHING leaves an already accepted/rejected row untouched).
-	for _, uid := range desired {
-		if _, err := dbtx.Exec(ctx, `
-			INSERT INTO track_collaborators (
-				track_id, collaborator_user_id, invited_by, status,
-				created_at, updated_at, txhash, blocknumber
-			) VALUES ($1, $2, $3, 'pending', $4, $4, $5, $6)
-			ON CONFLICT (track_id, collaborator_user_id) DO NOTHING
-		`, trackID, uid, ownerID, blockTime, txHash, blockNumber); err != nil {
-			return err
-		}
-	}
-	return nil
+	// Add newly listed collaborators as pending; ON CONFLICT DO NOTHING leaves
+	// an already accepted/rejected/pending row untouched.
+	_, err := dbtx.Exec(ctx, `
+		INSERT INTO track_collaborators (
+			track_id, collaborator_user_id, invited_by, status,
+			created_at, updated_at, txhash, blocknumber
+		)
+		SELECT $1, uid, $3, 'pending', $4, $4, $5, $6
+		FROM unnest($2::int[]) AS uid
+		ON CONFLICT (track_id, collaborator_user_id) DO NOTHING
+	`, trackID, desired, ownerID, blockTime, txHash, blockNumber)
+	return err
 }
 
 // getCollaboratorUserIDs extracts collaborator user IDs from track metadata's
@@ -83,6 +82,9 @@ func getCollaboratorUserIDs(metadata map[string]any, ownerID int64) []int64 {
 		}
 		seen[id] = true
 		ids = append(ids, id)
+		if len(ids) >= MaxTrackCollaborators {
+			break
+		}
 	}
 	return ids
 }


### PR DESCRIPTION
Follow-up to #345. Small cleanup from review of the `TrackCollaborator` entity — leaner production code, plus a guard against pathological input.

### Changes
- **Drop the redundant `(track_id)` index.** The primary key is `(track_id, collaborator_user_id)`, so its btree already serves `WHERE track_id = ?` (leading column). The separate index was pure write overhead.
- **Batch the insert + cap the list.** The reconcile replaced a per-collaborator `INSERT` loop with a single `INSERT … SELECT unnest($1)`, and now caps the list at `MaxTrackCollaborators` (50). A malformed or hostile track-metadata blob can no longer enqueue an unbounded number of rows / statements inside the block tx.
- **Collapse the empty-list special case.** `col <> ALL('{}')` already deletes every row for the track, so the dedicated empty-list `DELETE` is gone; `nil` is normalized to `[]int64{}` so it encodes as an empty array (`'{}'`) rather than `NULL`.

Net effect on the reconcile path and migration is a smaller diff; the line count only ticks up because of an added cap test and the safety constant.

### Deliberately not included
Validating that each collaborator ID is a real, existing user (as grant-create does for the grantee) was left out on purpose — it would add a per-ID lookup on the indexing hot path, and an invite to a nonexistent user simply stays `pending` forever and surfaces nowhere. Happy to add it if reviewers prefer parity with grants.

### Tests
Existing `track_collaborator_test.go` DB cases still pass (incl. empty-list-clears via the general DELETE), plus a new `TestGetCollaboratorUserIDs_Capped`. Full `entity_manager` suite green against Postgres 15.