### PR TITLE
feat(etl): let a collaborator leave a track after accepting

### DIFF
--- a/pkg/etl/processors/entity_manager/track_collaborator_approve.go
+++ b/pkg/etl/processors/entity_manager/track_collaborator_approve.go
@@ -6,10 +6,13 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
 )
 
-// A collaborator accepts or declines a track invite via a TrackCollaborator
-// Approve/Reject ManageEntity tx: entity_id = track_id, and the signing
-// user_id is the collaborator. Mirrors the Grant Approve/Reject flow — only a
-// 'pending' invite can transition, and only by the invited collaborator.
+// A collaborator manages a track credit via a TrackCollaborator Approve/Reject
+// ManageEntity tx: entity_id = track_id, and the signing user_id is the
+// collaborator. Approve accepts a pending invite (pending -> accepted). Reject
+// covers both declining a pending invite and leaving an already-accepted track
+// (pending|accepted -> rejected) — so a collaborator can always remove
+// themselves. The owner removes a collaborator separately, by dropping them
+// from the track metadata (reconciled in updateTrackCollaboratorsTable).
 
 type trackCollaboratorApproveHandler struct{}
 
@@ -29,12 +32,14 @@ func (h *trackCollaboratorRejectHandler) EntityType() string { return EntityType
 func (h *trackCollaboratorRejectHandler) Action() string     { return ActionReject }
 
 func (h *trackCollaboratorRejectHandler) Handle(ctx context.Context, params *Params) error {
-	if err := validateTrackCollaboratorPending(ctx, params); err != nil {
+	if err := validateTrackCollaboratorActive(ctx, params); err != nil {
 		return err
 	}
 	return setTrackCollaboratorStatus(ctx, params, "rejected")
 }
 
+// validateTrackCollaboratorPending permits a transition only from a pending
+// invite (used by Approve).
 func validateTrackCollaboratorPending(ctx context.Context, params *Params) error {
 	if err := ValidateSigner(ctx, params); err != nil {
 		return err
@@ -45,6 +50,22 @@ func validateTrackCollaboratorPending(ctx context.Context, params *Params) error
 	}
 	if status != "pending" {
 		return NewValidationError("collaborator invite for track %d and user %d is not pending (status=%s)", params.EntityID, params.UserID, status)
+	}
+	return nil
+}
+
+// validateTrackCollaboratorActive permits a Reject from either a pending invite
+// (decline) or an accepted credit (the collaborator leaving the track).
+func validateTrackCollaboratorActive(ctx context.Context, params *Params) error {
+	if err := ValidateSigner(ctx, params); err != nil {
+		return err
+	}
+	status, err := getTrackCollaboratorStatus(ctx, params.DBTX, params.EntityID, params.UserID)
+	if err != nil {
+		return NewValidationError("no collaborator invite for track %d and user %d", params.EntityID, params.UserID)
+	}
+	if status != "pending" && status != "accepted" {
+		return NewValidationError("collaborator credit for track %d and user %d is not active (status=%s)", params.EntityID, params.UserID, status)
 	}
 	return nil
 }

--- a/pkg/etl/processors/entity_manager/track_collaborator_test.go
+++ b/pkg/etl/processors/entity_manager/track_collaborator_test.go
@@ -176,6 +176,37 @@ func TestTrackCollaborator_AlreadyAcceptedNotPending(t *testing.T) {
 		"not pending")
 }
 
+// A collaborator can leave a track after accepting: Reject works from accepted.
+func TestTrackCollaborator_LeaveAfterAccept(t *testing.T) {
+	pool := setupTestDB(t)
+	owner := int64(UserIDOffset + 1)
+	c1 := int64(UserIDOffset + 2)
+	seedUser(t, pool, owner, "0xowner", "owner")
+	seedUser(t, pool, c1, "0xc1", "collab1")
+
+	tid := int64(TrackIDOffset + 1)
+	meta := fmt.Sprintf(`{"owner_id":%d,"title":"Song","collaborators":[%d]}`, owner, c1)
+	mustHandle(t, TrackCreate(), buildParams(t, pool, EntityTypeTrack, ActionCreate, owner, tid, "0xowner", meta))
+
+	mustHandle(t, TrackCollaboratorApprove(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionApprove, c1, tid, "0xc1", ""))
+	if got := statusOf(t, pool, tid, c1); got != "accepted" {
+		t.Fatalf("setup: c1 status = %q, want accepted", got)
+	}
+
+	// The collaborator removes themselves.
+	mustHandle(t, TrackCollaboratorReject(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionReject, c1, tid, "0xc1", ""))
+	if got := statusOf(t, pool, tid, c1); got != "rejected" {
+		t.Errorf("after leave: c1 status = %q, want rejected", got)
+	}
+
+	// Leaving again fails — no longer active.
+	mustReject(t, TrackCollaboratorReject(),
+		buildParams(t, pool, EntityTypeTrackCollaborator, ActionReject, c1, tid, "0xc1", ""),
+		"not active")
+}
+
 func TestTrackCollaborators_UpdateReconciles(t *testing.T) {
 	pool := setupTestDB(t)
 	owner := int64(UserIDOffset + 1)


### PR DESCRIPTION
Follow-up to #345/#346. Closes a gap in the `TrackCollaborator` lifecycle: an accepted collaborator could not remove themselves.

`Reject` previously required a `pending` invite. It now permits a transition from **pending** (decline an invite) or **accepted** (leave a track you'd joined) → `rejected`. `Approve` still requires a pending invite, and the owner-side removal path (dropping a collaborator from track metadata, reconciled in `updateTrackCollaboratorsTable`) is unchanged.

Only `accepted` rows surface a track on a profile/dashboard, so leaving (→ `rejected`) cleanly drops the credit everywhere downstream.

### Tests
Adds `TestTrackCollaborator_LeaveAfterAccept`: accept → leave (reject from accepted) → `rejected`, and leaving again fails ("not active"). Full `entity_manager` suite passes against Postgres 15.