### PR TITLE
fix(etl): persist dev-app image_url; rune-count video_url/redirect_uri

### DIFF
--- a/pkg/etl/processors/entity_manager/comment_create.go
+++ b/pkg/etl/processors/entity_manager/comment_create.go
@@ -166,7 +166,7 @@ func validateCommentWrite(ctx context.Context, params *Params, isCreate bool) er
 			return NewValidationError("is_members_only requires entity_type=FanClub (got %q)", etCheck)
 		}
 	}
-	if v := params.MetadataString("video_url"); len(v) > 2000 {
+	if v := params.MetadataString("video_url"); utf8.RuneCountInString(v) > 2000 {
 		return NewValidationError("video_url exceeds 2000 character limit")
 	}
 

--- a/pkg/etl/processors/entity_manager/developer_app_create.go
+++ b/pkg/etl/processors/entity_manager/developer_app_create.go
@@ -2,6 +2,7 @@ package entity_manager
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 )
@@ -10,6 +11,22 @@ const (
 	CharacterLimitAppName        = 50
 	CharacterLimitAppDescription = 160
 )
+
+// devAppImageURLRegexp mirrors the legacy indexer's is_fqdn check
+// (discovery-provider src/utils/helpers.py): a developer app image_url is only
+// persisted when it is a valid fully-qualified URL/host.
+var devAppImageURLRegexp = regexp.MustCompile(`^(?:^|[ \t])((https?://)?(?:localhost|(cn[0-9]_creator-node_1:[0-9]+)|(audius-protocol-creator-node-[0-9])|(audius-protocol-discovery-provider-[0-9])|[\w-]+(?:\.[\w-]+)+)(:\d+)?(/\S*)?)$`)
+
+// validatedAppImageURL returns the metadata image_url when it passes the FQDN
+// check, else "" (persisted as NULL). Matches the legacy indexer, which sets
+// image_url from metadata on both create and update (None when absent/invalid).
+func validatedAppImageURL(params *Params) string {
+	img := params.MetadataString("image_url")
+	if img != "" && devAppImageURLRegexp.MatchString(img) {
+		return img
+	}
+	return ""
+}
 
 type developerAppCreateHandler struct{}
 
@@ -76,18 +93,20 @@ func insertDeveloperApp(ctx context.Context, params *Params) error {
 	address := strings.ToLower(params.MetadataString("address"))
 	name := params.MetadataString("name")
 	description := params.MetadataString("description")
+	imageURL := validatedAppImageURL(params)
 	isPersonalAccess := params.MetadataBoolOr("is_personal_access", false)
 
 	_, err := params.DBTX.Exec(ctx, `
 		INSERT INTO developer_apps (
-			address, user_id, name, description, is_personal_access,
+			address, user_id, name, description, image_url, is_personal_access,
 			is_current, is_delete, created_at, updated_at, txhash, blocknumber
-		) VALUES ($1, $2, $3, $4, $5, true, false, $6, $6, $7, $8)
+		) VALUES ($1, $2, $3, $4, $5, $6, true, false, $7, $7, $8, $9)
 	`,
 		address,
 		params.UserID,
 		name,
 		nullString(description),
+		nullString(imageURL),
 		isPersonalAccess,
 		params.BlockTime,
 		params.TxHash,

--- a/pkg/etl/processors/entity_manager/developer_app_update.go
+++ b/pkg/etl/processors/entity_manager/developer_app_update.go
@@ -72,6 +72,7 @@ func updateDeveloperApp(ctx context.Context, params *Params) error {
 	address := strings.ToLower(params.MetadataString("address"))
 	name := params.MetadataString("name")
 	description := params.MetadataString("description")
+	imageURL := validatedAppImageURL(params)
 
 	// Mark current row as not current
 	_, err := params.DBTX.Exec(ctx,
@@ -89,14 +90,15 @@ func updateDeveloperApp(ctx context.Context, params *Params) error {
 
 	_, err = params.DBTX.Exec(ctx, `
 		INSERT INTO developer_apps (
-			address, user_id, name, description, is_personal_access,
+			address, user_id, name, description, image_url, is_personal_access,
 			is_current, is_delete, created_at, updated_at, txhash, blocknumber
-		) VALUES ($1, $2, $3, $4, $5, true, false, $6, $7, $8, $9)
+		) VALUES ($1, $2, $3, $4, $5, $6, true, false, $7, $8, $9, $10)
 	`,
 		address,
 		params.UserID,
 		name,
 		nullString(description),
+		nullString(imageURL),
 		isPersonalAccess,
 		createdAt,
 		params.BlockTime,

--- a/pkg/etl/processors/entity_manager/oauth_redirect_uris.go
+++ b/pkg/etl/processors/entity_manager/oauth_redirect_uris.go
@@ -2,6 +2,7 @@ package entity_manager
 
 import (
 	"context"
+	"unicode/utf8"
 
 	"github.com/OpenAudio/go-openaudio/pkg/etl/db"
 )
@@ -34,7 +35,7 @@ func extractRedirectURIs(metadata map[string]any) (uris []string, present bool, 
 		if !ok {
 			return nil, false, false
 		}
-		if len(s) > MaxRedirectURILength {
+		if utf8.RuneCountInString(s) > MaxRedirectURILength {
 			return nil, false, false
 		}
 		out = append(out, s)

--- a/pkg/etl/processors/entity_manager/parked_findings_test.go
+++ b/pkg/etl/processors/entity_manager/parked_findings_test.go
@@ -1,0 +1,73 @@
+package entity_manager
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Regression: developer app create/update must persist image_url (previously
+// dropped), gated by the legacy is_fqdn check. Update overwrites from metadata.
+func TestDeveloperApp_ImageURL(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	seedUser(t, pool, uid, "0xappowner", "appowner")
+
+	imageURL := func(addr string) sql.NullString {
+		var v sql.NullString
+		if err := pool.QueryRow(context.Background(),
+			"SELECT image_url FROM developer_apps WHERE address=$1 AND is_current=true", addr).Scan(&v); err != nil {
+			t.Fatalf("query image_url(%s): %v", addr, err)
+		}
+		return v
+	}
+
+	// Create with a valid FQDN image_url → stored.
+	mustHandle(t, DeveloperAppCreate(), buildParams(t, pool, EntityTypeDeveloperApp, ActionCreate, uid, 1, "0xAppOwner",
+		`{"address":"0ximgapp","name":"Img App","image_url":"https://cdn.audius.co/icon.png"}`))
+	if got := imageURL("0ximgapp"); !got.Valid || got.String != "https://cdn.audius.co/icon.png" {
+		t.Errorf("create valid image_url: got %v", got)
+	}
+
+	// Update to a new valid image_url → overwritten.
+	mustHandle(t, DeveloperAppUpdate(), buildParams(t, pool, EntityTypeDeveloperApp, ActionUpdate, uid, 1, "0xAppOwner",
+		`{"address":"0ximgapp","name":"Img App","image_url":"https://img.example.com/new.png"}`))
+	if got := imageURL("0ximgapp"); !got.Valid || got.String != "https://img.example.com/new.png" {
+		t.Errorf("update image_url: got %v", got)
+	}
+
+	// Create with an invalid (non-FQDN) image_url → NULL (legacy is_fqdn gate).
+	mustHandle(t, DeveloperAppCreate(), buildParams(t, pool, EntityTypeDeveloperApp, ActionCreate, uid, 2, "0xAppOwner",
+		`{"address":"0xbadimg","name":"Bad Img","image_url":"javascript:alert(1)"}`))
+	if got := imageURL("0xbadimg"); got.Valid {
+		t.Errorf("invalid image_url should be NULL, got %q", got.String)
+	}
+}
+
+// Regression: the comment video_url cap must count runes, not bytes (it claims
+// a "character limit" but used len()). A multibyte URL within 2000 characters
+// but over 2000 bytes must be accepted, not rejected.
+func TestCommentCreate_VideoURLCountsRunes(t *testing.T) {
+	pool := setupTestDB(t)
+	uid := int64(UserIDOffset + 1)
+	trackID := int64(TrackIDOffset + 1)
+	commentID := int64(CommentIDOffset + 60)
+	seedUser(t, pool, uid, "0xvurl", "vurlu")
+	seedTrack(t, pool, trackID, uid)
+
+	// 1500 runes, 4500 bytes: under the 2000-character limit, over 2000 bytes.
+	videoURL := strings.Repeat("✓", 1500)
+	meta := fmt.Sprintf(`{"body":"hi","entity_id":%d,"entity_type":"Track","video_url":%q}`, trackID, videoURL)
+	mustHandle(t, CommentCreate(), buildParams(t, pool, EntityTypeComment, ActionCreate, uid, commentID, "0xVurl", meta))
+
+	var stored string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT video_url FROM comments WHERE comment_id=$1", commentID).Scan(&stored); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if stored != videoURL {
+		t.Errorf("video_url not stored intact (got %d runes)", len([]rune(stored)))
+	}
+}


### PR DESCRIPTION
## Summary

Three audit findings, same families as the prior fixes (dropped field + byte-vs-rune over-strict validation).

### 1. `developer_apps.image_url` — dropped field
Create/update never wrote it; **271 of 1,226** prod dev apps have it set (legacy data). Now persisted on both paths, gated by the legacy `is_fqdn` regex (ported verbatim from `discovery-provider/src/utils/helpers.py`) and overwritten from metadata on update — matching the legacy indexer (`developer_app.py:362,396`), which sets `image_url = metadata or None` on both create and update.

### 2. `comment.video_url` — byte-length cap (over-strict)
`comment_create.go` used `len(v) > 2000` while the error says *"2000 character limit"*. A video URL within 2000 characters but over 2000 bytes (multibyte chars) was rejected, **blocking the whole comment** — the exact class fixed in #340. Now `utf8.RuneCountInString`.

### 3. `oauth_redirect_uris` per-URI cap — byte-length
Same byte-vs-rune issue on the 2000-char per-URI cap (lower impact — drops the field, not the tx). Now rune-counted, completing the cleanup of this class.

## Deliberately NOT changed: `genre` rejection
I'd flagged "invalid genre rejects the whole track vs. ignoring the field" as a possible over-strictness. **Checked the legacy source: it also `raise`s on an out-of-allowlist genre** (`track.py:514-516`). So the Go behavior already matches legacy — switching it to "ignore" would be the regression, not the fix. Left as-is.

## No migration
`image_url` already exists in migration `0002`; the others are validation-only. **Code-only.**

## Test plan
- [x] `go build ./...`, `go vet`, gofmt clean
- [x] Ported FQDN regex sanity-checked (accepts `https://cdn.audius.co/...`, `example.com/a`, `localhost:3000`; rejects `javascript:alert(1)`, plain words, empty)
- [x] DB-backed `TestDeveloperApp_ImageURL` (real Postgres): create stores valid FQDN, update overwrites, invalid (`javascript:`) → NULL
- [x] DB-backed `TestCommentCreate_VideoURLCountsRunes`: a 1500-rune / 4500-byte URL is now accepted and stored intact
- [x] Existing `TestCommentCreate_RejectsOverlongVideoURL` still passes (>2000 *runes* still rejected); full dev-app + comment suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)