### PR TITLE
fix: accept freeform genre strings (remove allowlist enforcement)

### DIFF
--- a/pkg/etl/processors/entity_manager/genre_allowlist.go
+++ b/pkg/etl/processors/entity_manager/genre_allowlist.go
@@ -1,6 +1,8 @@
 package entity_manager
 
-// GenreAllowlist is the set of valid genre strings.
+// GenreAllowlist is the canonical set of genre strings used for autocomplete
+// suggestions in UIs. It is NOT used for validation — the Open Audio Protocol
+// accepts any non-empty genre string up to 100 characters.
 var GenreAllowlist = map[string]struct{}{
 	"Acoustic": {}, "Alternative": {}, "Ambient": {}, "Audiobooks": {}, "Blues": {},
 	"Classical": {}, "Comedy": {}, "Country": {}, "Dancehall": {}, "Deep House": {},

--- a/pkg/etl/processors/entity_manager/track_create_test.go
+++ b/pkg/etl/processors/entity_manager/track_create_test.go
@@ -93,13 +93,13 @@ func TestTrackCreate_StatelessValidation(t *testing.T) {
 			wantErr:    "description exceeds",
 		},
 		{
-			name:       "invalid genre",
+			name:       "genre too long",
 			entityType: EntityTypeTrack,
 			action:     ActionCreate,
 			entityID:   TrackIDOffset + 1,
 			userID:     UserIDOffset + 1,
-			metadata:   `{"owner_id":3000001,"title":"T","genre":"Not A Real Genre"}`,
-			wantErr:    "allow list",
+			metadata:   `{"owner_id":3000001,"title":"T","genre":"` + strings.Repeat("x", 101) + `"}`,
+			wantErr:    "genre exceeds",
 		},
 	}
 

--- a/pkg/etl/processors/entity_manager/validate.go
+++ b/pkg/etl/processors/entity_manager/validate.go
@@ -163,13 +163,16 @@ func isValidMusicalKey(s string) bool {
 	return validMusicalKeys[s]
 }
 
-// ValidateGenre checks genre is in the allowlist.
+// ValidateGenre checks that a genre string is within the 100-character limit.
+// Any non-empty string is accepted; the Open Audio Protocol treats genre as a
+// free-form field at the protocol layer. GenreAllowlist provides canonical
+// autocomplete suggestions for UIs only.
 func ValidateGenre(genre string) error {
 	if genre == "" {
 		return nil
 	}
-	if _, ok := GenreAllowlist[genre]; !ok {
-		return NewValidationError("genre %q is not in the allow list", genre)
+	if utf8.RuneCountInString(genre) > 100 {
+		return NewValidationError("genre exceeds 100 character limit")
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

Freeform genres like "Ambient Drone" were silently discarded. The ETL processor validated genres against a hard-coded allowlist, but the SDK and API layers accept any string up to 100 characters. When a user set a freeform genre:

1. The SDK sent the metadata to the blockchain - accepted
2. block_confirmation returned block_passed: true - the client showed Changes saved!
3. The ETL processor hit ValidateGenre, got a rejection, and returned early without writing to the DB
4. The next refetch returned the old genre value

The failure was completely silent.

## Fix

- validate.go: Replace allowlist check with a 100-character length check, matching the SDK schema (genre: z.string().min(1).max(100))
- genre_allowlist.go: Update comment - the list is for UI autocomplete suggestions only, not enforcement
- track_create_test.go: Update the invalid genre test to validate the length limit instead of the removed allowlist

## Related

Frontend adapter fix: AudiusProject/apps#14465