### PR TITLE
feat(mediorum): add STORE_RECENT storage retention mode

### DIFF
--- a/pkg/mediorum/mediorum.go
+++ b/pkg/mediorum/mediorum.go
@@ -140,6 +140,7 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 	repairEnabled := env.Get("true", "OPENAUDIO_REPAIR_ENABLED") == "true"
 	repairInterval := env.GetDuration(time.Hour, "OPENAUDIO_REPAIR_INTERVAL")
 	repairConcurrency := env.GetInt(1, "OPENAUDIO_REPAIR_CONCURRENCY")
+	storeRecentTTL := parseStoreRecentTTL(env.String("OPENAUDIO_STORE_RECENT_TTL"))
 
 	// Archive mode keeps all history (no ops pruning). Otherwise the append-only
 	// crudr "ops" table is pruned, retaining 1 year by default.
@@ -169,6 +170,8 @@ func runMediorum(lc *lifecycle.Lifecycle, logger *zap.Logger, mediorumEnv string
 		AudiusDockerCompose:       env.String("OPENAUDIO_DOCKER_COMPOSE_GIT_SHA", "AUDIUS_DOCKER_COMPOSE_GIT_SHA"),
 		AutoUpgradeEnabled:        env.Bool("OPENAUDIO_AUTO_UPGRADE_ENABLED", "autoUpgradeEnabled"),
 		StoreAll:                  env.Bool("OPENAUDIO_STORE_ALL", "STORE_ALL"),
+		StoreRecent:               env.Bool("OPENAUDIO_STORE_RECENT"),
+		StoreRecentTTL:            storeRecentTTL,
 		VersionJson:               version.Version,
 		DiscoveryListensEndpoints: discoveryListensEndpoints(),
 		LogLevel:                  env.Get("info", "OPENAUDIO_LOG_LEVEL"),
@@ -197,4 +200,27 @@ func discoveryListensEndpoints() []string {
 		return []string{}
 	}
 	return strings.Split(endpoints, ",")
+}
+
+func parseStoreRecentTTL(raw string) time.Duration {
+	if strings.TrimSpace(raw) == "" {
+		return server.DefaultStoreRecentTTL
+	}
+	d, err := parseStoreRecentDuration(raw)
+	if err != nil {
+		return server.DefaultStoreRecentTTL
+	}
+	return d
+}
+
+func parseStoreRecentDuration(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasSuffix(raw, "d") || strings.HasSuffix(raw, "D") {
+		days, err := strconv.ParseFloat(strings.TrimSpace(raw[:len(raw)-1]), 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(days * float64(24*time.Hour)), nil
+	}
+	return time.ParseDuration(raw)
 }

--- a/pkg/mediorum/mediorum_test.go
+++ b/pkg/mediorum/mediorum_test.go
@@ -1,0 +1,29 @@
+package mediorum
+
+import (
+	"testing"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/mediorum/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseStoreRecentTTL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "unset defaults to one year", raw: "", want: server.DefaultStoreRecentTTL},
+		{name: "go duration still works", raw: "48h", want: 48 * time.Hour},
+		{name: "day suffix works", raw: "365d", want: 365 * 24 * time.Hour},
+		{name: "fractional day suffix works", raw: "1.5d", want: 36 * time.Hour},
+		{name: "invalid defaults to one year", raw: "nope", want: server.DefaultStoreRecentTTL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseStoreRecentTTL(tt.raw))
+		})
+	}
+}

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -33,20 +33,20 @@ type seenKeyResult struct {
 }
 
 type RepairTracker struct {
-	StartedAt      time.Time `gorm:"primaryKey;not null"`
-	UpdatedAt      time.Time `gorm:"not null"`
-	FinishedAt     time.Time
-	CleanupMode    bool           `gorm:"not null"`
-	CursorI        int            `gorm:"not null"`
-	CursorUploadID string         `gorm:"not null"`
-	CursorPreviewCID string       ``
-	CursorQmCID    string         `gorm:"not null"`
-	Counters       map[string]int `gorm:"not null;serializer:json"`
-	ContentSize    int64          `gorm:"not null"`
-	Duration       time.Duration  `gorm:"not null"`
-	AbortedReason  string         `gorm:"not null"`
-	SeenKeys       map[string]seenKeyResult `gorm:"-" json:"-"`
-	mu             *sync.Mutex    `gorm:"-" json:"-"`
+	StartedAt        time.Time `gorm:"primaryKey;not null"`
+	UpdatedAt        time.Time `gorm:"not null"`
+	FinishedAt       time.Time
+	CleanupMode      bool                     `gorm:"not null"`
+	CursorI          int                      `gorm:"not null"`
+	CursorUploadID   string                   `gorm:"not null"`
+	CursorPreviewCID string                   ``
+	CursorQmCID      string                   `gorm:"not null"`
+	Counters         map[string]int           `gorm:"not null;serializer:json"`
+	ContentSize      int64                    `gorm:"not null"`
+	Duration         time.Duration            `gorm:"not null"`
+	AbortedReason    string                   `gorm:"not null"`
+	SeenKeys         map[string]seenKeyResult `gorm:"-" json:"-"`
+	mu               *sync.Mutex              `gorm:"-" json:"-"`
 }
 
 func (ss *MediorumServer) startRepairer(ctx context.Context) error {
@@ -169,6 +169,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 		repairConcurrency = 1
 	}
 	tracker.mu = &sync.Mutex{}
+	retentionPolicy := newRepairRetentionPolicy(ss.Config, time.Now())
 
 	// Build a presence index from bucket listing to avoid per-key HeadObject.
 	// Replaces hundreds of thousands of HeadObject calls with one ListObjects pagination.
@@ -225,7 +226,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			go func() {
 				defer wg.Done()
 				defer func() { <-sem }()
-				ss.repairCid(ctx, u.OrigFileCID, u.PlacementHosts, tracker, presenceIndex)
+				ss.repairCidWithPolicy(ctx, u.OrigFileCID, u.PlacementHosts, tracker, presenceIndex, retentionPolicy, u.CreatedAt)
 				if u.Template != JobTemplateAudio {
 					return
 				}
@@ -233,7 +234,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 					if ctx.Err() != nil {
 						return
 					}
-					ss.repairCid(ctx, cid, u.PlacementHosts, tracker, presenceIndex)
+					ss.repairCidWithPolicy(ctx, cid, u.PlacementHosts, tracker, presenceIndex, retentionPolicy, u.CreatedAt)
 				}
 			}()
 		}
@@ -285,7 +286,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			go func() {
 				defer wg.Done()
 				defer func() { <-sem }()
-				ss.repairCid(ctx, u.CID, nil, tracker, presenceIndex)
+				ss.repairCidWithPolicy(ctx, u.CID, nil, tracker, presenceIndex, retentionPolicy, u.CreatedAt)
 			}()
 		}
 		wg.Wait()
@@ -343,7 +344,7 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 			go func() {
 				defer wg.Done()
 				defer func() { <-sem }()
-				ss.repairCid(ctx, cid, nil, tracker, presenceIndex)
+				ss.repairCidWithPolicy(ctx, cid, nil, tracker, presenceIndex, retentionPolicy, time.Time{})
 			}()
 		}
 		wg.Wait()
@@ -361,6 +362,10 @@ func (ss *MediorumServer) runRepair(ctx context.Context, tracker *RepairTracker)
 }
 
 func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHosts []string, tracker *RepairTracker, presenceIndex *repairPresenceIndex) error {
+	return ss.repairCidWithPolicy(ctx, cid, placementHosts, tracker, presenceIndex, newRepairRetentionPolicy(ss.Config, time.Now()), time.Time{})
+}
+
+func (ss *MediorumServer) repairCidWithPolicy(ctx context.Context, cid string, placementHosts []string, tracker *RepairTracker, presenceIndex *repairPresenceIndex, retentionPolicy repairRetentionPolicy, createdAt time.Time) error {
 	if cid == "" {
 		return nil
 	}
@@ -374,6 +379,10 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	logger := ss.logger.With(zap.String("task", "repair"), zap.String("cid", cid), zap.Bool("cleanup", tracker.CleanupMode))
 
 	preferredHosts, isMine := ss.rendezvousAllHosts(cid)
+	storeRecent := retentionPolicy.shouldStoreRecent(createdAt)
+	if storeRecent {
+		isMine = true
+	}
 
 	// if placementHosts is specified
 	isPlaced := len(placementHosts) > 0
@@ -411,7 +420,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 	if tracker.SeenKeys == nil {
 		tracker.SeenKeys = map[string]seenKeyResult{}
 	}
-	if prev, seen := tracker.SeenKeys[key]; seen {
+	if prev, seen := tracker.SeenKeys[key]; seen && !storeRecent {
 		tracker.Counters["repair_deduped"]++
 		if prev.alreadyHave {
 			tracker.Counters["already_have"]++
@@ -630,7 +639,7 @@ func (ss *MediorumServer) repairCid(ctx context.Context, cid string, placementHo
 		rankThreshold = ss.Config.ReplicationFactor * 2
 	}
 
-	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > rankThreshold && !wasReplicatedThisWeek {
+	if !isPlaced && !ss.Config.StoreAll && !storeRecent && tracker.CleanupMode && alreadyHave && myRank > rankThreshold && !wasReplicatedThisWeek {
 		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
 		tracker.mu.Lock()
 		tracker.Counters["delete_over_replicated_needed"]++

--- a/pkg/mediorum/server/repair_retention.go
+++ b/pkg/mediorum/server/repair_retention.go
@@ -1,0 +1,32 @@
+package server
+
+import "time"
+
+const DefaultStoreRecentTTL = 365 * 24 * time.Hour
+
+type repairRetentionPolicy struct {
+	storeAll    bool
+	storeRecent bool
+	ttl         time.Duration
+	now         time.Time
+}
+
+func newRepairRetentionPolicy(config MediorumConfig, now time.Time) repairRetentionPolicy {
+	ttl := config.StoreRecentTTL
+	if ttl <= 0 {
+		ttl = DefaultStoreRecentTTL
+	}
+	return repairRetentionPolicy{
+		storeAll:    config.StoreAll,
+		storeRecent: config.StoreRecent,
+		ttl:         ttl,
+		now:         now,
+	}
+}
+
+func (p repairRetentionPolicy) shouldStoreRecent(createdAt time.Time) bool {
+	if p.storeAll || !p.storeRecent || createdAt.IsZero() {
+		return false
+	}
+	return !createdAt.Before(p.now.Add(-p.ttl))
+}

--- a/pkg/mediorum/server/repair_retention_test.go
+++ b/pkg/mediorum/server/repair_retention_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/mediorum/cidutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestRepairRetentionPolicyShouldStoreRecent(t *testing.T) {
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		config    MediorumConfig
+		createdAt time.Time
+		want      bool
+	}{
+		{
+			name:      "default settings do not retain recent",
+			config:    MediorumConfig{},
+			createdAt: now,
+			want:      false,
+		},
+		{
+			name:      "store recent retains upload inside ttl",
+			config:    MediorumConfig{StoreRecent: true, StoreRecentTTL: 30 * 24 * time.Hour},
+			createdAt: now.Add(-29 * 24 * time.Hour),
+			want:      true,
+		},
+		{
+			name:      "store recent does not retain upload outside ttl",
+			config:    MediorumConfig{StoreRecent: true, StoreRecentTTL: 30 * 24 * time.Hour},
+			createdAt: now.Add(-31 * 24 * time.Hour),
+			want:      false,
+		},
+		{
+			name:      "store all ignores store recent",
+			config:    MediorumConfig{StoreAll: true, StoreRecent: true, StoreRecentTTL: 30 * 24 * time.Hour},
+			createdAt: now,
+			want:      false,
+		},
+		{
+			name:      "zero timestamp is not retained",
+			config:    MediorumConfig{StoreRecent: true, StoreRecentTTL: 30 * 24 * time.Hour},
+			createdAt: time.Time{},
+			want:      false,
+		},
+		{
+			name:      "zero ttl uses one year default",
+			config:    MediorumConfig{StoreRecent: true},
+			createdAt: now.Add(-364 * 24 * time.Hour),
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := newRepairRetentionPolicy(tt.config, now)
+			assert.Equal(t, tt.want, policy.shouldStoreRecent(tt.createdAt))
+		})
+	}
+}
+
+func TestRepairCidStoreRecentPullsRecentUpload(t *testing.T) {
+	ctx := context.Background()
+	source, target, cid, data := testRepairSourceAndNonPreferredTarget(t, "store-recent-pulls-recent-upload")
+
+	require.NoError(t, source.replicateToMyBucket(ctx, cid, bytes.NewReader(data), nil))
+	require.NoError(t, target.dropFromMyBucket(cid))
+
+	disabledTracker := &RepairTracker{
+		StartedAt:   time.Now(),
+		CleanupMode: false,
+		Counters:    map[string]int{},
+	}
+	disabledPolicy := newRepairRetentionPolicy(MediorumConfig{}, time.Now())
+	require.NoError(t, target.repairCidWithPolicy(ctx, cid, nil, disabledTracker, nil, disabledPolicy, time.Now()))
+	assert.False(t, target.haveInMyBucket(cid))
+
+	recentTracker := &RepairTracker{
+		StartedAt:   time.Now(),
+		CleanupMode: false,
+		Counters:    map[string]int{},
+	}
+	recentPolicy := newRepairRetentionPolicy(MediorumConfig{
+		StoreRecent:    true,
+		StoreRecentTTL: 365 * 24 * time.Hour,
+	}, time.Now())
+	require.NoError(t, target.repairCidWithPolicy(ctx, cid, nil, recentTracker, nil, recentPolicy, time.Now()))
+	assert.True(t, target.haveInMyBucket(cid))
+	assert.Equal(t, 1, recentTracker.Counters["pull_mine_success"])
+}
+
+func TestRepairCidStoreRecentKeepsOverReplicatedRecentUpload(t *testing.T) {
+	ctx := context.Background()
+	_, target, cid, data := testRepairSourceAndNonPreferredTarget(t, "store-recent-keeps-overreplicated-upload")
+
+	require.NoError(t, target.replicateToMyBucket(ctx, cid, bytes.NewReader(data), nil))
+	markLocalBlobOld(t, target, cid, 8*24*time.Hour)
+	target.mediorumPathFree = 0
+	target.mediorumPathSize = 1
+
+	recentPolicy := newRepairRetentionPolicy(MediorumConfig{
+		StoreRecent:    true,
+		StoreRecentTTL: 365 * 24 * time.Hour,
+	}, time.Now())
+	recentTracker := &RepairTracker{
+		StartedAt:   time.Now(),
+		CleanupMode: true,
+		Counters:    map[string]int{},
+	}
+	require.NoError(t, target.repairCidWithPolicy(ctx, cid, nil, recentTracker, nil, recentPolicy, time.Now()))
+	assert.True(t, target.haveInMyBucket(cid))
+	assert.Zero(t, recentTracker.Counters["delete_over_replicated_success"])
+
+	oldPolicy := newRepairRetentionPolicy(MediorumConfig{
+		StoreRecent:    true,
+		StoreRecentTTL: 365 * 24 * time.Hour,
+	}, time.Now())
+	oldTracker := &RepairTracker{
+		StartedAt:   time.Now(),
+		CleanupMode: true,
+		Counters:    map[string]int{},
+	}
+	target.mediorumPathFree = 0
+	target.mediorumPathSize = 1
+	require.NoError(t, target.repairCidWithPolicy(ctx, cid, nil, oldTracker, nil, oldPolicy, time.Now().Add(-366*24*time.Hour)))
+	assert.False(t, target.haveInMyBucket(cid))
+	assert.Equal(t, 1, oldTracker.Counters["delete_over_replicated_success"])
+}
+
+func testRepairSourceAndNonPreferredTarget(t *testing.T, seed string) (*MediorumServer, *MediorumServer, string, []byte) {
+	t.Helper()
+
+	data := []byte(seed)
+	cid, err := cidutil.ComputeFileCID(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	byHost := map[string]*MediorumServer{}
+	for _, s := range testNetwork {
+		byHost[s.Config.Self.Host] = s
+	}
+
+	preferred, _ := testNetwork[0].rendezvousAllHosts(cid)
+	require.Greater(t, len(preferred), testNetwork[0].Config.ReplicationFactor+2)
+
+	source := byHost[preferred[0]]
+	target := byHost[preferred[len(preferred)-1]]
+	require.NotNil(t, source)
+	require.NotNil(t, target)
+	require.Greater(t, slices.Index(preferred, target.Config.Self.Host), target.Config.ReplicationFactor+2)
+
+	return source, target, cid, data
+}
+
+func markLocalBlobOld(t *testing.T, ss *MediorumServer, cid string, age time.Duration) {
+	t.Helper()
+
+	u, err := url.Parse(ss.Config.BlobStoreDSN)
+	require.NoError(t, err)
+
+	key := cidutil.ShardCID(cid)
+	path := filepath.Join(u.Path, filepath.FromSlash(key))
+	old := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, old, old))
+}

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -74,13 +74,15 @@ type MediorumConfig struct {
 	AutoUpgradeEnabled        bool
 	WalletIsRegistered        bool
 	StoreAll                  bool
+	StoreRecent               bool
+	StoreRecentTTL            time.Duration `default:"8760h"`
 	VersionJson               version.VersionJson
 	DiscoveryListensEndpoints []string
 	LogLevel                  string
 	DeadHosts                 []string
-	RepairEnabled              bool          `default:"true"`
-	RepairInterval             time.Duration `default:"1h"`
-	RepairConcurrency          int           `default:"1"`
+	RepairEnabled             bool          `default:"true"`
+	RepairInterval            time.Duration `default:"1h"`
+	RepairConcurrency         int           `default:"1"`
 
 	// Archive mode (OPENAUDIO_ARCHIVE) keeps all history: no core block pruning
 	// and no crudr "ops" pruning. Otherwise ops older than OpsRetention are pruned.
@@ -89,14 +91,13 @@ type MediorumConfig struct {
 	OpsPruneInterval time.Duration `default:"6h"`
 
 	ProgrammableDistributionEnabled bool
-	BlobStorageStreaming             bool
+	BlobStorageStreaming            bool
 
 	// should have a basedir type of thing
 	// by default will put db + blobs there
 
 	privateKey *ecdsa.PrivateKey
 }
-
 
 type MediorumServer struct {
 	lc               *lifecycle.Lifecycle
@@ -190,6 +191,9 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		config.Env = v
 	}
 	config.ProgrammableDistributionEnabled = common.IsProgrammableDistributionEnabled(config.Env)
+	if config.StoreRecentTTL <= 0 {
+		config.StoreRecentTTL = DefaultStoreRecentTTL
+	}
 
 	isAudiusdManaged := env.IsSet("OPENAUDIO_AUDIUS_D_GENERATED", "AUDIUS_D_GENERATED")
 
@@ -408,8 +412,8 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 		bgPullBackoff:        imcache.New(imcache.WithMaxEntriesLimitOption[string, struct{}](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, struct{}](time.Hour)),
 		replicationAttempts:  imcache.New(imcache.WithMaxEntriesLimitOption[string, struct{}](50_000, imcache.EvictionPolicyLRU), imcache.WithDefaultExpirationOption[string, struct{}](time.Hour)),
 
-		StartedAt: time.Now().UTC(),
-		Config:    config,
+		StartedAt:    time.Now().UTC(),
+		Config:       config,
 		geoIPdbReady: make(chan struct{}),
 
 		core: core,


### PR DESCRIPTION
## Summary
- add OPENAUDIO_STORE_RECENT and OPENAUDIO_STORE_RECENT_TTL config, defaulting TTL to 365d / 1 year
- isolate recent-retention decisions in a small repair policy helper where STORE_ALL takes precedence
- use upload and audio_preview CreatedAt values to pull/retain recent CIDs during repair cleanup, while preserving default and STORE_ALL behavior

## Testing
- go test ./pkg/mediorum -run TestParseStoreRecentTTL
- go test -c ./pkg/mediorum/server

## Notes
- qm_cids rows are key-only, so they are not treated as recent without a timestamp source.
- STORE_ALL already prevents over-replication deletes, but cleanup may still mutate files through invalid-CID deletion and resized image variant cache deletion; this PR leaves those existing behaviors unchanged.