### PR TITLE
chore: drop creatornode2 from prod statesync RPCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ WRAPPER_TAG ?= default
 # One of patch, minor, or major
 UPGRADE_TYPE ?= patch
 
-PROD_STATE_SYNC_RPCS ?= https://creatornode.audius.co,https://v.monophonic.digital
+PROD_STATE_SYNC_RPCS ?= https://creatornode.audius.co,https://rpc.audius.co,https://v.monophonic.digital
 
 GIT_SHA := $(shell git rev-parse HEAD)
 VERSION_LDFLAG := -X github.com/OpenAudio/go-openaudio/pkg/core/config.Version=$(GIT_SHA)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ WRAPPER_TAG ?= default
 # One of patch, minor, or major
 UPGRADE_TYPE ?= patch
 
-PROD_STATE_SYNC_RPCS ?= https://creatornode.audius.co,https://creatornode2.audius.co
+PROD_STATE_SYNC_RPCS ?= https://creatornode.audius.co,https://v.monophonic.digital
 
 GIT_SHA := $(shell git rev-parse HEAD)
 VERSION_LDFLAG := -X github.com/OpenAudio/go-openaudio/pkg/core/config.Version=$(GIT_SHA)

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -53,7 +53,7 @@ const (
 )
 
 const (
-	ProdStateSyncRpcs  = "https://creatornode.audius.co,https://creatornode2.audius.co"
+	ProdStateSyncRpcs  = "https://creatornode.audius.co,https://v.monophonic.digital"
 	StageStateSyncRpcs = "https://creatornode11.audius.co,https://creatornode5.audius.co"
 )
 

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -53,7 +53,7 @@ const (
 )
 
 const (
-	ProdStateSyncRpcs  = "https://creatornode.audius.co,https://v.monophonic.digital"
+	ProdStateSyncRpcs  = "https://creatornode.audius.co,https://rpc.audius.co,https://v.monophonic.digital"
 	StageStateSyncRpcs = "https://creatornode11.audius.co,https://creatornode5.audius.co"
 )
 


### PR DESCRIPTION
## What
Set the prod statesync RPC defaults to `https://creatornode.audius.co,https://rpc.audius.co,https://v.monophonic.digital`, removing `creatornode2.audius.co`. Updated in both places that carry the default:
- `pkg/core/config/config.go` — `ProdStateSyncRpcs` (compiled default used by k8s prod when `stateSyncRPCServers` is unset)
- `Makefile` — `PROD_STATE_SYNC_RPCS` (passed as `stateSyncRPCServers` for make-based deploys)

## Why
`creatornode2.audius.co` is being decommissioned as part of the creatornode2 turndown.

## Snapshot-serving status of the three sources
| Node | Serves snapshots? | Operated by |
|---|---|---|
| creatornode.audius.co | ✅ enabled, 2 snapshots | Audius |
| rpc.audius.co | ✅ enabled, 1 snapshot | Audius |
| v.monophonic.digital | ⚠️ enabled but **0 snapshots** currently | third-party |

creatornode + rpc are both Audius-operated and actively serving snapshots, giving real two-source redundancy today. `v.monophonic.digital` is included so it's ready once its operator turns on snapshot serving — until then it's a no-op source (a bootstrapping node just falls through to the other two).

## Verification
- `go build ./pkg/core/config/...` passes