### PR TITLE
fix(console): rate limit historical pages

### DIFF
--- a/pkg/core/console/routes.go
+++ b/pkg/core/console/routes.go
@@ -3,9 +3,11 @@ package console
 import (
 	"embed"
 	"net/http"
+	"time"
 
 	"github.com/OpenAudio/go-openaudio/pkg/core/console/middleware"
 	"github.com/labstack/echo/v4"
+	echomiddleware "github.com/labstack/echo/v4/middleware"
 )
 
 const baseURL = "/console"
@@ -18,7 +20,9 @@ var embeddedAssets embed.FS
 func (c *Console) registerRoutes() {
 
 	g := c.e.Group(baseURL)
+	historicalPageLimiter := consoleHistoricalPageLimiter()
 
+	g.Use(consoleNoIndexMiddleware)
 	g.Use(middleware.JsonExtensionMiddleware)
 	g.Use(middleware.ErrorLoggerMiddleware(c.logger, c.views))
 
@@ -38,15 +42,15 @@ func (c *Console) registerRoutes() {
 	g.GET("/api/matrix", c.matrixAPI)
 	g.GET("/api/version-adoption", c.versionAdoptionAPI)
 	g.GET("/validator/:validator", c.nodePage)
-	g.GET("/uptime/:rollup/:endpoint", c.uptimeFragment)
-	g.GET("/uptime/:rollup", c.uptimeFragment)
-	g.GET("/uptime", c.uptimeFragment)
-	g.GET("/pos", c.posFragment)
-	g.GET("/pos/:address", c.posFragment)
-	g.GET("/block/:block", c.blockPage)
-	g.GET("/tx/:tx", c.txPage)
+	g.GET("/uptime/:rollup/:endpoint", c.uptimeFragment, historicalPageLimiter)
+	g.GET("/uptime/:rollup", c.uptimeFragment, historicalPageLimiter)
+	g.GET("/uptime", c.uptimeFragment, historicalPageLimiter)
+	g.GET("/pos", c.posFragment, historicalPageLimiter)
+	g.GET("/pos/:address", c.posFragment, historicalPageLimiter)
+	g.GET("/block/:block", c.blockPage, historicalPageLimiter)
+	g.GET("/tx/:tx", c.txPage, historicalPageLimiter)
 	g.GET("/genesis", c.genesisPage)
-	g.GET("/adjudicate/:sp", c.adjudicateFragment)
+	g.GET("/adjudicate/:sp", c.adjudicateFragment, historicalPageLimiter)
 	g.GET("/health_check", c.getHealth)
 
 	g.GET("/fragments/nav/chain_data", c.navChainData)
@@ -64,4 +68,21 @@ func (c *Console) registerRoutes() {
 	//g.GET("/content/users", c.usersPage)
 	//g.GET("/content/tracks", c.tracksPage)
 	//g.GET("/content/plays", c.playsPage)
+}
+
+func consoleNoIndexMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("X-Robots-Tag", "noindex, nofollow")
+		return next(c)
+	}
+}
+
+func consoleHistoricalPageLimiter() echo.MiddlewareFunc {
+	store := echomiddleware.NewRateLimiterMemoryStoreWithConfig(echomiddleware.RateLimiterMemoryStoreConfig{
+		Rate:      0.5,
+		Burst:     10,
+		ExpiresIn: 10 * time.Minute,
+	})
+
+	return echomiddleware.RateLimiter(store)
 }

--- a/pkg/core/console/routes_test.go
+++ b/pkg/core/console/routes_test.go
@@ -1,0 +1,57 @@
+package console
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestConsoleHistoricalPageLimiter(t *testing.T) {
+	e := echo.New()
+	limited := consoleHistoricalPageLimiter()(func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	for i := 0; i < 10; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/console/tx/abc", nil)
+		req.RemoteAddr = "203.0.113.10:1234"
+
+		if err := limited(e.NewContext(req, rec)); err != nil {
+			t.Fatalf("request %d returned error: %v", i+1, err)
+		}
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("request %d status = %d, want %d", i+1, rec.Code, http.StatusNoContent)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/console/tx/abc", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+
+	if err := limited(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("limited request returned error: %v", err)
+	}
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("limited request status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+}
+
+func TestConsoleNoIndexMiddleware(t *testing.T) {
+	e := echo.New()
+	handler := consoleNoIndexMiddleware(func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/console/overview", nil)
+
+	if err := handler(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if got := rec.Header().Get("X-Robots-Tag"); got != "noindex, nofollow" {
+		t.Fatalf("X-Robots-Tag = %q, want %q", got, "noindex, nofollow")
+	}
+}


### PR DESCRIPTION
## Summary
- add a noindex/nofollow header to console responses
- rate-limit historical console views that are easy for crawlers to walk (`/tx`, `/block`, `/pos`, `/uptime`, `/adjudicate`)
- leave overview polling fragments and static assets outside the stricter bucket so normal console use keeps working

## Testing
- go test ./pkg/core/console ./pkg/core/console/views/pages