### PR TITLE
fix(db): cap postgres connection pools

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OpenAudio/go-openaudio/pkg/core/console"
 	"github.com/OpenAudio/go-openaudio/pkg/core/db"
 	"github.com/OpenAudio/go-openaudio/pkg/core/server"
+	"github.com/OpenAudio/go-openaudio/pkg/dbpool"
 	"github.com/OpenAudio/go-openaudio/pkg/eth"
 	"github.com/OpenAudio/go-openaudio/pkg/lifecycle"
 	"github.com/OpenAudio/go-openaudio/pkg/pos"
@@ -39,7 +40,14 @@ func run(ctx context.Context, lc *lifecycle.Lifecycle, logger *zap.Logger, posCh
 	logger.Info("db migrations successful")
 
 	// Use the passed context for the pool
-	pool, err := pgxpool.New(ctx, config.PSQLConn)
+	pgConfig, err := pgxpool.ParseConfig(config.PSQLConn)
+	if err != nil {
+		return fmt.Errorf("parsing postgres config: %v", err)
+	}
+	dbpool.ConfigurePGX(pgConfig, config.PSQLConn)
+	logger.Info("core postgres pool configured", zap.Int32("maxConns", pgConfig.MaxConns), zap.Duration("maxConnIdleTime", pgConfig.MaxConnIdleTime))
+
+	pool, err := pgxpool.NewWithConfig(ctx, pgConfig)
 	if err != nil {
 		return fmt.Errorf("couldn't create pgx pool: %v", err)
 	}

--- a/pkg/dbpool/dbpool.go
+++ b/pkg/dbpool/dbpool.go
@@ -1,0 +1,91 @@
+package dbpool
+
+import (
+	"database/sql"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/OpenAudio/go-openaudio/pkg/env"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	defaultPGXMaxConns        = int32(8)
+	defaultPGXMaxConnIdleTime = 5 * time.Minute
+	defaultSQLMaxOpenConns    = 20
+	defaultSQLMaxIdleConns    = 5
+	defaultSQLConnMaxIdleTime = 5 * time.Minute
+	envPGXMaxConns            = "OPENAUDIO_PGX_POOL_MAX_CONNS"
+	envPGXMaxConnIdleTime     = "OPENAUDIO_PGX_POOL_MAX_CONN_IDLE_TIME"
+	envSQLMaxOpenConns        = "OPENAUDIO_GORM_MAX_OPEN_CONNS"
+	envSQLMaxIdleConns        = "OPENAUDIO_GORM_MAX_IDLE_CONNS"
+	envSQLConnMaxIdleTime     = "OPENAUDIO_GORM_CONN_MAX_IDLE_TIME"
+)
+
+// ConfigurePGX applies conservative defaults to long-lived application pools.
+// Explicit env vars win, then explicit pgxpool DSN params, then defaults.
+func ConfigurePGX(config *pgxpool.Config, dsn string) {
+	if maxConns, ok := lookupPositiveInt(defaultPGXMaxConns, envPGXMaxConns); ok {
+		config.MaxConns = int32(maxConns)
+	} else if !dsnHasPoolParam(dsn, "pool_max_conns") {
+		config.MaxConns = defaultPGXMaxConns
+	}
+
+	if idleTime, ok := lookupDuration(defaultPGXMaxConnIdleTime, envPGXMaxConnIdleTime); ok {
+		config.MaxConnIdleTime = idleTime
+	} else if !dsnHasPoolParam(dsn, "pool_max_conn_idle_time") {
+		config.MaxConnIdleTime = defaultPGXMaxConnIdleTime
+	}
+}
+
+// ConfigureSQL applies conservative defaults to database/sql pools.
+func ConfigureSQL(db *sql.DB) {
+	maxOpen := env.GetInt(defaultSQLMaxOpenConns, envSQLMaxOpenConns)
+	if maxOpen < 1 {
+		maxOpen = defaultSQLMaxOpenConns
+	}
+
+	maxIdle := env.GetInt(defaultSQLMaxIdleConns, envSQLMaxIdleConns)
+	if maxIdle < 1 {
+		maxIdle = defaultSQLMaxIdleConns
+	}
+	if maxIdle > maxOpen {
+		maxIdle = maxOpen
+	}
+
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxIdleTime(env.GetDuration(defaultSQLConnMaxIdleTime, envSQLConnMaxIdleTime))
+}
+
+func lookupPositiveInt(defaultValue int32, keys ...string) (int, bool) {
+	if val, ok := env.Lookup(keys...); ok {
+		i, err := strconv.Atoi(val)
+		if err != nil || i < 1 {
+			return int(defaultValue), true
+		}
+		return i, true
+	}
+	return 0, false
+}
+
+func lookupDuration(defaultValue time.Duration, keys ...string) (time.Duration, bool) {
+	if val, ok := env.Lookup(keys...); ok {
+		d, err := time.ParseDuration(val)
+		if err != nil {
+			return defaultValue, true
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+func dsnHasPoolParam(dsn, param string) bool {
+	if u, err := url.Parse(dsn); err == nil && u.Query().Has(param) {
+		return true
+	}
+
+	return strings.Contains(dsn, param+"=")
+}

--- a/pkg/dbpool/dbpool_test.go
+++ b/pkg/dbpool/dbpool_test.go
@@ -1,0 +1,118 @@
+package dbpool
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "modernc.org/sqlite"
+)
+
+func TestConfigurePGXUsesConservativeDefaults(t *testing.T) {
+	restoreEnv(t)
+
+	dsn := "postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable"
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ConfigurePGX(config, dsn)
+
+	if config.MaxConns != defaultPGXMaxConns {
+		t.Fatalf("MaxConns = %d, want %d", config.MaxConns, defaultPGXMaxConns)
+	}
+	if config.MaxConnIdleTime != defaultPGXMaxConnIdleTime {
+		t.Fatalf("MaxConnIdleTime = %s, want %s", config.MaxConnIdleTime, defaultPGXMaxConnIdleTime)
+	}
+}
+
+func TestConfigurePGXRespectsDSNPoolParams(t *testing.T) {
+	restoreEnv(t)
+
+	dsn := "postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable&pool_max_conns=12&pool_max_conn_idle_time=2m"
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ConfigurePGX(config, dsn)
+
+	if config.MaxConns != 12 {
+		t.Fatalf("MaxConns = %d, want 12", config.MaxConns)
+	}
+	if config.MaxConnIdleTime != 2*time.Minute {
+		t.Fatalf("MaxConnIdleTime = %s, want 2m", config.MaxConnIdleTime)
+	}
+}
+
+func TestConfigurePGXEnvOverridesDSNPoolParams(t *testing.T) {
+	restoreEnv(t)
+	t.Setenv(envPGXMaxConns, "6")
+	t.Setenv(envPGXMaxConnIdleTime, "30s")
+
+	dsn := "postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable&pool_max_conns=12&pool_max_conn_idle_time=2m"
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ConfigurePGX(config, dsn)
+
+	if config.MaxConns != 6 {
+		t.Fatalf("MaxConns = %d, want 6", config.MaxConns)
+	}
+	if config.MaxConnIdleTime != 30*time.Second {
+		t.Fatalf("MaxConnIdleTime = %s, want 30s", config.MaxConnIdleTime)
+	}
+}
+
+func TestConfigureSQLCapsMaxOpenConns(t *testing.T) {
+	restoreEnv(t)
+	t.Setenv(envSQLMaxOpenConns, "13")
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ConfigureSQL(db)
+
+	if got := db.Stats().MaxOpenConnections; got != 13 {
+		t.Fatalf("MaxOpenConnections = %d, want 13", got)
+	}
+}
+
+func restoreEnv(t *testing.T) {
+	t.Helper()
+
+	keys := []string{
+		envPGXMaxConns,
+		envPGXMaxConnIdleTime,
+		envSQLMaxOpenConns,
+		envSQLMaxIdleConns,
+		envSQLConnMaxIdleTime,
+	}
+
+	original := make(map[string]*string, len(keys))
+	for _, key := range keys {
+		if value, ok := os.LookupEnv(key); ok {
+			v := value
+			original[key] = &v
+		}
+		os.Unsetenv(key)
+	}
+
+	t.Cleanup(func() {
+		for _, key := range keys {
+			if value := original[key]; value != nil {
+				os.Setenv(key, *value)
+			} else {
+				os.Unsetenv(key)
+			}
+		}
+	})
+}

--- a/pkg/eth/eth.go
+++ b/pkg/eth/eth.go
@@ -12,6 +12,7 @@ import (
 
 	v1 "github.com/OpenAudio/go-openaudio/pkg/api/eth/v1"
 	"github.com/OpenAudio/go-openaudio/pkg/common"
+	"github.com/OpenAudio/go-openaudio/pkg/dbpool"
 	"github.com/OpenAudio/go-openaudio/pkg/eth/contracts"
 	"github.com/OpenAudio/go-openaudio/pkg/eth/contracts/gen"
 	"github.com/OpenAudio/go-openaudio/pkg/eth/db"
@@ -79,6 +80,8 @@ func (eth *EthService) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error parsing database config: %v", err)
 	}
+	dbpool.ConfigurePGX(pgConfig, eth.dbURL)
+	eth.logger.Info("eth postgres pool configured", zap.Int32("maxConns", pgConfig.MaxConns), zap.Duration("maxConnIdleTime", pgConfig.MaxConnIdleTime))
 
 	pool, err := pgxpool.NewWithConfig(ctx, pgConfig)
 	if err != nil {

--- a/pkg/mediorum/server/db.go
+++ b/pkg/mediorum/server/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/OpenAudio/go-openaudio/pkg/dbpool"
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/crudr"
 	"github.com/OpenAudio/go-openaudio/pkg/mediorum/ddl"
 	slogGorm "github.com/orandin/slog-gorm"
@@ -137,7 +138,7 @@ func dbMustDial(dbPath string) *gorm.DB {
 	}
 
 	sqlDb, _ := db.DB()
-	sqlDb.SetMaxOpenConns(50)
+	dbpool.ConfigureSQL(sqlDb)
 
 	// db = db.Debug()
 

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -24,6 +24,7 @@ import (
 	ethv1connect "github.com/OpenAudio/go-openaudio/pkg/api/eth/v1/v1connect"
 	"github.com/OpenAudio/go-openaudio/pkg/common"
 	coreServer "github.com/OpenAudio/go-openaudio/pkg/core/server"
+	"github.com/OpenAudio/go-openaudio/pkg/dbpool"
 	"github.com/OpenAudio/go-openaudio/pkg/env"
 	audiusHttputil "github.com/OpenAudio/go-openaudio/pkg/httputil"
 	"github.com/OpenAudio/go-openaudio/pkg/lifecycle"
@@ -309,7 +310,12 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 
 	// pg pool
 	// config.PostgresDSN
-	pgConfig, _ := pgxpool.ParseConfig(config.PostgresDSN)
+	pgConfig, err := pgxpool.ParseConfig(config.PostgresDSN)
+	if err != nil {
+		return nil, fmt.Errorf("parse postgres config: %w", err)
+	}
+	dbpool.ConfigurePGX(pgConfig, config.PostgresDSN)
+	logger.Info("mediorum postgres pool configured", zap.Int32("maxConns", pgConfig.MaxConns), zap.Duration("maxConnIdleTime", pgConfig.MaxConnIdleTime))
 	pgPool, err := pgxpool.NewWithConfig(context.Background(), pgConfig)
 	if err != nil {
 		logger.Error("dial postgres failed", zap.Error(err))


### PR DESCRIPTION
## Summary
- add a shared dbpool helper that applies conservative connection-pool defaults to long-lived Postgres pools
- cap core, eth, and mediorum pgx pools at 8 max conns by default while preserving explicit pgxpool DSN params
- reduce mediorum GORM/sql pool from 50 max open conns to a 20 max / 5 idle default with env overrides

## Pool knobs
- `OPENAUDIO_PGX_POOL_MAX_CONNS`
- `OPENAUDIO_PGX_POOL_MAX_CONN_IDLE_TIME`
- `OPENAUDIO_GORM_MAX_OPEN_CONNS`
- `OPENAUDIO_GORM_MAX_IDLE_CONNS`
- `OPENAUDIO_GORM_CONN_MAX_IDLE_TIME`

## Testing
- `go test ./pkg/dbpool ./pkg/core ./pkg/eth`
- `go test -c ./pkg/mediorum/server -o /tmp/mediorum-server.test`

## Notes
- `go test ./pkg/mediorum/server` still requires its local Postgres harness on localhost:5454; without that harness it fails during TestMain database setup before package tests run.