### PR TITLE
fix(etl): let a grant's grantee revoke their own user-to-user grant

### DIFF
--- a/pkg/etl/processors/entity_manager/grant_revoke.go
+++ b/pkg/etl/processors/entity_manager/grant_revoke.go
@@ -23,10 +23,6 @@ func (h *grantDeleteHandler) Handle(ctx context.Context, params *Params) error {
 }
 
 func validateGrantDelete(ctx context.Context, params *Params) error {
-	if err := ValidateSigner(ctx, params); err != nil {
-		return err
-	}
-
 	granteeAddress := strings.ToLower(params.MetadataString("grantee_address"))
 	if granteeAddress == "" {
 		return NewValidationError("grantee_address is required for grant revoke")
@@ -40,7 +36,22 @@ func validateGrantDelete(ctx context.Context, params *Params) error {
 		return NewValidationError("no active grant for grantee %s from user %d", granteeAddress, params.UserID)
 	}
 
-	return nil
+	// The signer may be the grantor (the user in the grant) or, for a
+	// user-to-user manager grant, the grantee revoking their own management
+	// relationship. Mirrors the legacy indexer's grant DELETE signer check.
+	if err := ValidateSigner(ctx, params); err == nil {
+		return nil
+	}
+	granteeUserID, isUserGrant, err := activeUserIDByWallet(ctx, params.DBTX, granteeAddress)
+	if err != nil {
+		return err
+	}
+	if isUserGrant {
+		if err := validateSignerForUser(ctx, params, granteeUserID); err == nil {
+			return nil
+		}
+	}
+	return NewValidationError("signer %s is not authorized to revoke the grant for grantee %s from user %d", params.Signer, granteeAddress, params.UserID)
 }
 
 func revokeGrant(ctx context.Context, params *Params) error {

--- a/pkg/etl/processors/entity_manager/grant_test.go
+++ b/pkg/etl/processors/entity_manager/grant_test.go
@@ -117,6 +117,49 @@ func TestGrantDelete_Success(t *testing.T) {
 	}
 }
 
+// Regression: the grantee (manager) of a user-to-user grant may revoke their
+// own grant — the legacy indexer allowed this; the Go port only allowed the
+// grantor.
+func TestGrantDelete_GranteeCanRevokeOwnUserGrant(t *testing.T) {
+	pool := setupTestDB(t)
+	grantor := int64(UserIDOffset + 1)
+	grantee := int64(UserIDOffset + 2)
+	seedUser(t, pool, grantor, "0xgrantor", "grantor")
+	seedUser(t, pool, grantee, "0xgrantee", "grantee")
+
+	grantMeta := `{"grantee_address":"0xgrantee"}`
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 1, "0xGrantor", grantMeta))
+
+	// Grantee signs the revoke of their own management grant.
+	mustHandle(t, GrantDelete(), buildParams(t, pool, EntityTypeGrant, ActionDelete, grantor, 1, "0xGrantee", grantMeta))
+
+	var isRevoked bool
+	if err := pool.QueryRow(context.Background(),
+		"SELECT is_revoked FROM grants WHERE grantee_address='0xgrantee' AND user_id=$1 AND is_current=true", grantor).Scan(&isRevoked); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !isRevoked {
+		t.Error("grantee-signed revoke should set is_revoked=true")
+	}
+}
+
+// Security guard: a third party who is neither the grantor nor the grantee
+// must NOT be able to revoke the grant.
+func TestGrantDelete_RejectsUnauthorizedSigner(t *testing.T) {
+	pool := setupTestDB(t)
+	grantor := int64(UserIDOffset + 1)
+	grantee := int64(UserIDOffset + 2)
+	stranger := int64(UserIDOffset + 3)
+	seedUser(t, pool, grantor, "0xgrantor", "grantor")
+	seedUser(t, pool, grantee, "0xgrantee", "grantee")
+	seedUser(t, pool, stranger, "0xstranger", "stranger")
+
+	grantMeta := `{"grantee_address":"0xgrantee"}`
+	mustHandle(t, GrantCreate(), buildParams(t, pool, EntityTypeGrant, ActionCreate, grantor, 1, "0xGrantor", grantMeta))
+
+	mustReject(t, GrantDelete(), buildParams(t, pool, EntityTypeGrant, ActionDelete, grantor, 1, "0xStranger", grantMeta), "not authorized")
+}
+
 func TestGrantDelete_RejectsNoActiveGrant(t *testing.T) {
 	pool := setupTestDB(t)
 	uid := int64(UserIDOffset + 1)

--- a/pkg/etl/processors/entity_manager/validate.go
+++ b/pkg/etl/processors/entity_manager/validate.go
@@ -81,32 +81,39 @@ func ValidateDescription(desc string) error {
 	return nil
 }
 
-// ValidateSigner checks that the signer is the user's wallet or holds a valid
-// grant from the user. Grants come from either a developer app (auto-approved
-// at creation) or another user wallet acting in manager mode (must be approved
-// by the grantor).
+// ValidateSigner checks that the signer is params.UserID's wallet or holds a
+// valid grant from that user. Grants come from either a developer app
+// (auto-approved at creation) or another user wallet acting in manager mode
+// (must be approved by the grantor).
 func ValidateSigner(ctx context.Context, params *Params) error {
-	wallet, err := getUserWallet(ctx, params.DBTX, params.UserID)
+	return validateSignerForUser(ctx, params, params.UserID)
+}
+
+// validateSignerForUser is ValidateSigner against an explicit user id. Grant
+// revocation uses this with the grantee's user id so the grantee (manager) can
+// revoke their own user-to-user grant, matching the legacy indexer.
+func validateSignerForUser(ctx context.Context, params *Params, userID int64) error {
+	wallet, err := getUserWallet(ctx, params.DBTX, userID)
 	if err != nil {
 		return err
 	}
 	if wallet == "" {
-		return NewValidationError("user %d does not exist", params.UserID)
+		return NewValidationError("user %d does not exist", userID)
 	}
 	if strings.EqualFold(wallet, params.Signer) {
 		return nil
 	}
 
 	signer := strings.ToLower(params.Signer)
-	grant, err := getActiveGrant(ctx, params.DBTX, signer, params.UserID)
+	grant, err := getActiveGrant(ctx, params.DBTX, signer, userID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return NewValidationError("signer %s is not authorized for user %d", params.Signer, params.UserID)
+			return NewValidationError("signer %s is not authorized for user %d", params.Signer, userID)
 		}
 		return err
 	}
 	if grant.isRevoked {
-		return NewValidationError("signer %s grant for user %d is revoked", params.Signer, params.UserID)
+		return NewValidationError("signer %s grant for user %d is revoked", params.Signer, userID)
 	}
 
 	isApp, err := developerAppExists(ctx, params.DBTX, signer)
@@ -123,9 +130,25 @@ func ValidateSigner(ctx context.Context, params *Params) error {
 
 	approved := isApp || (grant.isApproved != nil && *grant.isApproved)
 	if !approved {
-		return NewValidationError("signer %s grant for user %d is not approved", params.Signer, params.UserID)
+		return NewValidationError("signer %s grant for user %d is not approved", params.Signer, userID)
 	}
 	return nil
+}
+
+// activeUserIDByWallet returns the user_id of an active user with the given
+// wallet, and whether one exists.
+func activeUserIDByWallet(ctx context.Context, dbtx db.DBTX, wallet string) (int64, bool, error) {
+	var userID int64
+	err := dbtx.QueryRow(ctx,
+		"SELECT user_id FROM users WHERE wallet = $1 AND is_current = true AND is_deactivated = false LIMIT 1",
+		strings.ToLower(wallet)).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return userID, true, nil
 }
 
 func getUserWallet(ctx context.Context, dbtx db.DBTX, userID int64) (string, error) {


### PR DESCRIPTION
## Summary

Found while auditing the entity-manager handlers for legacy-divergence bugs. Grant DELETE only authorized the **grantor**, so a manager (the **grantee** of a user-to-user grant) could not revoke their own management relationship. The legacy Python indexer explicitly allows the grantee to sign the revoke of a user-to-user grant, falling back to the grantor:

```python
# discovery-provider .../entities/grant.py (DELETE branch)
is_user_to_user_grant = grantee in params.existing_records[USER_WALLET]
if is_user_to_user_grant:
    try:
        validate_signer(params, user_override=grantee_user)  # grantee may sign
        signer_is_grantee = True
    except IndexingValidationError: pass
if not signer_is_grantee:
    validate_signer(params)  # else grantor
```

The Go `validateGrantDelete` called only `ValidateSigner` (grantor), so a grantee-initiated "stop managing this account" was rejected.

## Fix
- **`validate.go`**: factor `ValidateSigner` into `validateSignerForUser(ctx, params, userID)` (a pure refactor — `ValidateSigner` now calls it with `params.UserID`, so existing callers are unchanged). Add `activeUserIDByWallet`.
- **`grant_revoke.go`**: authorize the signer as the **grantor** OR, for a user-to-user grant (grantee_address resolves to an active user), the **grantee**. App grants (grantee is a developer app, not a user) are unaffected — only the grantor can revoke, exactly as before and as legacy does.

## Security
This widens who can revoke, so I added an explicit guard test: a third party who is **neither grantor nor grantee is still rejected**. The grantee path only triggers when `grantee_address` is an active user, and still runs the full `validateSignerForUser` (signer must be the grantee's wallet or an approved manager of the grantee).

## Test plan (real Postgres)
- [x] `go build ./...`, `go vet`, gofmt clean
- [x] `TestGrantDelete_GranteeCanRevokeOwnUserGrant` — grantee-signed revoke now succeeds
- [x] `TestGrantDelete_RejectsUnauthorizedSigner` — stranger still rejected (no hole opened)
- [x] Existing grant suite (create/delete/approve/reject, app + user grants) all green
- Code-only, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)