### PR TITLE
fix(core): broaden mainnet p2p bootstrap peers

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -47,7 +47,34 @@ const (
 )
 
 const (
-	ProdPersistentPeers  = "326d405aba6eab9df677ddf62d1331638e99da91@34.71.91.82:26656,edf0b62f900c6319fdb482b0379b91b8a3c0d773@104.154.119.194:26656,35207ecb279b19ab53e0172f0e3ae47ac930d147@34.173.190.5:26656,f0d79ce5eb91847db0a1b9ad4c8a15824710f9c3@34.121.217.14:26656,53a2506dcf34b267c3e04bb63e0ee4f563c7850d@34.67.133.214:26656,a3a9659fdd6e25e41324764adc8029b486814533@34.46.116.59:26656,25a80eb8f8755d73ab9b4e0e5cf31dcc0b757aab@35.222.113.66:26656,2c176c34a2fa881b72acfedc1e3815710c4f1bd5@34.28.164.31:26656"
+	// Mainnet bootstrap peers. Keep this broad: every validator starts from this
+	// list before PEX fills the address book, so a stale or tiny list becomes a
+	// consensus-gossip availability risk.
+	ProdPersistentPeers = "326d405aba6eab9df677ddf62d1331638e99da91@34.71.91.82:26656," +
+		"edf0b62f900c6319fdb482b0379b91b8a3c0d773@104.154.119.194:26656," +
+		"0b6bade75a38b6e7468d795dfdc7b2cf9f717255@val003.open-audio-validator.com:26656," +
+		"0c196c272a34ad51ab563253234e71b664b309da@val007.open-audio-validator.com:26656," +
+		"12abeaff908616575cec416af2c79c540bee63e1@audius-creator-4.theblueprint.xyz:26656," +
+		"1375316fb25560f97bf7cf6e02cede670d840618@audius-creator-7.theblueprint.xyz:26656," +
+		"13bcf9b4c1df378f4d2de4fb8801cabfa0a01a11@audius-creator-8.theblueprint.xyz:26656," +
+		"29156c622bd3e4183c3994a435da878c0cdc9fa6@val016.open-audio-validator.com:26656," +
+		"29d7892d176fb6f6a3740fdb753a618c612b9f0b@val011.open-audio-validator.com:26656," +
+		"2ec3f5d35b751db7c38d008f965cc268a139a15d@audius-content-2.figment.io:26656," +
+		"32b088725b4b82c3604cd05dc1f5ea3c8c09c5ba@audius-creator-5.theblueprint.xyz:26656," +
+		"3317946736f9e99c01bcfeeccd44c41b0d53caee@val005.open-audio-validator.com:26656," +
+		"33623aa633af52ef4d692320de0d22d1897fbbb9@audius-figment-1-validator-19.figment.io:26656," +
+		"34df66133ab8e1e761d1e5a60c7453683dcb0ba7@audius-creator-9.theblueprint.xyz:26656," +
+		"3714f1a5753d776e628be0524897be5a962db97e@audius-creator-6.theblueprint.xyz:26656," +
+		"3bd77cde0aa19b7d0370c1b4d0d26cde8ac38aa9@audius-creator-3.theblueprint.xyz:26656," +
+		"4868de2a01f29367796063cd87ed8d93b9866d84@val010.open-audio-validator.com:26656," +
+		"4a1e3fd9a5a1c982b0c7372abb80305b5b4cceee@audius-creator-11.theblueprint.xyz:26656," +
+		"51fc74a91a1daef3834e3028e3592d03633c44ed@audius-creator-15.theblueprint.xyz:26656," +
+		"56049970fbad44d540b8bef6118800433d269049@audius-content-12.figment.io:26656," +
+		"568224b2a1957bf45d9ce6835b9bbf346d0e7424@audius-creator-14.theblueprint.xyz:26656," +
+		"59f72f7f31155f850181fea0c525073c74b93741@audius-content-3.figment.io:26656," +
+		"5cba61b158b3b23705d859ddc98150a1ccb79b1d@cn1.shakespearetech.com:26656," +
+		"61cc1a7db1c91fd0ff9c3670cf5e03939fa53a78@val002.open-audio-validator.com:26656," +
+		"6210e9689aa8b3539b2191ea44879dbca7ca6691@audius-creator-17.theblueprint.xyz:26656"
 	StagePersistentPeers = "f277f58522627a5cb890aececed8f08e7f13e097@35.193.20.31:26656,6a5d8207ed912eaa60cdfb8181fa97587d41dd1c@34.121.162.132:26656,8f27745ad44e08f449728960fa67827eb9477cf2@34.30.203.99:26656,96bba6b462e35f83866fbac271bfcee0a96d68e8@34.9.143.36:26656,1eec5742f64fb243d22594e4143e14e77a38f232@34.28.231.197:26656,2da43f6e1b5614ea8fc8b7e89909863033ca6a27@34.123.76.111:26656"
 	DevPersistentPeers   = "ffad25668e060a357bbe534c8b7e5b4e1274368b@openaudio-1:26656"
 )
@@ -102,12 +129,12 @@ type Config struct {
 	EthRegistryAddress string
 
 	/* System Config */
-	RunDownMigration             bool
-	SlaRollupInterval            int
-	ValidatorVotingPower         int
-	ValidatorPurgeMinValidators  int
-	ValidatorWardenIntervalMins  int // how often the validator warden checks for underperformance (minutes)
-	UseHttpsForSdk               bool
+	RunDownMigration            bool
+	SlaRollupInterval           int
+	ValidatorVotingPower        int
+	ValidatorPurgeMinValidators int
+	ValidatorWardenIntervalMins int // how often the validator warden checks for underperformance (minutes)
+	UseHttpsForSdk              bool
 
 	StateSync *StateSyncConfig
 
@@ -258,6 +285,7 @@ func ReadConfig() (*Config, error) {
 	cfg.AddrBookStrict = true
 	cfg.UseHttpsForSdk = env.Get("true", "OPENAUDIO_USE_HTTPS_FOR_SDK", "useHttpsForSdk") == "true"
 	cfg.ExternalAddress = env.String("OPENAUDIO_EXTERNAL_ADDRESS", "externalAddress")
+	cfg.Seeds = env.Get("", "OPENAUDIO_SEEDS", "seeds")
 	cfg.EthRegistryAddress = GetRegistryAddress()
 
 	switch cfg.Environment {

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -159,6 +159,9 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 	if envConfig.PersistentPeers != "" {
 		cometConfig.P2P.PersistentPeers = envConfig.PersistentPeers
 	}
+	if envConfig.Seeds != "" {
+		cometConfig.P2P.Seeds = envConfig.Seeds
+	}
 	if envConfig.ExternalAddress != "" {
 		cometConfig.P2P.ExternalAddress = envConfig.ExternalAddress
 	}

--- a/pkg/core/config/setup_test.go
+++ b/pkg/core/config/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -21,12 +22,38 @@ func TestModuloPersistentPeers(t *testing.T) {
 	}
 
 	nodes2 := moduloPersistentPeers("0xE019F1Ad9803cfC83e11D37Da442c9Dc8D8d82a6", ProdPersistentPeers, 3)
-	selectedPersistentPeers2 := strings.Split(nodes, ",")
+	selectedPersistentPeers2 := strings.Split(nodes2, ",")
 	if len(selectedPersistentPeers2) != 3 {
 		t.Fatalf("expected 3 persistent peers, got %d", len(selectedPersistentPeers))
 	}
 
 	require.NotEqual(t, nodes, nodes2)
+}
+
+func TestProdPersistentPeersBroadAndParseable(t *testing.T) {
+	peers := strings.Split(ProdPersistentPeers, ",")
+	require.GreaterOrEqual(t, len(peers), 20, "prod should not bootstrap from a tiny hub-only peer set")
+
+	seen := map[string]bool{}
+	for _, peer := range peers {
+		require.NotEmpty(t, peer)
+		addr, err := p2p.NewNetAddressString(peer)
+		require.NoError(t, err, "peer %q should be a valid CometBFT net address", peer)
+		id := string(addr.ID)
+		require.False(t, seen[id], "duplicate peer id %s", addr.ID)
+		seen[id] = true
+	}
+
+	for _, staleIP := range []string{
+		"34.173.190.5:26656",
+		"34.121.217.14:26656",
+		"34.67.133.214:26656",
+		"34.46.116.59:26656",
+		"35.222.113.66:26656",
+		"34.28.164.31:26656",
+	} {
+		require.NotContains(t, ProdPersistentPeers, staleIP)
+	}
 }
 
 func TestEnsurePrivValidator(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the stale 8-entry mainnet persistent-peer default with a broader bootstrap set
- include the 2 still-reachable existing Audius hub IPs plus 23 live validator endpoints that accepted TCP/26656 during verification
- wire `OPENAUDIO_SEEDS` through to CometBFT `P2P.Seeds` so ops can add seed nodes without another code change
- add config tests for broad, parseable, unique prod peers and removal of the six stale IPs

## Tests
- `go test ./pkg/core/config`
- `go test ./pkg/core/...`
- `git diff --check`