### PR TITLE
fix(core): keep StorageProof checks out of block replay

### DIFF
--- a/pkg/core/server/abci.go
+++ b/pkg/core/server/abci.go
@@ -239,8 +239,11 @@ func (s *Server) Query(ctx context.Context, req *abcitypes.QueryRequest) (*abcit
 }
 
 func (s *Server) CheckTx(_ context.Context, check *abcitypes.CheckTxRequest) (*abcitypes.CheckTxResponse, error) {
-	_, err := s.isValidSignedTransaction(check.Tx)
+	msg, err := s.isValidSignedTransaction(check.Tx)
 	if err != nil {
+		return &abcitypes.CheckTxResponse{Code: 1}, nil
+	}
+	if err := validateSignedTransactionForCheckTx(msg); err != nil {
 		return &abcitypes.CheckTxResponse{Code: 1}, nil
 	}
 
@@ -913,39 +916,45 @@ func (s *Server) isValidSignedTransaction(tx []byte) (*v1.SignedTransaction, err
 	if err := proto.Unmarshal(tx, &msg); err != nil {
 		return nil, err
 	}
+	return &msg, nil
+}
 
+func validateSignedTransactionForCheckTx(msg *v1.SignedTransaction) error {
+	if msg == nil {
+		return fmt.Errorf("transaction is nil")
+	}
 	if msg.Transaction == nil {
-		return nil, fmt.Errorf("transaction has no body")
+		return fmt.Errorf("transaction has no body")
 	}
 
 	switch msg.Transaction.(type) {
 	case *v1.SignedTransaction_StorageProof:
 		sp := msg.GetStorageProof()
 		if len(sp.ProverAddresses) == 0 {
-			return nil, fmt.Errorf("storage proof has no prover addresses")
+			return fmt.Errorf("storage proof has no prover addresses")
 		}
 		if sp.Address == "" {
-			return nil, fmt.Errorf("storage proof has no prover address")
+			return fmt.Errorf("storage proof has no prover address")
 		}
 		if sp.Height == 0 {
-			return nil, fmt.Errorf("storage proof has no height")
+			return fmt.Errorf("storage proof has no height")
 		}
 	case *v1.SignedTransaction_StorageProofVerification:
 		spv := msg.GetStorageProofVerification()
 		if spv.Height == 0 {
-			return nil, fmt.Errorf("storage proof verification has no height")
+			return fmt.Errorf("storage proof verification has no height")
 		}
 		if len(spv.Proof) == 0 {
-			return nil, fmt.Errorf("storage proof verification has no proof")
+			return fmt.Errorf("storage proof verification has no proof")
 		}
 	case *v1.SignedTransaction_Attestation:
 		att := msg.GetAttestation()
 		if att.GetValidatorRegistration() == nil && att.GetValidatorDeregistration() == nil {
-			return nil, fmt.Errorf("attestation has no body")
+			return fmt.Errorf("attestation has no body")
 		}
 	}
 
-	return &msg, nil
+	return nil
 }
 
 func (s *Server) isValidV2Transaction(tx []byte) (*v1beta1.Transaction, error) {

--- a/pkg/core/server/abci_test.go
+++ b/pkg/core/server/abci_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	v1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
@@ -15,13 +17,22 @@ func marshalSignedTx(t *testing.T, tx *v1.SignedTransaction) []byte {
 	return b
 }
 
-func TestIsValidSignedTransaction_EmptyBody(t *testing.T) {
+func checkTxCode(t *testing.T, tx []byte) uint32 {
+	t.Helper()
+	res, err := (&Server{}).CheckTx(context.Background(), &abcitypes.CheckTxRequest{Tx: tx})
+	require.NoError(t, err)
+	return res.Code
+}
+
+func TestIsValidSignedTransaction_ParseOnly(t *testing.T) {
 	s := &Server{}
 
 	t.Run("nil transaction body", func(t *testing.T) {
 		tx := marshalSignedTx(t, &v1.SignedTransaction{})
-		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no body")
+		msg, err := s.isValidSignedTransaction(tx)
+		require.NoError(t, err)
+		require.Nil(t, msg.Transaction)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 
 	t.Run("invalid protobuf", func(t *testing.T) {
@@ -55,32 +66,40 @@ func TestIsValidSignedTransaction_StorageProof(t *testing.T) {
 
 	t.Run("empty prover addresses", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProof{Height: 100, Address: "ABCD1234"})
-		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no prover addresses")
+		msg, err := s.isValidSignedTransaction(tx)
+		require.NoError(t, err)
+		require.Empty(t, msg.GetStorageProof().ProverAddresses)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 
 	t.Run("nil prover addresses after proto roundtrip", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProof{Height: 100, Address: "ABCD1234", ProverAddresses: nil})
-		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no prover addresses")
+		msg, err := s.isValidSignedTransaction(tx)
+		require.NoError(t, err)
+		require.Empty(t, msg.GetStorageProof().ProverAddresses)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 
 	t.Run("empty slice prover addresses after proto roundtrip", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProof{Height: 100, Address: "ABCD1234", ProverAddresses: []string{}})
-		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no prover addresses")
+		msg, err := s.isValidSignedTransaction(tx)
+		require.NoError(t, err)
+		require.Empty(t, msg.GetStorageProof().ProverAddresses)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 
 	t.Run("missing address", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProof{Height: 100, ProverAddresses: []string{"ADDR1"}})
 		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no prover address")
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 
 	t.Run("zero height", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProof{Address: "ABCD1234", ProverAddresses: []string{"ADDR1"}})
 		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no height")
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 }
 
@@ -104,13 +123,15 @@ func TestIsValidSignedTransaction_StorageProofVerification(t *testing.T) {
 	t.Run("zero height", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProofVerification{Proof: []byte("proof-data")})
 		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no height")
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 
 	t.Run("empty proof", func(t *testing.T) {
 		tx := marshal(t, &v1.StorageProofVerification{Height: 100})
 		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no proof")
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 }
 
@@ -161,7 +182,8 @@ func TestIsValidSignedTransaction_Attestation(t *testing.T) {
 			Signatures: []string{"sig1"},
 		})
 		_, err := s.isValidSignedTransaction(tx)
-		require.ErrorContains(t, err, "no body")
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), checkTxCode(t, tx))
 	})
 }
 

--- a/pkg/core/server/pos.go
+++ b/pkg/core/server/pos.go
@@ -223,10 +223,6 @@ func (s *Server) isValidStorageProofTx(ctx context.Context, tx *v1.SignedTransac
 		return fmt.Errorf("proof is for '%s' but was signed by '%s'", sp.Address, node.CometAddress)
 	}
 
-	if len(sp.ProverAddresses) == 0 {
-		return fmt.Errorf("storage proof has no prover addresses")
-	}
-
 	// validate height
 	height := sp.GetHeight()
 	if height == 0 {


### PR DESCRIPTION
## Summary
- keep `isValidSignedTransaction` replay-safe by making it protobuf-decode only again
- move structural transaction checks into the `CheckTx` path
- remove the empty `StorageProof.prover_addresses` reject from the shared StorageProof validator so committed blocks replay with stable-compatible result codes

## Tests
- `go test ./pkg/core/server -run 'TestIsValidSignedTransaction'`\n- `go test ./pkg/core/...`\n- `git diff --check`