### PR TITLE
docs: update stale Python/celery indexer references

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -216,6 +216,9 @@ func ReadConfig() (*Config, error) {
 	cfg.ProgrammableDistributionEnabled = common.IsProgrammableDistributionEnabled(cfg.Environment)
 
 	cfg.SkipEthRegistration = env.Get("false", "OPENAUDIO_SKIP_ETH_REGISTRATION", "skipEthRegistration") == "true"
+	// Defaults to false for nodes that opt out of indexing, but the Go ETL is
+	// the production indexer and OPENAUDIO_ETL_ENABLED is set to true in
+	// production deployments.
 	cfg.EnableETL = env.Get("false", "OPENAUDIO_ETL_ENABLED") == "true"
 	cfg.EnableExplorer = env.Get("false", "OPENAUDIO_EXPLORER_ENABLED") == "true"
 	cfg.EnableGRPCReflection = env.Get("false", "OPENAUDIO_GRPC_REFLECTION_ENABLED") == "true"

--- a/pkg/etl/FEATURE.md
+++ b/pkg/etl/FEATURE.md
@@ -160,7 +160,7 @@ users, tracks, playlists, follows, saves, reposts, track_routes, playlist_routes
 
 All migrations are idempotent (`IF NOT EXISTS`, `DO $$ EXCEPTION`, `DROP TRIGGER IF EXISTS`).
 
-Schema matches discovery-provider exactly (same table names, columns, composite PKs, enums). This enables the cutover strategy: stop celery indexer, start ETL indexer, same database.
+Schema matches discovery-provider exactly (same table names, columns, composite PKs, enums). This is what allowed the production cutover from the legacy Python celery indexer to the Go ETL on the same database. The Go ETL is now the production indexer; the Python celery indexer is no longer active.
 
 Migrations are embedded and run automatically via `Indexer.Run()` → `db.RunMigrations()`.
 
@@ -175,9 +175,9 @@ core_indexed_blocks(chain_id, height, em_block)
   - offset:   em_block - height (constant per chain_id)
 ```
 
-At startup, the indexer queries `core_indexed_blocks` for the current chain ID to determine the offset. For existing databases with prior Python-indexed data, this continues the `blocks.number` sequence seamlessly. For clean databases, the offset is 0 (em_block = chain height).
+At startup, the indexer queries `core_indexed_blocks` for the current chain ID to determine the offset. For production databases that contain pre-cutover rows written by the legacy Python indexer, this continues the `blocks.number` sequence seamlessly. For clean databases, the offset is 0 (em_block = chain height).
 
-**Known limitation:** Chain ID rollovers (e.g., `audius-mainnet-alpha` → `audius-mainnet-alpha-beta`) are not handled. The offset is looked up once at startup for the current chain ID. If the chain rolls over, the ETL must be restarted (and may need manual intervention to set the correct offset for the new chain). The Python discovery indexer has explicit chain rollover detection logic that the Go ETL does not yet replicate.
+**Known limitation:** Chain ID rollovers (e.g., `audius-mainnet-alpha` → `audius-mainnet-alpha-beta`) are not handled. The offset is looked up once at startup for the current chain ID. If the chain rolls over, the ETL must be restarted (and may need manual intervention to set the correct offset for the new chain). The legacy Python indexer had explicit chain rollover detection logic that the Go ETL does not currently replicate.
 
 ## Testing
 
@@ -216,7 +216,7 @@ Progress is logged at INFO level every 10 seconds (block height, tx counts).
 
 ### Parity testing (against production clone)
 
-Standalone CLI tool in `pkg/etl/parity/` for comparing Go ETL output against existing Python-indexed data.
+Standalone CLI tool in `pkg/etl/parity/` for comparing Go ETL output against the pre-cutover rows written by the legacy Python indexer. This tool was used to validate the production cutover (now complete); it remains useful for auditing the Go ETL against a snapshot of historical data.
 
 ```bash
 cd pkg/etl

--- a/pkg/etl/indexer.go
+++ b/pkg/etl/indexer.go
@@ -427,7 +427,9 @@ func (e *Indexer) processBlock(ctx context.Context, pb prefetchedBlock) (*blockR
 			// our MAX+1 with a different hash. Within our tx, both calls
 			// see the same snapshot semantics (READ COMMITTED), so the
 			// retry only helps if the conflict was with a *committed*
-			// outside writer — which is exactly the cutover scenario.
+			// outside writer — which is what could happen while a second
+			// writer (e.g. the legacy Python indexer) was still running
+			// during the production cutover to the Go ETL.
 			n, err = e.resolveBlockNumber(ctx, tx, block.Hash)
 		}
 		if err != nil {
@@ -880,8 +882,9 @@ func (e *Indexer) firePlaysHooks(ctx context.Context, sp pgx.Tx, plays []*corev1
 // blocks row if needed, all within the caller-supplied transaction.
 //
 // Idempotent and tolerant of co-existing writers (e.g. the legacy Python
-// indexer during a cutover): if a row for blockHash already exists, its
-// number is adopted. If not, a new row is inserted at MAX(number)+1
+// indexer, which ran alongside the Go ETL during the production cutover):
+// if a row for blockHash already exists, its number is adopted. If not,
+// a new row is inserted at MAX(number)+1
 // computed in-statement. The DB is the source of truth; no in-memory
 // counter to drift from concurrent writers or stale snapshots.
 //

--- a/pkg/etl/parity/compare.go
+++ b/pkg/etl/parity/compare.go
@@ -131,8 +131,10 @@ var compareTables = []compareTable{
 	},
 }
 
-// Compare connects to both the ETL clone and production DB and compares
-// rows created after the snapshot boundary.
+// Compare connects to both the ETL clone and a database holding the
+// pre-cutover rows written by the legacy Python indexer, and compares
+// rows created after the snapshot boundary. (Used to validate the
+// production cutover to the Go ETL, now complete.)
 //
 // The boundary is determined automatically: the first em_block written by
 // the Go ETL is the lowest em_block in core_indexed_blocks that was NOT
@@ -142,7 +144,7 @@ func Compare(ctx context.Context, etlPool *pgxpool.Pool, prodPool *pgxpool.Pool)
 	// Find the em_block boundary using etl_blocks, which only the Go ETL writes to.
 	// The first etl_blocks row marks where Go started indexing. We then find the
 	// minimum em_block assigned by Go in core_indexed_blocks for that height range.
-	// Everything below that em_block was written by the legacy indexer; everything at or above is written here.
+	// Everything below that em_block was written by the legacy Python indexer (pre-cutover); everything at or above was written by the Go ETL.
 	var minGoHeight, maxGoHeight int64
 	err := etlPool.QueryRow(ctx,
 		`SELECT MIN(block_height), MAX(block_height) FROM etl_blocks`).Scan(&minGoHeight, &maxGoHeight)

--- a/pkg/etl/parity/main.go
+++ b/pkg/etl/parity/main.go
@@ -1,4 +1,10 @@
-// Parity compare tool: field-by-field comparison of Go ETL output against production data.
+// Parity compare tool: field-by-field comparison of Go ETL output against the
+// pre-cutover rows written by the legacy Python indexer.
+//
+// This tool was used to validate the production cutover from the legacy Python
+// celery indexer to the Go ETL (now complete — the Go ETL is the production
+// indexer). It remains useful for auditing the Go ETL against a snapshot of
+// historical data.
 //
 // Usage:
 //

--- a/pkg/etl/plan.md
+++ b/pkg/etl/plan.md
@@ -30,8 +30,8 @@ todos:
     content: "PR9: Comment Create/Update/Delete/React/Unreact/Pin/Unpin/Report/Mute/Unmute handlers"
     status: completed
   - id: remaining-entities
-    content: "Future: AssociatedWallet, DashboardWalletUser, Tip (require crypto sig verification)"
-    status: pending
+    content: "AssociatedWallet, DashboardWalletUser, Tip, EncryptedEmail, EmailAccess, Event (incl. crypto sig verification)"
+    status: completed
 isProject: false
 ---
 
@@ -39,7 +39,9 @@ isProject: false
 
 ## Current State
 
-35 entity manager handlers implemented with full validation parity against the discovery-provider celery indexer. The ETL indexer processes ManageEntity transactions through a dispatcher that routes to per-entity-action handlers, each performing stateless validation, stateful validation, and domain table writes.
+Parity work is complete: the Go ETL is the production indexer, having replaced the legacy discovery-provider celery indexer (no longer active). All entity manager handlers are implemented with full validation parity against the behavior of the former celery indexer. The ETL indexer processes ManageEntity transactions through a dispatcher that routes to per-entity-action handlers, each performing stateless validation, stateful validation, and domain table writes.
+
+The sections below are retained as a historical record of how the parity effort was staged.
 
 ## Graphite Stack
 
@@ -71,9 +73,9 @@ main
 | PlaylistSeen | View | `notification.go` |
 | Comment | Create, Update, Delete, React, Unreact, Pin, Unpin, Report, Mute, Unmute | `comment_*.go` |
 
-## Remaining Entities (lower priority)
+## Remaining Entities (now implemented)
 
-These require Ethereum/Solana signature verification and will be added when crypto primitives are available:
+These required Ethereum/Solana signature verification and have since been implemented:
 
 - **AssociatedWallet**: Create, Delete — ETH/SOL signature recovery
 - **DashboardWalletUser**: Create, Delete — ETH signature recovery + timestamp validation


### PR DESCRIPTION
The Go ETL is the production indexer. Remove references framing it as a future replacement for the Python celery indexer.

## Changes

- **`pkg/etl/FEATURE.md`** — reframe the schema-cutover note as complete; the Go ETL is now the production indexer and the Python celery indexer is no longer active. Past-tense the chain-rollover and parity-tool descriptions.
- **`pkg/etl/plan.md`** — mark parity work and the previously-"pending"/"Future" remaining entities (AssociatedWallet, DashboardWalletUser, Tip, EncryptedEmail, EmailAccess, Event) as complete; note the staged sections are a historical record.
- **`pkg/etl/parity/{compare.go,main.go}`** — clarify the parity tool compared against pre-cutover rows written by the legacy Python indexer to validate the now-complete cutover.
- **`pkg/etl/indexer.go`** — past-tense the co-existing-writer / cutover comments.
- **`pkg/core/config/config.go`** — clarify that although `OPENAUDIO_ETL_ENABLED` defaults to false, it is set to true in production deployments.

Docs/comments only — no logic changes. `pkg/core/config` and the `pkg/etl` submodule both still build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)