### PR TITLE
fix: skip comet removal for jailed deregistrations

### DIFF
--- a/pkg/core/server/abci.go
+++ b/pkg/core/server/abci.go
@@ -346,6 +346,8 @@ func (s *Server) FinalizeBlock(ctx context.Context, req *abcitypes.FinalizeBlock
 			// set tx to ok and set to not okay later if error occurs
 			txs[i] = &abcitypes.ExecTxResult{Code: abcitypes.CodeTypeOK}
 
+			emitDeregistrationValidatorUpdate := s.deregistrationNeedsValidatorUpdate(ctx, signedTx)
+
 			// Use raw transaction bytes for consistent hashing during block sync
 			txhash := common.ToTxHashFromBytes(tx)
 			finalizedTx, err := s.finalizeTransaction(ctx, req, signedTx, txhash, req.Height)
@@ -381,11 +383,13 @@ func (s *Server) FinalizeBlock(ctx context.Context, req *abcitypes.FinalizeBlock
 				vr := att.GetValidatorDeregistration()
 				vrPubKey := ed25519.PubKey(vr.GetPubKey())
 				vrAddr := vrPubKey.Address().String()
-				// intentionally override any existing updates
-				validatorUpdatesMap[vrAddr] = abcitypes.ValidatorUpdate{
-					Power:       int64(0),
-					PubKeyBytes: vr.PubKey,
-					PubKeyType:  "ed25519",
+				if emitDeregistrationValidatorUpdate {
+					// intentionally override any existing updates
+					validatorUpdatesMap[vrAddr] = abcitypes.ValidatorUpdate{
+						Power:       int64(0),
+						PubKeyBytes: vr.PubKey,
+						PubKeyType:  "ed25519",
+					}
 				}
 				if err := s.appendDeregistrationToValidatorHistory(ctx, vr, req.Time, req.Height); err != nil {
 					// do not halt on validator history
@@ -394,11 +398,13 @@ func (s *Server) FinalizeBlock(ctx context.Context, req *abcitypes.FinalizeBlock
 			} else if vd := signedTx.GetValidatorDeregistration(); vd != nil { // TODO: delete legacy deregistration after chain rollover
 				vdPubKey := ed25519.PubKey(vd.GetPubKey())
 				vdAddr := vdPubKey.Address().String()
-				// intentionally override any existing updates
-				validatorUpdatesMap[vdAddr] = abcitypes.ValidatorUpdate{
-					Power:       int64(0),
-					PubKeyBytes: vd.PubKey,
-					PubKeyType:  "ed25519",
+				if emitDeregistrationValidatorUpdate {
+					// intentionally override any existing updates
+					validatorUpdatesMap[vdAddr] = abcitypes.ValidatorUpdate{
+						Power:       int64(0),
+						PubKeyBytes: vd.PubKey,
+						PubKeyType:  "ed25519",
+					}
 				}
 			}
 
@@ -873,6 +879,35 @@ func (s *Server) ExtendVote(_ context.Context, extend *abcitypes.ExtendVoteReque
 
 func (s *Server) VerifyVoteExtension(_ context.Context, verify *abcitypes.VerifyVoteExtensionRequest) (*abcitypes.VerifyVoteExtensionResponse, error) {
 	return &abcitypes.VerifyVoteExtensionResponse{}, nil
+}
+
+func (s *Server) deregistrationNeedsValidatorUpdate(ctx context.Context, tx *v1.SignedTransaction) bool {
+	var cometAddress string
+
+	if att := tx.GetAttestation(); att != nil {
+		if dereg := att.GetValidatorDeregistration(); dereg != nil {
+			cometAddress = dereg.GetCometAddress()
+		}
+	} else if dereg := tx.GetValidatorDeregistration(); dereg != nil {
+		cometAddress = dereg.GetCometAddress()
+	}
+
+	if cometAddress == "" {
+		return false
+	}
+
+	node, err := s.getDb().GetRegisteredNodeByCometAddress(ctx, cometAddress)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false
+	}
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("failed to check validator state before deregistration", zap.String("comet_address", cometAddress), zap.Error(err))
+		}
+		return false
+	}
+
+	return !node.Jailed
 }
 
 //////////////////////////////////

--- a/pkg/core/server/validator_state_test.go
+++ b/pkg/core/server/validator_state_test.go
@@ -239,6 +239,57 @@ func TestFinalizeDeregisterBranching(t *testing.T) {
 	})
 }
 
+func TestDeregistrationNeedsValidatorUpdate(t *testing.T) {
+	pool := setupValidatorTestDB(t)
+	ctx := context.Background()
+
+	makeServer := func(tx pgx.Tx) *Server {
+		return &Server{
+			db:        db.New(pool),
+			abciState: &ABCIState{onGoingBlock: tx},
+			logger:    zap.NewNop(),
+		}
+	}
+
+	t.Run("active validator removal updates comet validator set", func(t *testing.T) {
+		truncateValidators(t, pool)
+		require.NoError(t, db.New(pool).InsertRegisteredNode(ctx, testNode))
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx)
+
+		require.True(t, makeServer(tx).deregistrationNeedsValidatorUpdate(ctx, makeDereigstrationTx("ABCDEF", true)))
+	})
+
+	t.Run("jailed validator removal only mutates app state", func(t *testing.T) {
+		truncateValidators(t, pool)
+		q := db.New(pool)
+		require.NoError(t, q.InsertRegisteredNode(ctx, testNode))
+		require.NoError(t, q.JailRegisteredNode(ctx, "ABCDEF"))
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx)
+
+		require.False(t, makeServer(tx).deregistrationNeedsValidatorUpdate(ctx, makeDereigstrationTx("ABCDEF", true)))
+	})
+
+	t.Run("duplicate removal in same block does not update comet twice", func(t *testing.T) {
+		truncateValidators(t, pool)
+		require.NoError(t, db.New(pool).InsertRegisteredNode(ctx, testNode))
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx)
+
+		s := makeServer(tx)
+		require.True(t, s.deregistrationNeedsValidatorUpdate(ctx, makeDereigstrationTx("ABCDEF", true)))
+		require.NoError(t, s.getDb().DeleteRegisteredNode(ctx, "ABCDEF"))
+		require.False(t, s.deregistrationNeedsValidatorUpdate(ctx, makeDereigstrationTx("ABCDEF", true)))
+	})
+}
+
 func TestIsSelfAlreadyRegistered(t *testing.T) {
 	pool := setupValidatorTestDB(t)
 	ctx := context.Background()
@@ -393,11 +444,7 @@ func TestRemoveValidatorGoesThoughConsensus(t *testing.T) {
 	})
 }
 
-// TestFinalizeBlockProducesValidatorUpdate verifies that the FinalizeBlock code
-// path correctly builds a ValidatorUpdate with Power=0 for deregistration
-// attestation transactions. This is the CometBFT signal to remove a validator
-// from the active set — and it only runs inside FinalizeBlock (consensus).
-func TestFinalizeBlockProducesValidatorUpdate(t *testing.T) {
+func TestDeregistrationPubKeyAddressRoundTrip(t *testing.T) {
 	privKey := ed25519.GenPrivKey()
 	pubKey := privKey.PubKey().(ed25519.PubKey)
 	cometAddress := pubKey.Address().String()
@@ -426,5 +473,4 @@ func TestFinalizeBlockProducesValidatorUpdate(t *testing.T) {
 	recoveredAddr := recoveredPubKey.Address().String()
 
 	require.Equal(t, cometAddress, recoveredAddr, "address should round-trip through pubkey")
-	require.Equal(t, int64(0), int64(0), "deregistration attestation always produces Power=0 validator update")
 }


### PR DESCRIPTION
## Summary
- avoid emitting a CometBFT zero-power validator update when a deregistration removes a validator that is already jailed in app state
- preserve normal active-validator deregistration behavior by still emitting the zero-power update for active validators
- add focused coverage for active, jailed, and duplicate same-block removal cases

## Context
The network is stuck around the CN2 deregistration because block replay tries to remove CN2's comet validator address even though it is already absent from the active Comet validator set. The patch lets `Remove=true` still delete the app-level `core_validators` row while skipping the duplicate Comet removal for jailed validators.

## Test Plan
- `go test ./pkg/core/server`
