### PR TITLE
feat(genesis-writer): add play count reconciliation step

### DIFF
--- a/cmd/genesis-writer/entities_play_reconciliation.go
+++ b/cmd/genesis-writer/entities_play_reconciliation.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+)
+
+// playCountReconciliation emits a ManageEntity transaction that tells the ETL
+// to set a track's aggregate play count to a specific value. This covers the
+// historical plays that were pruned from the plays table (older than ~400 days)
+// and cannot be reconstructed from individual play records.
+//
+// The delta is: aggregate_plays.count - COUNT(plays for that track).
+// Tracks where the plays table already accounts for the full count are skipped.
+
+type playCountReconciliationMetadata struct {
+	Delta int64 `json:"delta"`
+}
+
+type sourcePlayCountDelta struct {
+	PlayItemID int64
+	Delta      int64
+}
+
+func (w *Writer) writePlayCountReconciliation(ctx context.Context) error {
+	return processBatched(ctx, w, "play_count_reconciliation",
+		// Count tracks that have a positive delta (pruned plays not in the plays table).
+		`SELECT count(*) FROM (
+			SELECT ap.play_item_id
+			FROM aggregate_plays ap
+			LEFT JOIN (
+				SELECT play_item_id, count(*) AS cnt
+				FROM plays
+				GROUP BY play_item_id
+			) p ON p.play_item_id = ap.play_item_id
+			WHERE ap.count - COALESCE(p.cnt, 0) > 0
+		) t`,
+		// Select the delta for each track.
+		`SELECT ap.play_item_id, ap.count - COALESCE(p.cnt, 0) AS delta
+		FROM aggregate_plays ap
+		LEFT JOIN (
+			SELECT play_item_id, count(*) AS cnt
+			FROM plays
+			GROUP BY play_item_id
+		) p ON p.play_item_id = ap.play_item_id
+		WHERE ap.count - COALESCE(p.cnt, 0) > 0
+		ORDER BY ap.play_item_id`,
+		func(rows pgx.Rows) (sourcePlayCountDelta, error) {
+			var d sourcePlayCountDelta
+			err := rows.Scan(&d.PlayItemID, &d.Delta)
+			return d, err
+		},
+		func(ctx context.Context, d sourcePlayCountDelta) error {
+			metaJSON, err := json.Marshal(playCountReconciliationMetadata{
+				Delta: d.Delta,
+			})
+			if err != nil {
+				return fmt.Errorf("marshal play count reconciliation metadata for track %d: %w", d.PlayItemID, err)
+			}
+			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+				UserId:     0,
+				EntityType: "PlayCount",
+				EntityId:   d.PlayItemID,
+				Action:     "Reconcile",
+				Metadata:   string(metaJSON),
+			})
+		},
+	)
+}

--- a/cmd/genesis-writer/writer.go
+++ b/cmd/genesis-writer/writer.go
@@ -422,7 +422,8 @@ func (w *Writer) Run(ctx context.Context) error {
 		{"encrypted emails", w.cfg.SkipEmails, w.writeEncryptedEmails},
 		{"email access", w.cfg.SkipEmails, w.writeEmailAccess},
 
-		// Phase 7: Activity — plays and tip reactions
+		// Phase 7: Activity — play count reconciliation, plays, and tip reactions
+		{"play count reconciliation", w.cfg.SkipPlays, w.writePlayCountReconciliation},
 		{"plays", w.cfg.SkipPlays, w.writePlays},
 		{"tip reactions", w.cfg.SkipTipReactions, w.writeTipReactions},
 	}


### PR DESCRIPTION
## Summary

- The `plays` table only retains ~400 days of play history, but `aggregate_plays` has lifetime totals. This means genesis replay of just the `plays` rows would undercount tracks with older history.
- This adds a new `play_count_reconciliation` step that emits `PlayCount/Reconcile` ManageEntity transactions carrying the delta between `aggregate_plays.count` and the actual row count in `plays` for each track.
- Runs before the `plays` step so the ETL can set the base count before individual plays are replayed on top.

## Notes

- The ETL will need a corresponding handler to process `PlayCount/Reconcile` transactions (separate PR).
- Tracks where the plays table already accounts for the full count are skipped (delta <= 0).
- Gated by the existing `SkipPlays` config flag.

## Test plan

- [ ] Verify genesis-writer compiles with the new file
- [ ] Run against a staging database and confirm `PlayCount/Reconcile` transactions are emitted with correct deltas
- [ ] Confirm tracks with no pruned plays are skipped
- [ ] End-to-end test once the ETL handler is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)