### PR TITLE
fix(genesis-writer): migrate access_authorities for programmable distribution

### DIFF
--- a/cmd/genesis-writer/entities_track.go
+++ b/cmd/genesis-writer/entities_track.go
@@ -11,8 +11,9 @@ import (
 )
 
 type trackMetadataWrapper struct {
-	CID  string             `json:"cid"`
-	Data trackMetadataInner `json:"data"`
+	CID               string             `json:"cid"`
+	AccessAuthorities []string           `json:"access_authorities,omitempty"`
+	Data              trackMetadataInner `json:"data"`
 }
 
 type trackMetadataInner struct {
@@ -73,6 +74,7 @@ type sourceTrack struct {
 	StreamConditions    []byte // JSONB
 	IsDownloadGated     bool
 	DownloadConditions  []byte // JSONB
+	AccessAuthorities   []string
 	CreatedAt           time.Time
 }
 
@@ -88,6 +90,7 @@ func (w *Writer) writeTracks(ctx context.Context) error {
 			remix_of, stem_of,
 			is_stream_gated, stream_conditions,
 			is_download_gated, download_conditions,
+			access_authorities,
 			created_at
 		FROM tracks
 		WHERE is_current = true AND is_delete = false AND is_available = true
@@ -103,6 +106,7 @@ func (w *Writer) writeTracks(ctx context.Context) error {
 				&t.RemixOf, &t.StemOf,
 				&t.IsStreamGated, &t.StreamConditions,
 				&t.IsDownloadGated, &t.DownloadConditions,
+				&t.AccessAuthorities,
 				&t.CreatedAt,
 			)
 			return t, err
@@ -141,8 +145,9 @@ func (w *Writer) writeTracks(ctx context.Context) error {
 			inner.TrackCID = deref(t.TrackCID)
 
 			metaJSON, err := json.Marshal(trackMetadataWrapper{
-				CID:  deref(t.TrackCID),
-				Data: inner,
+				CID:               deref(t.TrackCID),
+				AccessAuthorities: t.AccessAuthorities,
+				Data:              inner,
 			})
 			if err != nil {
 				return fmt.Errorf("marshal track %d metadata: %w", t.TrackID, err)

--- a/pkg/core/server/manage_entity.go
+++ b/pkg/core/server/manage_entity.go
@@ -24,14 +24,30 @@ func (s *Server) validateManageEntity(_ context.Context, stx *v1.SignedTransacti
 }
 
 // finalizeManageEntityMigration handles ManageEntityLegacyMigration transactions written
-// by genesis-writer. The transaction is stored as-is; no additional chain-side processing
-// is performed (e.g. sound_recordings/management_keys are not populated for Track creates
-// because genesis migration data does not carry live CIDs).
-func (s *Server) finalizeManageEntityMigration(_ context.Context, stx *v1.SignedTransaction) (proto.Message, error) {
+// by genesis-writer. Populates sound_recordings and management_keys for Track
+// creates that carry access_authorities, matching the finalizeManageEntity path.
+func (s *Server) finalizeManageEntityMigration(ctx context.Context, stx *v1.SignedTransaction) (proto.Message, error) {
 	me := stx.GetManageEntityMigration()
 	if me == nil {
 		return nil, errors.New("not manage entity migration")
 	}
+
+	if strings.EqualFold(me.GetEntityType(), "Track") &&
+		strings.EqualFold(me.GetAction(), "Create") {
+		legacy := &v1.ManageEntityLegacy{
+			UserId:     me.GetUserId(),
+			EntityType: me.GetEntityType(),
+			EntityId:   me.GetEntityId(),
+			Action:     me.GetAction(),
+			Metadata:   me.GetMetadata(),
+		}
+		if err := s.processTrackManageEntity(ctx, legacy); err != nil {
+			s.logger.Error("failed to process migrated track manage entity", zap.Error(err),
+				zap.String("entity_type", me.GetEntityType()),
+				zap.Int64("entity_id", me.GetEntityId()))
+		}
+	}
+
 	return me, nil
 }
 


### PR DESCRIPTION
## Summary
- Genesis writer was not including `access_authorities` in track metadata, so `sound_recordings` and `management_keys` tables were empty after migration — breaking coin-gated streams and USDC purchase gating
- `finalizeManageEntityMigration` now calls `processTrackManageEntity` for Track Creates, populating the tables from the metadata

## What was broken
For any track with programmable distribution (coin-gated streams, USDC purchase gating):
- `management_keys` was empty, so mediorum's access check fell through to default validator auth
- Gated tracks became freely streamable by anyone with a validator signature

## Test plan
- [ ] Run genesis writer against snapshot, verify `management_keys` and `sound_recordings` are populated for gated tracks
- [ ] Verify non-gated tracks are unaffected (no `access_authorities` → no rows inserted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)