### PR TITLE
fix(genesis-writer): use user wallets as signer for ValidateSigner entities

### DIFF
--- a/cmd/genesis-writer/entities_comment.go
+++ b/cmd/genesis-writer/entities_comment.go
@@ -26,6 +26,7 @@ type sourceComment struct {
 	CommentID       int64
 	Text            *string
 	UserID          int64
+	UserWallet      string
 	EntityID        int64
 	EntityType      string
 	TrackTimestampS *int
@@ -49,13 +50,14 @@ func (w *Writer) writeComments(ctx context.Context) error {
 
 	return processBatched(ctx, w, "comments",
 		`SELECT count(*) FROM comments WHERE is_delete = false`,
-		`SELECT comment_id, text, user_id, entity_id, entity_type, track_timestamp_s, created_at
-		FROM comments
-		WHERE is_delete = false
-		ORDER BY comment_id`,
+		`SELECT c.comment_id, c.text, c.user_id, COALESCE(LOWER(u.wallet), ''), c.entity_id, c.entity_type, c.track_timestamp_s, c.created_at
+		FROM comments c
+		LEFT JOIN users u ON u.user_id = c.user_id AND u.is_current = true
+		WHERE c.is_delete = false
+		ORDER BY c.comment_id`,
 		func(rows pgx.Rows) (sourceComment, error) {
 			var c sourceComment
-			err := rows.Scan(&c.CommentID, &c.Text, &c.UserID, &c.EntityID, &c.EntityType, &c.TrackTimestampS, &c.CreatedAt)
+			err := rows.Scan(&c.CommentID, &c.Text, &c.UserID, &c.UserWallet, &c.EntityID, &c.EntityType, &c.TrackTimestampS, &c.CreatedAt)
 			return c, err
 		},
 		func(ctx context.Context, c sourceComment) error {
@@ -81,13 +83,13 @@ func (w *Writer) writeComments(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal comment %d metadata: %w", c.CommentID, err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     c.UserID,
 				EntityType: "Comment",
 				EntityId:   c.CommentID,
 				Action:     "Create",
 				Metadata:   string(metaJSON),
-			})
+			}, c.UserWallet)
 		},
 	)
 }
@@ -98,17 +100,19 @@ func (w *Writer) writeCommentReactions(ctx context.Context) error {
 	type commentReaction struct {
 		commentID int64
 		userID    int64
+		wallet    string
 		createdAt time.Time
 	}
 	return processBatched(ctx, w, "comment_reactions",
 		`SELECT count(*) FROM comment_reactions WHERE is_delete = false`,
-		`SELECT comment_id, user_id, created_at
-		FROM comment_reactions
-		WHERE is_delete = false
-		ORDER BY comment_id, user_id`,
+		`SELECT cr.comment_id, cr.user_id, COALESCE(LOWER(u.wallet), ''), cr.created_at
+		FROM comment_reactions cr
+		LEFT JOIN users u ON u.user_id = cr.user_id AND u.is_current = true
+		WHERE cr.is_delete = false
+		ORDER BY cr.comment_id, cr.user_id`,
 		func(rows pgx.Rows) (commentReaction, error) {
 			var cr commentReaction
-			err := rows.Scan(&cr.commentID, &cr.userID, &cr.createdAt)
+			err := rows.Scan(&cr.commentID, &cr.userID, &cr.wallet, &cr.createdAt)
 			return cr, err
 		},
 		func(ctx context.Context, cr commentReaction) error {
@@ -116,13 +120,13 @@ func (w *Writer) writeCommentReactions(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal comment reaction metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     cr.userID,
 				EntityType: "CommentReaction",
 				EntityId:   cr.commentID,
 				Action:     "React",
 				Metadata:   string(metaJSON),
-			})
+			}, cr.wallet)
 		},
 	)
 }

--- a/cmd/genesis-writer/entities_playlist.go
+++ b/cmd/genesis-writer/entities_playlist.go
@@ -32,6 +32,7 @@ type playlistMetadataInner struct {
 type sourcePlaylist struct {
 	PlaylistID          int64
 	PlaylistOwnerID     int64
+	OwnerWallet         string
 	PlaylistName        *string
 	Description         *string
 	IsAlbum             bool
@@ -49,18 +50,21 @@ func (w *Writer) writePlaylists(ctx context.Context) error {
 	return processBatched(ctx, w, "playlists",
 		`SELECT count(*) FROM playlists WHERE is_current = true AND is_delete = false`,
 		`SELECT
-			playlist_id, playlist_owner_id, playlist_name, description,
-			is_album, is_private,
-			metadata_multihash, playlist_image_sizes_multihash, playlist_contents,
-			release_date::text, is_stream_gated, stream_conditions,
-			created_at
-		FROM playlists
-		WHERE is_current = true AND is_delete = false
-		ORDER BY playlist_id`,
+			p.playlist_id, p.playlist_owner_id, COALESCE(LOWER(u.wallet), ''),
+			p.playlist_name, p.description,
+			p.is_album, p.is_private,
+			p.metadata_multihash, p.playlist_image_sizes_multihash, p.playlist_contents,
+			p.release_date::text, p.is_stream_gated, p.stream_conditions,
+			p.created_at
+		FROM playlists p
+		LEFT JOIN users u ON u.user_id = p.playlist_owner_id AND u.is_current = true
+		WHERE p.is_current = true AND p.is_delete = false
+		ORDER BY p.playlist_id`,
 		func(rows pgx.Rows) (sourcePlaylist, error) {
 			var p sourcePlaylist
 			err := rows.Scan(
-				&p.PlaylistID, &p.PlaylistOwnerID, &p.PlaylistName, &p.Description,
+				&p.PlaylistID, &p.PlaylistOwnerID, &p.OwnerWallet,
+				&p.PlaylistName, &p.Description,
 				&p.IsAlbum, &p.IsPrivate,
 				&p.MetadataMultihash, &p.ImageSizesMultihash, &p.PlaylistContents,
 				&p.ReleaseDate, &p.IsStreamGated, &p.StreamConditions,
@@ -95,13 +99,13 @@ func (w *Writer) writePlaylists(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal playlist %d metadata: %w", p.PlaylistID, err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     p.PlaylistOwnerID,
 				EntityType: "Playlist",
 				EntityId:   p.PlaylistID,
 				Action:     "Create",
 				Metadata:   string(metaJSON),
-			})
+			}, p.OwnerWallet)
 		},
 	)
 }

--- a/cmd/genesis-writer/entities_social.go
+++ b/cmd/genesis-writer/entities_social.go
@@ -24,17 +24,19 @@ func fmtCreatedAt(t time.Time) string {
 func (w *Writer) writeFollows(ctx context.Context) error {
 	type follow struct {
 		follower, followee int64
+		wallet             string
 		createdAt          time.Time
 	}
 	return processBatched(ctx, w, "follows",
 		`SELECT count(*) FROM follows WHERE is_current = true AND is_delete = false`,
-		`SELECT follower_user_id, followee_user_id, created_at
-		FROM follows
-		WHERE is_current = true AND is_delete = false
-		ORDER BY follower_user_id, followee_user_id`,
+		`SELECT f.follower_user_id, f.followee_user_id, COALESCE(LOWER(u.wallet), ''), f.created_at
+		FROM follows f
+		LEFT JOIN users u ON u.user_id = f.follower_user_id AND u.is_current = true
+		WHERE f.is_current = true AND f.is_delete = false
+		ORDER BY f.follower_user_id, f.followee_user_id`,
 		func(rows pgx.Rows) (follow, error) {
 			var f follow
-			err := rows.Scan(&f.follower, &f.followee, &f.createdAt)
+			err := rows.Scan(&f.follower, &f.followee, &f.wallet, &f.createdAt)
 			return f, err
 		},
 		func(ctx context.Context, f follow) error {
@@ -42,13 +44,13 @@ func (w *Writer) writeFollows(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal follow metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     f.follower,
 				EntityType: "User",
 				EntityId:   f.followee,
 				Action:     "Follow",
 				Metadata:   string(metaJSON),
-			})
+			}, f.wallet)
 		},
 	)
 }
@@ -58,18 +60,20 @@ func (w *Writer) writeFollows(ctx context.Context) error {
 func (w *Writer) writeSaves(ctx context.Context) error {
 	type save struct {
 		userID, itemID int64
+		wallet         string
 		saveType       string
 		createdAt      time.Time
 	}
 	return processBatched(ctx, w, "saves",
 		`SELECT count(*) FROM saves WHERE is_current = true AND is_delete = false`,
-		`SELECT user_id, save_item_id, save_type, created_at
-		FROM saves
-		WHERE is_current = true AND is_delete = false
-		ORDER BY user_id, save_item_id`,
+		`SELECT s.user_id, s.save_item_id, COALESCE(LOWER(u.wallet), ''), s.save_type, s.created_at
+		FROM saves s
+		LEFT JOIN users u ON u.user_id = s.user_id AND u.is_current = true
+		WHERE s.is_current = true AND s.is_delete = false
+		ORDER BY s.user_id, s.save_item_id`,
 		func(rows pgx.Rows) (save, error) {
 			var s save
-			err := rows.Scan(&s.userID, &s.itemID, &s.saveType, &s.createdAt)
+			err := rows.Scan(&s.userID, &s.itemID, &s.wallet, &s.saveType, &s.createdAt)
 			return s, err
 		},
 		func(ctx context.Context, s save) error {
@@ -77,13 +81,13 @@ func (w *Writer) writeSaves(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal save metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     s.userID,
 				EntityType: saveRepostEntityType(s.saveType),
 				EntityId:   s.itemID,
 				Action:     "Save",
 				Metadata:   string(metaJSON),
-			})
+			}, s.wallet)
 		},
 	)
 }
@@ -93,18 +97,20 @@ func (w *Writer) writeSaves(ctx context.Context) error {
 func (w *Writer) writeReposts(ctx context.Context) error {
 	type repost struct {
 		userID, itemID int64
+		wallet         string
 		repostType     string
 		createdAt      time.Time
 	}
 	return processBatched(ctx, w, "reposts",
 		`SELECT count(*) FROM reposts WHERE is_current = true AND is_delete = false`,
-		`SELECT user_id, repost_item_id, repost_type, created_at
-		FROM reposts
-		WHERE is_current = true AND is_delete = false
-		ORDER BY user_id, repost_item_id`,
+		`SELECT r.user_id, r.repost_item_id, COALESCE(LOWER(u.wallet), ''), r.repost_type, r.created_at
+		FROM reposts r
+		LEFT JOIN users u ON u.user_id = r.user_id AND u.is_current = true
+		WHERE r.is_current = true AND r.is_delete = false
+		ORDER BY r.user_id, r.repost_item_id`,
 		func(rows pgx.Rows) (repost, error) {
 			var r repost
-			err := rows.Scan(&r.userID, &r.itemID, &r.repostType, &r.createdAt)
+			err := rows.Scan(&r.userID, &r.itemID, &r.wallet, &r.repostType, &r.createdAt)
 			return r, err
 		},
 		func(ctx context.Context, r repost) error {
@@ -112,13 +118,13 @@ func (w *Writer) writeReposts(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal repost metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     r.userID,
 				EntityType: saveRepostEntityType(r.repostType),
 				EntityId:   r.itemID,
 				Action:     "Repost",
 				Metadata:   string(metaJSON),
-			})
+			}, r.wallet)
 		},
 	)
 }
@@ -129,17 +135,19 @@ func (w *Writer) writeShares(ctx context.Context) error {
 	type share struct {
 		userID    int64
 		itemID    int64
+		wallet    string
 		shareType string
 		createdAt time.Time
 	}
 	return processBatched(ctx, w, "shares",
 		`SELECT count(*) FROM shares`,
-		`SELECT user_id, share_item_id, share_type, created_at
-		FROM shares
-		ORDER BY user_id, share_item_id`,
+		`SELECT s.user_id, s.share_item_id, COALESCE(LOWER(u.wallet), ''), s.share_type, s.created_at
+		FROM shares s
+		LEFT JOIN users u ON u.user_id = s.user_id AND u.is_current = true
+		ORDER BY s.user_id, s.share_item_id`,
 		func(rows pgx.Rows) (share, error) {
 			var s share
-			err := rows.Scan(&s.userID, &s.itemID, &s.shareType, &s.createdAt)
+			err := rows.Scan(&s.userID, &s.itemID, &s.wallet, &s.shareType, &s.createdAt)
 			return s, err
 		},
 		func(ctx context.Context, s share) error {
@@ -147,13 +155,13 @@ func (w *Writer) writeShares(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal share metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     s.userID,
 				EntityType: saveRepostEntityType(s.shareType),
 				EntityId:   s.itemID,
 				Action:     "Share",
 				Metadata:   string(metaJSON),
-			})
+			}, s.wallet)
 		},
 	)
 }
@@ -163,17 +171,19 @@ func (w *Writer) writeShares(ctx context.Context) error {
 func (w *Writer) writeSubscriptions(ctx context.Context) error {
 	type subscription struct {
 		subscriberID, userID int64
+		wallet               string
 		createdAt            time.Time
 	}
 	return processBatched(ctx, w, "subscriptions",
 		`SELECT count(*) FROM subscriptions WHERE is_current = true AND is_delete = false`,
-		`SELECT subscriber_id, user_id, created_at
-		FROM subscriptions
-		WHERE is_current = true AND is_delete = false
-		ORDER BY subscriber_id, user_id`,
+		`SELECT s.subscriber_id, s.user_id, COALESCE(LOWER(u.wallet), ''), s.created_at
+		FROM subscriptions s
+		LEFT JOIN users u ON u.user_id = s.subscriber_id AND u.is_current = true
+		WHERE s.is_current = true AND s.is_delete = false
+		ORDER BY s.subscriber_id, s.user_id`,
 		func(rows pgx.Rows) (subscription, error) {
 			var s subscription
-			err := rows.Scan(&s.subscriberID, &s.userID, &s.createdAt)
+			err := rows.Scan(&s.subscriberID, &s.userID, &s.wallet, &s.createdAt)
 			return s, err
 		},
 		func(ctx context.Context, s subscription) error {
@@ -181,13 +191,13 @@ func (w *Writer) writeSubscriptions(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal subscription metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     s.subscriberID,
 				EntityType: "User",
 				EntityId:   s.userID,
 				Action:     "Subscribe",
 				Metadata:   string(metaJSON),
-			})
+			}, s.wallet)
 		},
 	)
 }
@@ -197,17 +207,19 @@ func (w *Writer) writeSubscriptions(ctx context.Context) error {
 func (w *Writer) writeMutedUsers(ctx context.Context) error {
 	type mutedUser struct {
 		userID, mutedUserID int64
+		wallet              string
 		createdAt           time.Time
 	}
 	return processBatched(ctx, w, "muted_users",
 		`SELECT count(*) FROM muted_users WHERE is_delete = false`,
-		`SELECT user_id, muted_user_id, created_at
-		FROM muted_users
-		WHERE is_delete = false
-		ORDER BY user_id, muted_user_id`,
+		`SELECT m.user_id, m.muted_user_id, COALESCE(LOWER(u.wallet), ''), m.created_at
+		FROM muted_users m
+		LEFT JOIN users u ON u.user_id = m.user_id AND u.is_current = true
+		WHERE m.is_delete = false
+		ORDER BY m.user_id, m.muted_user_id`,
 		func(rows pgx.Rows) (mutedUser, error) {
 			var m mutedUser
-			err := rows.Scan(&m.userID, &m.mutedUserID, &m.createdAt)
+			err := rows.Scan(&m.userID, &m.mutedUserID, &m.wallet, &m.createdAt)
 			return m, err
 		},
 		func(ctx context.Context, m mutedUser) error {
@@ -215,13 +227,13 @@ func (w *Writer) writeMutedUsers(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal muted user metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     m.userID,
 				EntityType: "MutedUser",
 				EntityId:   m.mutedUserID,
 				Action:     "Mute",
 				Metadata:   string(metaJSON),
-			})
+			}, m.wallet)
 		},
 	)
 }

--- a/cmd/genesis-writer/entities_tip.go
+++ b/cmd/genesis-writer/entities_tip.go
@@ -62,13 +62,13 @@ func (w *Writer) writeTipReactions(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal tip reaction metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     userID,
 				EntityType: "Tip",
 				EntityId:   0,
 				Action:     "React",
 				Metadata:   string(metaJSON),
-			})
+			}, strings.ToLower(tr.SenderWallet))
 		},
 	)
 }

--- a/cmd/genesis-writer/entities_track.go
+++ b/cmd/genesis-writer/entities_track.go
@@ -48,6 +48,7 @@ type trackMetadataInner struct {
 type sourceTrack struct {
 	TrackID             int64
 	OwnerID             int64
+	OwnerWallet         string
 	Title               *string
 	Description         *string
 	Duration            *int
@@ -80,22 +81,23 @@ func (w *Writer) writeTracks(ctx context.Context) error {
 	return processBatched(ctx, w, "tracks",
 		`SELECT count(*) FROM tracks WHERE is_current = true AND is_delete = false AND is_available = true`,
 		`SELECT
-			track_id, owner_id, title, description, duration, genre, mood, tags,
-			track_cid,
-			cover_art, cover_art_sizes, preview_cid,
-			is_unlisted, is_downloadable, is_original_available,
-			release_date::text, license, isrc, iswc, bpm, musical_key,
-			remix_of, stem_of,
-			is_stream_gated, stream_conditions,
-			is_download_gated, download_conditions,
-			created_at
-		FROM tracks
-		WHERE is_current = true AND is_delete = false AND is_available = true
-		ORDER BY track_id`,
+			t.track_id, t.owner_id, COALESCE(LOWER(u.wallet), ''), t.title, t.description, t.duration, t.genre, t.mood, t.tags,
+			t.track_cid,
+			t.cover_art, t.cover_art_sizes, t.preview_cid,
+			t.is_unlisted, t.is_downloadable, t.is_original_available,
+			t.release_date::text, t.license, t.isrc, t.iswc, t.bpm, t.musical_key,
+			t.remix_of, t.stem_of,
+			t.is_stream_gated, t.stream_conditions,
+			t.is_download_gated, t.download_conditions,
+			t.created_at
+		FROM tracks t
+		LEFT JOIN users u ON u.user_id = t.owner_id AND u.is_current = true
+		WHERE t.is_current = true AND t.is_delete = false AND t.is_available = true
+		ORDER BY t.track_id`,
 		func(rows pgx.Rows) (sourceTrack, error) {
 			var t sourceTrack
 			err := rows.Scan(
-				&t.TrackID, &t.OwnerID, &t.Title, &t.Description, &t.Duration, &t.Genre, &t.Mood, &t.Tags,
+				&t.TrackID, &t.OwnerID, &t.OwnerWallet, &t.Title, &t.Description, &t.Duration, &t.Genre, &t.Mood, &t.Tags,
 				&t.TrackCID,
 				&t.CoverArt, &t.CoverArtSizes, &t.PreviewCID,
 				&t.IsUnlisted, &t.IsDownloadable, &t.IsOriginalAvailable,
@@ -147,13 +149,13 @@ func (w *Writer) writeTracks(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal track %d metadata: %w", t.TrackID, err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     t.OwnerID,
 				EntityType: "Track",
 				EntityId:   t.TrackID,
 				Action:     "Create",
 				Metadata:   string(metaJSON),
-			})
+			}, t.OwnerWallet)
 		},
 	)
 }
@@ -171,6 +173,7 @@ type sourceTrackDownload struct {
 	ParentTrackID int64
 	TrackID       int64
 	UserID        *int64
+	UserWallet    string
 	City          *string
 	Region        *string
 	Country       *string
@@ -180,12 +183,13 @@ type sourceTrackDownload struct {
 func (w *Writer) writeTrackDownloads(ctx context.Context) error {
 	return processBatched(ctx, w, "track_downloads",
 		`SELECT count(*) FROM track_downloads`,
-		`SELECT parent_track_id, track_id, user_id, city, region, country, created_at
-		FROM track_downloads
-		ORDER BY parent_track_id, track_id`,
+		`SELECT td.parent_track_id, td.track_id, td.user_id, COALESCE(LOWER(u.wallet), ''), td.city, td.region, td.country, td.created_at
+		FROM track_downloads td
+		LEFT JOIN users u ON u.user_id = td.user_id AND u.is_current = true
+		ORDER BY td.parent_track_id, td.track_id`,
 		func(rows pgx.Rows) (sourceTrackDownload, error) {
 			var d sourceTrackDownload
-			err := rows.Scan(&d.ParentTrackID, &d.TrackID, &d.UserID, &d.City, &d.Region, &d.Country, &d.CreatedAt)
+			err := rows.Scan(&d.ParentTrackID, &d.TrackID, &d.UserID, &d.UserWallet, &d.City, &d.Region, &d.Country, &d.CreatedAt)
 			return d, err
 		},
 		func(ctx context.Context, d sourceTrackDownload) error {
@@ -203,13 +207,13 @@ func (w *Writer) writeTrackDownloads(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal track download metadata: %w", err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     userID,
 				EntityType: "Track",
 				EntityId:   d.TrackID,
 				Action:     "Download",
 				Metadata:   string(metaJSON),
-			})
+			}, d.UserWallet)
 		},
 	)
 }

--- a/cmd/genesis-writer/entities_user.go
+++ b/cmd/genesis-writer/entities_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
@@ -99,13 +100,17 @@ func (w *Writer) writeUsers(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("marshal user %d metadata: %w", u.UserID, err)
 			}
-			return w.addManageEntity(ctx, &corev1.ManageEntityLegacy{
+			signer := w.signerAddr
+			if u.Wallet != nil && *u.Wallet != "" {
+				signer = strings.ToLower(*u.Wallet)
+			}
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
 				UserId:     u.UserID,
 				EntityType: "User",
 				EntityId:   u.UserID,
 				Action:     "Create",
 				Metadata:   string(metaJSON),
-			})
+			}, signer)
 		},
 	)
 }


### PR DESCRIPTION
## Summary
- The ETL's `ValidateSigner` checks that `params.Signer` matches the acting user's wallet. Previously, the genesis writer used the migration address as signer for most entity types, which would cause all migration txs to be silently rejected as validation warnings.
- Each entity query now JOINs the `users` table to fetch the wallet inline (no in-memory cache needed), and passes it to `addManageEntityWithSigner`.
- Updated entities: Track, Playlist, Follow, Save, Repost, Share, Subscribe, MutedUser, Comment, CommentReaction, Tip, TrackDownload, User. Email and PlayCount entities unchanged (their ETL handlers don't call `ValidateSigner`).

## Test plan
- [ ] Run `go build ./cmd/genesis-writer/...` — compiles clean
- [ ] Run genesis writer integration test against a test database
- [ ] Verify migrated entities have user wallets as signer (not migration address)
- [ ] Verify ETL indexes all migrated entity types without ValidateSigner rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)