### PR TITLE
feat(genesis-writer): add events migration

### DIFF
--- a/cmd/genesis-writer/entities_event.go
+++ b/cmd/genesis-writer/entities_event.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	"github.com/jackc/pgx/v5"
+)
+
+type eventMetadata struct {
+	EventType  string `json:"event_type"`
+	EndDate    string `json:"end_date,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
+	EntityID   *int64 `json:"entity_id,omitempty"`
+	EventData  any    `json:"event_data,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+}
+
+type sourceEvent struct {
+	EventID    int64
+	EventType  string
+	UserID     int64
+	UserWallet string
+	EntityType *string
+	EntityID   *int64
+	EndDate    *time.Time
+	EventData  []byte // JSONB
+	CreatedAt  time.Time
+}
+
+func (w *Writer) writeEvents(ctx context.Context) error {
+	return processBatched(ctx, w, "events",
+		`SELECT count(*) FROM events WHERE is_deleted = false`,
+		`SELECT e.event_id, e.event_type, e.user_id, COALESCE(LOWER(u.wallet), ''),
+			e.entity_type, e.entity_id, e.end_date, e.event_data, e.created_at
+		FROM events e
+		LEFT JOIN users u ON u.user_id = e.user_id AND u.is_current = true
+		WHERE e.is_deleted = false
+		ORDER BY e.event_id`,
+		func(rows pgx.Rows) (sourceEvent, error) {
+			var e sourceEvent
+			err := rows.Scan(&e.EventID, &e.EventType, &e.UserID, &e.UserWallet,
+				&e.EntityType, &e.EntityID, &e.EndDate, &e.EventData, &e.CreatedAt)
+			return e, err
+		},
+		func(ctx context.Context, e sourceEvent) error {
+			meta := eventMetadata{
+				EventType: e.EventType,
+				EntityID:  e.EntityID,
+				CreatedAt: e.CreatedAt.Format(time.RFC3339),
+			}
+			if e.EntityType != nil {
+				meta.EntityType = *e.EntityType
+			}
+			if e.EndDate != nil {
+				meta.EndDate = e.EndDate.Format(time.RFC3339)
+			}
+			meta.EventData = unmarshalJSONB(e.EventData)
+
+			metaJSON, err := json.Marshal(meta)
+			if err != nil {
+				return fmt.Errorf("marshal event %d metadata: %w", e.EventID, err)
+			}
+			return w.addManageEntityWithSigner(ctx, &corev1.ManageEntityLegacy{
+				UserId:     e.UserID,
+				EntityType: "Event",
+				EntityId:   e.EventID,
+				Action:     "Create",
+				Metadata:   string(metaJSON),
+			}, e.UserWallet)
+		},
+	)
+}

--- a/cmd/genesis-writer/main.go
+++ b/cmd/genesis-writer/main.go
@@ -132,6 +132,7 @@ func writeCmd() *cli.Command {
 			&cli.BoolFlag{Name: "skip-comments", EnvVars: []string{"GENESIS_SKIP_COMMENTS"}, Usage: "Skip comments and comment reactions"},
 			&cli.BoolFlag{Name: "skip-emails", EnvVars: []string{"GENESIS_SKIP_EMAILS"}, Usage: "Skip encrypted emails and email access grants"},
 			&cli.BoolFlag{Name: "skip-tip-reactions", EnvVars: []string{"GENESIS_SKIP_TIP_REACTIONS"}},
+			&cli.BoolFlag{Name: "skip-events", EnvVars: []string{"GENESIS_SKIP_EVENTS"}, Usage: "Skip events"},
 		},
 		Action: func(c *cli.Context) error {
 			logger, _ := zap.NewProduction()
@@ -221,6 +222,7 @@ func writeCmd() *cli.Command {
 				SkipComments:         c.Bool("skip-comments"),
 				SkipEmails:           c.Bool("skip-emails"),
 				SkipTipReactions:     c.Bool("skip-tip-reactions"),
+				SkipEvents:           c.Bool("skip-events"),
 			}
 
 			w, err := NewWriter(cfg, logger)

--- a/cmd/genesis-writer/writer.go
+++ b/cmd/genesis-writer/writer.go
@@ -55,6 +55,7 @@ type WriterConfig struct {
 	SkipComments         bool
 	SkipEmails           bool
 	SkipTipReactions     bool
+	SkipEvents           bool
 	// RunMigrations applies the Core chain schema to DstDSN before writing.
 	// Useful when starting from a fresh database (e.g., in integration tests).
 	RunMigrations bool
@@ -422,7 +423,10 @@ func (w *Writer) Run(ctx context.Context) error {
 		{"encrypted emails", w.cfg.SkipEmails, w.writeEncryptedEmails},
 		{"email access", w.cfg.SkipEmails, w.writeEmailAccess},
 
-		// Phase 7: Activity — play count reconciliation, plays, and tip reactions
+		// Phase 7: Events
+		{"events", w.cfg.SkipEvents, w.writeEvents},
+
+		// Phase 8: Activity — play count reconciliation, plays, and tip reactions
 		{"play count reconciliation", w.cfg.SkipPlays, w.writePlayCountReconciliation},
 		{"plays", w.cfg.SkipPlays, w.writePlays},
 		{"tip reactions", w.cfg.SkipTipReactions, w.writeTipReactions},


### PR DESCRIPTION
## Summary
- Adds `entities_event.go` to query the `events` table and emit `Event:Create` ManageEntity transactions
- JOINs `users` table to set the user's wallet as signer (required by ETL `ValidateSigner`)
- Adds `--skip-events` / `GENESIS_SKIP_EVENTS` flag
- Events are placed in Phase 7 (after emails, before plays/activity)

## Test plan
- [ ] `go build ./cmd/genesis-writer/...` compiles clean
- [ ] Run genesis writer against a test DB with events present
- [ ] Verify ETL indexes migrated events without ValidateSigner rejections
- [ ] Verify event_routes are generated correctly by the ETL handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)