### PR TITLE
feat(genesis-writer): add rewards migration via blockstore replay

### DIFF
--- a/cmd/genesis-writer/entities_reward.go
+++ b/cmd/genesis-writer/entities_reward.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	dbm "github.com/cometbft/cometbft-db"
+	cmtstore "github.com/cometbft/cometbft/store"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+// writeRewards scans the old chain's blockstore for RewardPoolMessage and
+// RewardMessage transactions and re-emits them verbatim into the new chain.
+// The ABCI finalization layer processes them normally — signature recovery,
+// pool authorization, and deadline checks all pass because the original
+// signed bytes are preserved and the new chain's block heights are low
+// enough that no deadline has expired.
+//
+// Pool transactions are emitted before reward transactions (matching the
+// original chain order) so that pool authorization checks succeed.
+func (w *Writer) writeRewards(ctx context.Context) error {
+	if w.cfg.CoreCMTHome == "" {
+		w.logger.Info("no --core-cmt-home provided, skipping rewards")
+		return nil
+	}
+
+	dataDir := filepath.Join(w.cfg.CoreCMTHome, "data")
+	bsDB, err := dbm.NewDB("blockstore", dbm.PebbleDBBackend, dataDir)
+	if err != nil {
+		return fmt.Errorf("open old blockstore: %w", err)
+	}
+	defer bsDB.Close()
+
+	oldStore := cmtstore.NewBlockStore(bsDB)
+	base := oldStore.Base()
+	height := oldStore.Height()
+	w.logger.Info("scanning old blockstore for reward txs",
+		zap.Int64("base", base), zap.Int64("height", height))
+
+	// Two passes: pools first, then rewards, to satisfy FK ordering.
+	// Collect raw tx bytes per category.
+	var poolTxBytes [][]byte
+	var rewardTxBytes [][]byte
+
+	for h := base; h <= height; h++ {
+		block, _ := oldStore.LoadBlock(h)
+		if block == nil {
+			continue
+		}
+		for _, tx := range block.Txs {
+			var stx corev1.SignedTransaction
+			if err := proto.Unmarshal(tx, &stx); err != nil {
+				continue // not a valid proto — skip
+			}
+			switch stx.Transaction.(type) {
+			case *corev1.SignedTransaction_RewardPool:
+				poolTxBytes = append(poolTxBytes, tx)
+			case *corev1.SignedTransaction_Reward:
+				rewardTxBytes = append(rewardTxBytes, tx)
+			}
+		}
+
+		if h%100000 == 0 && h > base {
+			w.logger.Info("scan progress",
+				zap.Int64("height", h),
+				zap.Int("pools", len(poolTxBytes)),
+				zap.Int("rewards", len(rewardTxBytes)))
+		}
+	}
+
+	w.logger.Info("found reward txs",
+		zap.Int("pools", len(poolTxBytes)),
+		zap.Int("rewards", len(rewardTxBytes)))
+
+	// Emit pool txs first.
+	for i, txBytes := range poolTxBytes {
+		if err := w.addTx(ctx, txBytes); err != nil {
+			return fmt.Errorf("emit reward pool tx %d: %w", i, err)
+		}
+	}
+
+	// Then reward txs.
+	for i, txBytes := range rewardTxBytes {
+		if err := w.addTx(ctx, txBytes); err != nil {
+			return fmt.Errorf("emit reward tx %d: %w", i, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/genesis-writer/main.go
+++ b/cmd/genesis-writer/main.go
@@ -132,6 +132,12 @@ func writeCmd() *cli.Command {
 			&cli.BoolFlag{Name: "skip-comments", EnvVars: []string{"GENESIS_SKIP_COMMENTS"}, Usage: "Skip comments and comment reactions"},
 			&cli.BoolFlag{Name: "skip-emails", EnvVars: []string{"GENESIS_SKIP_EMAILS"}, Usage: "Skip encrypted emails and email access grants"},
 			&cli.BoolFlag{Name: "skip-tip-reactions", EnvVars: []string{"GENESIS_SKIP_TIP_REACTIONS"}},
+			&cli.BoolFlag{Name: "skip-rewards", EnvVars: []string{"GENESIS_SKIP_REWARDS"}, Usage: "Skip reward pools and rewards"},
+			&cli.StringFlag{
+				Name:    "core-cmt-home",
+				Usage:   "CometBFT home directory of the OLD Core chain. Used to scan the blockstore for reward transactions to replay.",
+				EnvVars: []string{"GENESIS_CORE_CMT_HOME"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			logger, _ := zap.NewProduction()
@@ -221,6 +227,8 @@ func writeCmd() *cli.Command {
 				SkipComments:         c.Bool("skip-comments"),
 				SkipEmails:           c.Bool("skip-emails"),
 				SkipTipReactions:     c.Bool("skip-tip-reactions"),
+				SkipRewards:          c.Bool("skip-rewards"),
+				CoreCMTHome:          c.String("core-cmt-home"),
 			}
 
 			w, err := NewWriter(cfg, logger)

--- a/cmd/genesis-writer/writer.go
+++ b/cmd/genesis-writer/writer.go
@@ -55,6 +55,12 @@ type WriterConfig struct {
 	SkipComments         bool
 	SkipEmails           bool
 	SkipTipReactions     bool
+	SkipRewards          bool
+	// CoreCMTHome is the CometBFT home directory of the OLD chain. When set,
+	// the genesis writer scans its blockstore for RewardMessage and
+	// RewardPoolMessage transactions and replays them verbatim into the new
+	// chain. If empty, rewards are skipped.
+	CoreCMTHome          string
 	// RunMigrations applies the Core chain schema to DstDSN before writing.
 	// Useful when starting from a fresh database (e.g., in integration tests).
 	RunMigrations bool
@@ -422,7 +428,10 @@ func (w *Writer) Run(ctx context.Context) error {
 		{"encrypted emails", w.cfg.SkipEmails, w.writeEncryptedEmails},
 		{"email access", w.cfg.SkipEmails, w.writeEmailAccess},
 
-		// Phase 7: Activity — play count reconciliation, plays, and tip reactions
+		// Phase 7: Rewards — replay reward pool and reward txs from old chain blockstore
+		{"rewards", w.cfg.SkipRewards, w.writeRewards},
+
+		// Phase 8: Activity — play count reconciliation, plays, and tip reactions
 		{"play count reconciliation", w.cfg.SkipPlays, w.writePlayCountReconciliation},
 		{"plays", w.cfg.SkipPlays, w.writePlays},
 		{"tip reactions", w.cfg.SkipTipReactions, w.writeTipReactions},


### PR DESCRIPTION
## Summary
- Scans the old Core chain's CometBFT blockstore for `RewardPoolMessage` and `RewardMessage` transactions and replays the original signed bytes verbatim into the new chain
- Pool transactions are emitted before rewards to satisfy FK ordering constraints
- Adds `--core-cmt-home` flag (path to old chain's CometBFT home directory) and `--skip-rewards` flag

## Test plan
- [ ] Run genesis writer with `--core-cmt-home` pointing to old chain data dir and verify reward pools and rewards are written
- [ ] Run with `--skip-rewards` and verify rewards step is skipped
- [ ] Run without `--core-cmt-home` and verify rewards are gracefully skipped with info log
- [ ] Verify FK ordering: all reward pool txs are committed before reward txs

🤖 Generated with [Claude Code](https://claude.com/claude-code)