### PR TITLE
test(genesis-writer): add events and collaborator test coverage

### DIFF
--- a/cmd/genesis-writer/docker-compose.yml
+++ b/cmd/genesis-writer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: discovery_provider_1
     volumes:
-      - ../../cmd/genesis-replay/testdata/dp_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ../../cmd/genesis-writer/testdata/dp_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
       - ../../cmd/genesis-writer/testdata/dp_seed.sql:/docker-entrypoint-initdb.d/02_seed.sql:ro
       - ../../cmd/genesis-writer/testdata/source_init.sh:/docker-entrypoint-initdb.d/03_source_init.sh:ro
       - ../../cmd/genesis-writer/testdata/seed.sql:/tmp/source_seed.sql:ro

--- a/cmd/genesis-writer/integration_test.go
+++ b/cmd/genesis-writer/integration_test.go
@@ -108,9 +108,10 @@ func TestGenesisWriter(t *testing.T) {
 	require.NoError(t, srcPool.Ping(ctx), "ping source DB")
 
 	expected := snapshotSource(t, ctx, srcPool)
-	t.Logf("source snapshot: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts, %d plays",
+	t.Logf("source snapshot: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts, %d plays, %d events, %d collaborators (%d accepted)",
 		len(expected.users), len(expected.tracks), len(expected.playlists),
-		len(expected.follows), len(expected.saves), len(expected.reposts), expected.playCount)
+		len(expected.follows), len(expected.saves), len(expected.reposts), expected.playCount,
+		len(expected.events), len(expected.collaborators), expected.acceptedCollaborators)
 
 	// ---- 2. Set up CometBFT home directory -----------------------------------
 	// Genesis-writer writes state.db + blockstore.db into cmtHome.
@@ -189,9 +190,10 @@ func TestGenesisWriter(t *testing.T) {
 	// directly from the core DB — no discovery-provider needed.
 	t.Log("indexing chain transactions...")
 	indexed := indexChain(t, ctx, dstPool, genesisHeight)
-	t.Logf("indexed: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts, %d plays",
+	t.Logf("indexed: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts, %d plays, %d events, %d collaborators (%d accepted)",
 		len(indexed.users), len(indexed.tracks), len(indexed.playlists),
-		len(indexed.follows), len(indexed.saves), len(indexed.reposts), indexed.playCount)
+		len(indexed.follows), len(indexed.saves), len(indexed.reposts), indexed.playCount,
+		len(indexed.events), len(indexed.collaborators), indexed.acceptedCollaborators)
 
 	assert.Equal(t, expected.users, indexed.users, "users mismatch")
 	assert.Equal(t, expected.tracks, indexed.tracks, "tracks mismatch")
@@ -200,6 +202,9 @@ func TestGenesisWriter(t *testing.T) {
 	assert.Equal(t, expected.saves, indexed.saves, "saves mismatch")
 	assert.Equal(t, expected.reposts, indexed.reposts, "reposts mismatch")
 	assert.Equal(t, expected.playCount, indexed.playCount, "plays count mismatch")
+	assert.Equal(t, expected.events, indexed.events, "events mismatch")
+	assert.Equal(t, expected.collaborators, indexed.collaborators, "collaborators mismatch")
+	assert.Equal(t, expected.acceptedCollaborators, indexed.acceptedCollaborators, "accepted collaborators mismatch")
 
 	// ---- 6. Start openaudio-1 and verify consensus ---------------------------
 	t.Log("starting openaudio-1...")
@@ -246,9 +251,10 @@ func TestGenesisWriter(t *testing.T) {
 	waitForStateSyncData(t, ctx, db2Pool, genesisHeight)
 
 	indexed2 := indexChain(t, ctx, db2Pool, genesisHeight)
-	t.Logf("state-synced node: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts, %d plays",
+	t.Logf("state-synced node: %d users, %d tracks, %d playlists, %d follows, %d saves, %d reposts, %d plays, %d events, %d collaborators (%d accepted)",
 		len(indexed2.users), len(indexed2.tracks), len(indexed2.playlists),
-		len(indexed2.follows), len(indexed2.saves), len(indexed2.reposts), indexed2.playCount)
+		len(indexed2.follows), len(indexed2.saves), len(indexed2.reposts), indexed2.playCount,
+		len(indexed2.events), len(indexed2.collaborators), indexed2.acceptedCollaborators)
 
 	assert.Equal(t, expected.users, indexed2.users, "state-synced users mismatch")
 	assert.Equal(t, expected.tracks, indexed2.tracks, "state-synced tracks mismatch")
@@ -257,6 +263,9 @@ func TestGenesisWriter(t *testing.T) {
 	assert.Equal(t, expected.saves, indexed2.saves, "state-synced saves mismatch")
 	assert.Equal(t, expected.reposts, indexed2.reposts, "state-synced reposts mismatch")
 	assert.Equal(t, expected.playCount, indexed2.playCount, "state-synced plays count mismatch")
+	assert.Equal(t, expected.events, indexed2.events, "state-synced events mismatch")
+	assert.Equal(t, expected.collaborators, indexed2.collaborators, "state-synced collaborators mismatch")
+	assert.Equal(t, expected.acceptedCollaborators, indexed2.acceptedCollaborators, "state-synced accepted collaborators mismatch")
 	t.Log("state sync verification passed: all entities match")
 }
 
@@ -444,13 +453,16 @@ func waitForStateSyncProgress(t *testing.T, ctx context.Context, client corev1co
 // ---- source snapshot --------------------------------------------------------
 
 type sourceSnapshot struct {
-	users     []snapshotUser
-	tracks    []snapshotTrack
-	playlists []snapshotPlaylist
-	follows   []followPair
-	saves     []saveTuple
-	reposts   []repostTuple
-	playCount int
+	users                 []snapshotUser
+	tracks                []snapshotTrack
+	playlists             []snapshotPlaylist
+	follows               []followPair
+	saves                 []saveTuple
+	reposts               []repostTuple
+	playCount             int
+	events                []snapshotEvent
+	collaborators         []collabTuple
+	acceptedCollaborators int
 }
 
 type snapshotUser struct {
@@ -489,6 +501,18 @@ type repostTuple struct {
 	RepostType string
 }
 
+type snapshotEvent struct {
+	EventID   int64
+	EventType string
+	UserID    int64
+}
+
+type collabTuple struct {
+	TrackID int64
+	UserID  int64
+	Status  string
+}
+
 func snapshotSource(t *testing.T, ctx context.Context, db *pgxpool.Pool) sourceSnapshot {
 	t.Helper()
 	var s sourceSnapshot
@@ -499,6 +523,8 @@ func snapshotSource(t *testing.T, ctx context.Context, db *pgxpool.Pool) sourceS
 	s.saves = querySaves(t, ctx, db)
 	s.reposts = queryReposts(t, ctx, db)
 	s.playCount = queryPlayCount(t, ctx, db)
+	s.events = queryEvents(t, ctx, db)
+	s.collaborators, s.acceptedCollaborators = queryCollaborators(t, ctx, db)
 	return s
 }
 
@@ -625,6 +651,48 @@ func queryPlayCount(t *testing.T, ctx context.Context, db *pgxpool.Pool) int {
 	return n
 }
 
+func queryEvents(t *testing.T, ctx context.Context, db *pgxpool.Pool) []snapshotEvent {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT event_id, event_type::text, user_id
+		FROM events
+		WHERE is_deleted = false
+		ORDER BY event_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []snapshotEvent
+	for rows.Next() {
+		var e snapshotEvent
+		require.NoError(t, rows.Scan(&e.EventID, &e.EventType, &e.UserID))
+		out = append(out, e)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func queryCollaborators(t *testing.T, ctx context.Context, db *pgxpool.Pool) ([]collabTuple, int) {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+		SELECT track_id, collaborator_user_id, status
+		FROM track_collaborators
+		WHERE status IN ('pending', 'accepted')
+		ORDER BY track_id, collaborator_user_id`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []collabTuple
+	accepted := 0
+	for rows.Next() {
+		var c collabTuple
+		require.NoError(t, rows.Scan(&c.TrackID, &c.UserID, &c.Status))
+		out = append(out, c)
+		if c.Status == "accepted" {
+			accepted++
+		}
+	}
+	require.NoError(t, rows.Err())
+	return out, accepted
+}
+
 // ---- lightweight chain indexer ----------------------------------------------
 
 // indexChain reads all ManageEntityLegacyMigration and TrackPlays transactions
@@ -658,6 +726,11 @@ func indexChain(t *testing.T, ctx context.Context, pool *pgxpool.Pool, maxHeight
 		RepostType     string
 	}
 	repostSet := map[repostKey]bool{}
+
+	eventMap := map[int64]snapshotEvent{}
+
+	type collabKey struct{ TrackID, UserID int64 }
+	collabSet := map[collabKey]string{} // status
 
 	playCount := 0
 
@@ -695,9 +768,10 @@ func indexChain(t *testing.T, ctx context.Context, pool *pgxpool.Pool, maxHeight
 				case "Track":
 					var w struct {
 						Data struct {
-							OwnerID int64  `json:"owner_id"`
-							Title   string `json:"title"`
-							Genre   string `json:"genre"`
+							OwnerID       int64   `json:"owner_id"`
+							Title         string  `json:"title"`
+							Genre         string  `json:"genre"`
+							Collaborators []int64 `json:"collaborators"`
 						} `json:"data"`
 					}
 					_ = json.Unmarshal([]byte(me.Metadata), &w)
@@ -706,6 +780,10 @@ func indexChain(t *testing.T, ctx context.Context, pool *pgxpool.Pool, maxHeight
 						OwnerID: w.Data.OwnerID,
 						Title:   w.Data.Title,
 						Genre:   w.Data.Genre,
+					}
+					// Collaborators in Track:Create metadata become pending invites.
+					for _, uid := range w.Data.Collaborators {
+						collabSet[collabKey{me.EntityId, uid}] = "pending"
 					}
 				case "Playlist":
 					var w struct {
@@ -721,6 +799,20 @@ func indexChain(t *testing.T, ctx context.Context, pool *pgxpool.Pool, maxHeight
 						PlaylistName:    w.Data.PlaylistName,
 						IsAlbum:         w.Data.IsAlbum,
 					}
+				case "Event":
+					var meta struct {
+						EventType string `json:"event_type"`
+					}
+					_ = json.Unmarshal([]byte(me.Metadata), &meta)
+					eventMap[me.EntityId] = snapshotEvent{
+						EventID:   me.EntityId,
+						EventType: meta.EventType,
+						UserID:    me.UserId,
+					}
+				}
+			case "Approve":
+				if me.EntityType == "TrackCollaborator" {
+					collabSet[collabKey{me.EntityId, me.UserId}] = "accepted"
 				}
 			case "Follow":
 				// UserId=follower, EntityId=followee
@@ -792,6 +884,24 @@ func indexChain(t *testing.T, ctx context.Context, pool *pgxpool.Pool, maxHeight
 			return s.reposts[i].UserID < s.reposts[j].UserID
 		}
 		return s.reposts[i].ItemID < s.reposts[j].ItemID
+	})
+
+	for _, e := range eventMap {
+		s.events = append(s.events, e)
+	}
+	sort.Slice(s.events, func(i, j int) bool { return s.events[i].EventID < s.events[j].EventID })
+
+	for k, status := range collabSet {
+		s.collaborators = append(s.collaborators, collabTuple{k.TrackID, k.UserID, status})
+		if status == "accepted" {
+			s.acceptedCollaborators++
+		}
+	}
+	sort.Slice(s.collaborators, func(i, j int) bool {
+		if s.collaborators[i].TrackID != s.collaborators[j].TrackID {
+			return s.collaborators[i].TrackID < s.collaborators[j].TrackID
+		}
+		return s.collaborators[i].UserID < s.collaborators[j].UserID
 	})
 
 	return s

--- a/cmd/genesis-writer/testdata/dp_schema.sql
+++ b/cmd/genesis-writer/testdata/dp_schema.sql
@@ -1,0 +1,18967 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict m2R0Xrr2M70d8hLjwblvFqPiH7hL2wRm5AnbsIsPeL7ouQYXYoxsnkDeEoKyYER
+
+-- Dumped from database version 15.17
+-- Dumped by pg_dump version 17.9 (Homebrew)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: hashids; Type: SCHEMA; Schema: -; Owner: postgres
+--
+
+CREATE SCHEMA hashids;
+
+
+ALTER SCHEMA hashids OWNER TO postgres;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: cloudsqlsuperuser
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+ALTER SCHEMA public OWNER TO cloudsqlsuperuser;
+
+--
+-- Name: amcheck; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS amcheck WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION amcheck; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION amcheck IS 'functions for verifying relation integrity';
+
+
+--
+-- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pg_stat_statements IS 'track planning and execution statistics of all SQL statements executed';
+
+
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
+--
+-- Name: tsm_system_rows; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS tsm_system_rows WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION tsm_system_rows; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION tsm_system_rows IS 'TABLESAMPLE method which accepts number of rows as a limit';
+
+
+--
+-- Name: challengetype; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.challengetype AS ENUM (
+    'boolean',
+    'numeric',
+    'aggregate',
+    'trending'
+);
+
+
+ALTER TYPE public.challengetype OWNER TO postgres;
+
+--
+-- Name: delist_entity; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.delist_entity AS ENUM (
+    'TRACKS',
+    'USERS'
+);
+
+
+ALTER TYPE public.delist_entity OWNER TO postgres;
+
+--
+-- Name: delist_track_reason; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.delist_track_reason AS ENUM (
+    'DMCA',
+    'ACR',
+    'MANUAL',
+    'ACR_COUNTER_NOTICE',
+    'DMCA_RETRACTION',
+    'DMCA_COUNTER_NOTICE',
+    'DMCA_AND_ACR_COUNTER_NOTICE'
+);
+
+
+ALTER TYPE public.delist_track_reason OWNER TO postgres;
+
+--
+-- Name: delist_user_reason; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.delist_user_reason AS ENUM (
+    'STRIKE_THRESHOLD',
+    'COPYRIGHT_SCHOOL',
+    'MANUAL'
+);
+
+
+ALTER TYPE public.delist_user_reason OWNER TO postgres;
+
+--
+-- Name: etl_proof_status; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.etl_proof_status AS ENUM (
+    'unresolved',
+    'pass',
+    'fail'
+);
+
+
+ALTER TYPE public.etl_proof_status OWNER TO postgres;
+
+--
+-- Name: event_entity_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.event_entity_type AS ENUM (
+    'track',
+    'collection',
+    'user'
+);
+
+
+ALTER TYPE public.event_entity_type OWNER TO postgres;
+
+--
+-- Name: event_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.event_type AS ENUM (
+    'remix_contest',
+    'live_event',
+    'new_release'
+);
+
+
+ALTER TYPE public.event_type OWNER TO postgres;
+
+--
+-- Name: parental_warning_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.parental_warning_type AS ENUM (
+    'explicit',
+    'explicit_content_edited',
+    'not_explicit',
+    'no_advice_available'
+);
+
+
+ALTER TYPE public.parental_warning_type OWNER TO postgres;
+
+--
+-- Name: profile_type_enum; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.profile_type_enum AS ENUM (
+    'label'
+);
+
+
+ALTER TYPE public.profile_type_enum OWNER TO postgres;
+
+--
+-- Name: proof_status; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.proof_status AS ENUM (
+    'unresolved',
+    'pass',
+    'fail'
+);
+
+
+ALTER TYPE public.proof_status OWNER TO postgres;
+
+--
+-- Name: reposttype; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.reposttype AS ENUM (
+    'track',
+    'playlist',
+    'album'
+);
+
+
+ALTER TYPE public.reposttype OWNER TO postgres;
+
+--
+-- Name: savetype; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.savetype AS ENUM (
+    'track',
+    'playlist',
+    'album'
+);
+
+
+ALTER TYPE public.savetype OWNER TO postgres;
+
+--
+-- Name: sharetype; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.sharetype AS ENUM (
+    'track',
+    'playlist'
+);
+
+
+ALTER TYPE public.sharetype OWNER TO postgres;
+
+--
+-- Name: skippedtransactionlevel; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.skippedtransactionlevel AS ENUM (
+    'node',
+    'network'
+);
+
+
+ALTER TYPE public.skippedtransactionlevel OWNER TO postgres;
+
+--
+-- Name: usdc_purchase_access_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.usdc_purchase_access_type AS ENUM (
+    'stream',
+    'download'
+);
+
+
+ALTER TYPE public.usdc_purchase_access_type OWNER TO postgres;
+
+--
+-- Name: usdc_purchase_content_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.usdc_purchase_content_type AS ENUM (
+    'track',
+    'playlist',
+    'album'
+);
+
+
+ALTER TYPE public.usdc_purchase_content_type OWNER TO postgres;
+
+--
+-- Name: validator_event; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.validator_event AS ENUM (
+    'registered',
+    'deregistered'
+);
+
+
+ALTER TYPE public.validator_event OWNER TO postgres;
+
+--
+-- Name: wallet_chain; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.wallet_chain AS ENUM (
+    'eth',
+    'sol'
+);
+
+
+ALTER TYPE public.wallet_chain OWNER TO postgres;
+
+--
+-- Name: clean_alphabet_from_seps(text, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.clean_alphabet_from_seps(p_seps text, p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_seps ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    v_split_seps text[] := regexp_split_to_array(p_seps, '');
+    v_split_alphabet text[] := regexp_split_to_array(p_alphabet, '');
+    v_i integer := 1;
+    v_length integer := length(p_alphabet);
+    v_ret text := '';
+BEGIN
+	-- had to add this function because doing this:
+	-- p_alphabet := array_to_string(ARRAY( select chars.cha from (select unnest(regexp_split_to_array(p_alphabet, '')) as cha EXCEPT select unnest(regexp_split_to_array(p_seps, '')) as cha) as chars  ), '');
+	-- doesn't preserve the order of the input
+
+	for v_i in 1..v_length loop
+		--raise notice 'v_split_alphabet[%]: % != %', v_i, v_split_alphabet[v_i], v_split_alphabet[v_i] <> all (v_split_seps);
+		if (v_split_alphabet[v_i] <> all (v_split_seps)) then
+			v_ret = v_ret || v_split_alphabet[v_i];
+		end if;
+	end loop;
+
+	-- raise notice 'v_ret: %', v_ret;
+	return v_ret;
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.clean_alphabet_from_seps(p_seps text, p_alphabet text) OWNER TO postgres;
+
+--
+-- Name: clean_seps_from_alphabet(text, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.clean_seps_from_alphabet(p_seps text, p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_seps ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    v_split_seps text[] := regexp_split_to_array(p_seps, '');
+    v_split_alphabet text[] := regexp_split_to_array(p_alphabet, '');
+    v_i integer := 1;
+    v_length integer := length(p_seps);
+    v_ret text := '';
+BEGIN
+	-- had to add this function because doing this:
+	-- p_seps := array_to_string(ARRAY(select chars.cha from (select unnest(regexp_split_to_array(p_seps, '')) as cha intersect select unnest(regexp_split_to_array(p_alphabet, '')) as cha ) as chars order by ascii(cha) desc), '');
+	-- doesn't preserve the order of the input
+
+	for v_i in 1..v_length loop
+		-- raise notice 'v_split_seps[%]: %  == %', v_i, v_split_seps[v_i], v_split_seps[v_i] = any (v_split_alphabet);
+		if (v_split_seps[v_i] = any (v_split_alphabet)) then
+			v_ret = v_ret || v_split_seps[v_i];
+		end if;
+	end loop;
+
+	-- raise notice 'v_ret: %', v_ret;
+	return v_ret;
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.clean_seps_from_alphabet(p_seps text, p_alphabet text) OWNER TO postgres;
+
+--
+-- Name: consistent_shuffle(text, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.consistent_shuffle(p_alphabet text, p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE p_alphabet ALIAS FOR $1;
+	p_salt ALIAS FOR $2;
+	v_ls int;
+	v_i int;
+	v_v int := 0;
+	v_p int := 0;
+	v_n int := 0;
+	v_j int := 0;
+	v_temp char(1);
+BEGIN
+
+	-- Null or Whitespace?
+	IF p_salt IS NULL OR length(LTRIM(RTRIM(p_salt))) = 0 THEN
+		RETURN p_alphabet;
+	END IF;
+
+	v_ls := length(p_salt);
+	v_i := length(p_alphabet) - 1;
+
+	WHILE v_i > 0 LOOP
+
+		v_v := v_v % v_ls;
+		v_n := ascii(SUBSTRING(p_salt, v_v + 1, 1)); -- need some investigation to see if +1 here is because of 1 based arrays in sql ... this isn't in the reference JS or .net code.
+		v_p := v_p + v_n;
+		v_j := (v_n + v_v + v_p) % v_i;
+		v_temp := SUBSTRING(p_alphabet, v_j + 1, 1);
+		p_alphabet :=
+				SUBSTRING(p_alphabet, 1, v_j) ||
+				SUBSTRING(p_alphabet, v_i + 1, 1) ||
+				SUBSTRING(p_alphabet, v_j + 2, 255);
+		p_alphabet :=  SUBSTRING(p_alphabet, 1, v_i) || v_temp || SUBSTRING(p_alphabet, v_i + 2, 255);
+		v_i := v_i - 1;
+		v_v := v_v + 1;
+
+	END LOOP; -- WHILE
+
+	RETURN p_alphabet;
+
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.consistent_shuffle(p_alphabet text, p_salt text) OWNER TO postgres;
+
+--
+-- Name: decode(text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.decode(p_hash text) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt text := ''; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.decode(p_hash text) OWNER TO postgres;
+
+--
+-- Name: decode(text, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.decode(p_hash text, p_salt text) OWNER TO postgres;
+
+--
+-- Name: decode(text, text, integer); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length ALIAS for $3; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer) OWNER TO postgres;
+
+--
+-- Name: decode(text, text, integer, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer, p_alphabet text) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length ALIAS for $3; -- default
+        p_alphabet ALIAS for $4; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.decode(p_hash, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer, p_alphabet text) OWNER TO postgres;
+
+--
+-- Name: decode(text, text, integer, text, boolean); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS bigint[]
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_hash ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3;
+    p_alphabet ALIAS for $4;
+    p_zero_offset ALIAS for $5; -- adding an offset so that this can work with values from a zero based array language
+
+    v_seps text;
+    v_guards text;
+    v_alphabet text := p_alphabet;
+    v_lottery char(1);
+
+    v_hashBreakdown varchar(255);
+    v_hashArray text[];
+    v_index integer := 1;
+    v_j integer := 1;
+    v_hashArrayLength integer;
+    v_subHash varchar;
+    v_buffer varchar(255);
+    v_encodeCheck varchar(255);
+    v_ret_temp bigint;
+    v_ret bigint[];
+BEGIN
+
+    select * from hashids.setup_alphabet(p_salt, v_alphabet) into v_alphabet, v_seps, v_guards;
+    --raise notice 'v_seps: %', v_seps;
+    --raise notice 'v_alphabet: %', v_alphabet;
+    --raise notice 'v_guards: %', v_guards;
+
+    v_hashBreakdown := regexp_replace(p_hash, '[' || v_guards || ']', ' ');
+    v_hashArray := regexp_split_to_array(p_hash, '[' || v_guards || ']');
+
+    -- take the guards and replace with space,
+    -- split on space
+    -- if length is 3 or 2, set index to 1 else start at zero
+
+    -- if first index in idBreakDown isn't default
+
+    if ((array_length(v_hashArray, 1) = 3) or (array_length(v_hashArray, 1) = 2)) then
+        v_index := 2; -- in the example code (C# and js) it is 1 here, but postgresql arrays start at 1, so switching to 2
+    END IF;
+    --raise notice '%', v_hashArray;
+
+    v_hashBreakdown := v_hashArray[v_index];
+    --raise notice 'v_hashArray[%] %', v_index, v_hashBreakdown;
+    if (left(v_hashBreakdown, 1) <> '') IS NOT false then
+        v_lottery := left(v_hashBreakdown, 1);
+        --raise notice 'v_lottery %', v_lottery;
+        --raise notice 'SUBSTRING(%, 2, % - 1) %', v_hashBreakdown, length(v_hashBreakdown), SUBSTRING(v_hashBreakdown, 2);
+
+        v_hashBreakdown := SUBSTRING(v_hashBreakdown, 2);
+        v_hashArray := regexp_split_to_array(v_hashBreakdown, '[' || v_seps || ']');
+        --raise notice 'v_hashArray % -- %', v_hashArray, array_length(v_hashArray, 1);
+        v_hashArrayLength := array_length(v_hashArray, 1);
+        for v_j in 1..v_hashArrayLength LOOP
+            v_subHash := v_hashArray[v_j];
+            --raise notice 'v_subHash %', v_subHash;
+            v_buffer := v_lottery || p_salt || v_alphabet;
+            --raise notice 'v_buffer %', v_buffer;
+            --raise notice 'v_alphabet: hashids.consistent_shuffle(%, %) == %', v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)), hashids.consistent_shuffle(v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)));
+            v_alphabet := hashids.consistent_shuffle(v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)));
+            v_ret_temp := hashids.unhash(v_subHash, v_alphabet, p_zero_offset);
+            --raise notice 'v_ret_temp: %', v_ret_temp;
+            v_ret := array_append(v_ret, v_ret_temp);
+        END LOOP;
+        v_encodeCheck := hashids.encode_list(v_ret, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+        IF (v_encodeCheck <> p_hash) then
+            raise notice 'hashids.encodeList(%): % <> %', v_ret, v_encodeCheck, p_hash;
+            return ARRAY[]::bigint[];
+        end if;
+    end if;
+
+    RETURN v_ret;
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.decode(p_hash text, p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean) OWNER TO postgres;
+
+--
+-- Name: distinct_alphabet(text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.distinct_alphabet(p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_alphabet ALIAS for $1;
+    v_split_alphabet text[] := regexp_split_to_array(p_alphabet, '');
+    v_i integer := 2;
+    v_length integer := length(p_alphabet);
+    v_ret_array text[];
+BEGIN
+	-- had to add this function because doing this:
+	-- p_alphabet := string_agg(distinct chars.split_chars, '') from (select unnest(regexp_split_to_array(p_alphabet, '')) as split_chars) as chars;
+	-- doesn't preserve the order of the input, which was causing issues
+	if (v_length = 0) then
+		RAISE EXCEPTION 'alphabet must contain at least 1 char' USING HINT = 'Please check your alphabet';
+	end if;
+	v_ret_array := array_append(v_ret_array, v_split_alphabet[1]);
+
+	-- starting at 2 because already appended 1 to it.
+	for v_i in 2..v_length loop
+		-- raise notice 'v_split_alphabet[%]: % != %', v_i, v_split_alphabet[v_i], v_split_alphabet[v_i] <> all (v_ret_array);
+
+		if (v_split_alphabet[v_i] <> all (v_ret_array)) then
+			v_ret_array := array_append(v_ret_array, v_split_alphabet[v_i]);
+		end if;
+	end loop;
+
+	-- raise notice 'v_ret_array: %', array_to_string(v_ret_array, '');
+	return array_to_string(v_ret_array, '');
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.distinct_alphabet(p_alphabet text) OWNER TO postgres;
+
+--
+-- Name: encode(bigint); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt text := ''; -- default
+    p_min_hash_length integer := 0; -- default
+    p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode(p_number bigint) OWNER TO postgres;
+
+--
+-- Name: encode(bigint, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length integer := 0; -- default
+    p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode(p_number bigint, p_salt text) OWNER TO postgres;
+
+--
+-- Name: encode(bigint, text, integer); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3; -- default
+    p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer) OWNER TO postgres;
+
+--
+-- Name: encode(bigint, text, integer, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer, p_alphabet text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3; -- default
+    p_alphabet ALIAS for $4; -- default
+    p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer, p_alphabet text) OWNER TO postgres;
+
+--
+-- Name: encode(bigint, text, integer, text, boolean); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+DECLARE
+    p_number ALIAS for $1;
+    p_salt ALIAS for $2;
+    p_min_hash_length ALIAS for $3; -- default
+    p_alphabet ALIAS for $4; -- default
+    p_zero_offset ALIAS for $5 ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(ARRAY[p_number::bigint]::bigint[], p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode(p_number bigint, p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean) OWNER TO postgres;
+
+--
+-- Name: encode_list(bigint[]); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[]) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+-- Options Data - generated by hashids-tsql
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt text := ''; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(p_numbers, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode_list(p_numbers bigint[]) OWNER TO postgres;
+
+--
+-- Name: encode_list(bigint[], text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+-- Options Data - generated by hashids-tsql
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length integer := 0; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(p_numbers, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text) OWNER TO postgres;
+
+--
+-- Name: encode_list(bigint[], text, integer); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text, p_min_hash_length integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $_$
+-- Options Data - generated by hashids-tsql
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2; -- default
+        p_min_hash_length ALIAS for $3; -- default
+        p_alphabet text := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'; -- default
+        p_zero_offset boolean := true ; -- adding an offset so that this can work with values from a zero based array language
+BEGIN
+    RETURN hashids.encode_list(p_numbers, p_salt, p_min_hash_length, p_alphabet, p_zero_offset);
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text, p_min_hash_length integer) OWNER TO postgres;
+
+--
+-- Name: encode_list(bigint[], text, integer, text, boolean); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 350
+    AS $_$
+    DECLARE
+        p_numbers ALIAS for $1;
+        p_salt ALIAS for $2;
+        p_min_hash_length ALIAS for $3;
+        p_alphabet ALIAS for $4;
+        p_zero_offset integer := case when $5 = true then 1 else 0 end ; -- adding an offset so that this can work with values from a zero based array language
+        v_seps text;
+        v_guards text;
+
+        -- Working Data
+        v_alphabet text := p_alphabet;
+        v_numbersHashInt int = 0;
+        v_lottery char(1);
+        v_buffer varchar(255);
+        v_last varchar(255);
+        v_ret varchar(255);
+        v_sepsIndex int;
+        v_lastId int;
+        v_count int = array_length(p_numbers, 1);
+        v_i int = 0;
+        v_id int = 0;
+        v_number int;
+        v_guardIndex int;
+        v_guard char(1);
+        v_halfLength int;
+        v_excess int;
+BEGIN
+
+    select * from hashids.setup_alphabet(p_salt, p_alphabet) into v_alphabet, v_seps, v_guards;
+    --raise notice 'v_seps: %', v_seps;
+    --raise notice 'v_alphabet: %', v_alphabet;
+    --raise notice 'v_guards: %', v_guards;
+
+    -- Calculate numbersHashInt
+    for v_lastId in 1..v_count LOOP
+        v_numbersHashInt := v_numbersHashInt + (p_numbers[v_lastId] % ((v_lastId-p_zero_offset) + 100));
+    END LOOP;
+
+    -- Choose lottery
+    v_lottery := SUBSTRING(v_alphabet, (v_numbersHashInt % length(v_alphabet)) + 1, 1); -- is this a +1 because of sql 1 based index, need to double check to see if can be replaced with param.
+    v_ret := v_lottery;
+
+    -- Encode many
+    v_i := 0;
+    v_id := 0;
+    for v_i in 1..v_count LOOP
+        v_number := p_numbers[v_i];
+        -- raise notice '%[%]: % for %', p_numbers, v_i, v_number, v_count;
+
+        v_buffer := v_lottery || p_salt || v_alphabet;
+        v_alphabet := hashids.consistent_shuffle(v_alphabet, SUBSTRING(v_buffer, 1, length(v_alphabet)));
+        v_last := hashids.hash(v_number, v_alphabet, cast(p_zero_offset as boolean));
+        v_ret := v_ret || v_last;
+        --raise notice 'v_ret: %', v_ret;
+        --raise notice '(v_i < v_count: % < % == %', v_i, v_count, (v_i < v_count);
+        IF (v_i) < v_count THEN
+            --raise notice 'v_sepsIndex:  % mod (% + %) == %', v_number, ascii(SUBSTRING(v_last, 1, 1)), v_i, (v_number % (ascii(SUBSTRING(v_last, 1, 1)) + v_i));
+            v_sepsIndex := v_number % (ascii(SUBSTRING(v_last, 1, 1)) + (v_i-p_zero_offset)); -- since this is 1 base vs 0 based bringing the number back down so that the mod is the same for zero based records
+            v_sepsIndex := v_sepsIndex % length(v_seps);
+            v_ret := v_ret || SUBSTRING(v_seps, v_sepsIndex+1, 1);
+        END IF;
+
+    END LOOP;
+
+    ----------------------------------------------------------------------------
+    -- Enforce minHashLength
+    ----------------------------------------------------------------------------
+    IF length(v_ret) < p_min_hash_length THEN
+
+        ------------------------------------------------------------------------
+        -- Add first 2 guard characters
+        ------------------------------------------------------------------------
+        v_guardIndex := (v_numbersHashInt + ascii(SUBSTRING(v_ret, 1, 1))) % length(v_guards);
+        v_guard := SUBSTRING(v_guards, v_guardIndex + 1, 1);
+        --raise notice '% || % is %', v_guard, v_ret, v_guard || v_ret;
+        v_ret := v_guard || v_ret;
+        IF length(v_ret) < p_min_hash_length THEN
+            v_guardIndex := (v_numbersHashInt + ascii(SUBSTRING(v_ret, 3, 1))) % length(v_guards);
+            v_guard := SUBSTRING(v_guards, v_guardIndex + 1, 1);
+            v_ret := v_ret || v_guard;
+        END IF;
+        ------------------------------------------------------------------------
+        -- Add the rest
+        ------------------------------------------------------------------------
+        WHILE length(v_ret) < p_min_hash_length LOOP
+            v_halfLength := COALESCE(v_halfLength, CAST((length(v_alphabet) / 2) as int));
+            v_alphabet := hashids.consistent_shuffle(v_alphabet, v_alphabet);
+            v_ret := SUBSTRING(v_alphabet, v_halfLength + 1, 255) || v_ret || SUBSTRING(v_alphabet, 1, v_halfLength);
+            v_excess := length(v_ret) - p_min_hash_length;
+            IF v_excess > 0 THEN
+                v_ret := SUBSTRING(v_ret, CAST((v_excess / 2) as int) + 1, p_min_hash_length);
+            END IF;
+        END LOOP;
+    END IF;
+    RETURN v_ret;
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.encode_list(p_numbers bigint[], p_salt text, p_min_hash_length integer, p_alphabet text, p_zero_offset boolean) OWNER TO postgres;
+
+--
+-- Name: hash(bigint, text, boolean); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.hash(p_input bigint, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 250
+    AS $_$
+DECLARE
+    p_input ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    p_zero_offset integer := case when $3 = true then 1 else 0 end ; -- adding an offset so that this can work with values from a zero based array language
+    v_hash varchar(255) := '';
+    v_alphabet_length integer := length($2);
+    v_pos integer;
+BEGIN
+
+    WHILE 1 = 1 LOOP
+        v_pos := (p_input % v_alphabet_length) + p_zero_offset; -- have to add one, because SUBSTRING in SQL starts at 1 instead of 0 (like it does in other languages)
+        --raise notice '% mod % == %', p_input, v_alphabet_length, v_pos;
+        --raise notice 'SUBSTRING(%, %, 1): %', p_alphabet, v_pos, (SUBSTRING(p_alphabet, v_pos, 1));
+        --raise notice '% || % == %', SUBSTRING(p_alphabet, v_pos, 1), v_hash, SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
+        v_hash := SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
+        p_input := CAST((p_input / v_alphabet_length) as int);
+        --raise notice 'p_input %', p_input;
+        IF p_input <= 0 THEN
+            EXIT;
+        END IF;
+    END LOOP;
+
+    RETURN v_hash;
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.hash(p_input bigint, p_alphabet text, p_zero_offset boolean) OWNER TO postgres;
+
+--
+-- Name: setup_alphabet(text, text); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.setup_alphabet(p_salt text DEFAULT ''::text, INOUT p_alphabet text DEFAULT 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'::text, OUT p_seps text, OUT p_guards text) RETURNS record
+    LANGUAGE plpgsql IMMUTABLE COST 200
+    AS $_$
+DECLARE
+    p_salt ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    p_seps ALIAS for $3;
+    p_guards ALIAS for $4;
+    v_sep_div float := 3.5;
+    v_guard_div float := 12.0;
+    v_guard_count integer;
+    v_seps_length integer;
+    v_seps_diff integer;
+BEGIN
+    p_seps := 'cfhistuCFHISTU';
+    -- p_alphabet := string_agg(distinct chars.split_chars, '') from (select unnest(regexp_split_to_array(p_alphabet, '')) as split_chars) as chars;
+		-- this also doesn't preserve the order of alphabet, but it doesn't appear to matter, never mind on that
+		p_alphabet := hashids.distinct_alphabet(p_alphabet);
+
+
+    if length(p_alphabet) < 16 then
+        RAISE EXCEPTION 'alphabet must contain 16 unique characters, it is: %', length(p_alphabet) USING HINT = 'Please check your alphabet';
+    end if;
+
+    -- seps should only contain character present in the passed alphabet
+    -- p_seps := array_to_string(ARRAY(select chars.cha from (select unnest(regexp_split_to_array(p_seps, '')) as cha intersect select unnest(regexp_split_to_array(p_alphabet, '')) as cha ) as chars order by ascii(cha) desc), '');
+    -- this doesn't preserve the input order, which is bad
+    p_seps := hashids.clean_seps_from_alphabet(p_seps, p_alphabet);
+
+    -- alphabet should not contain seps.
+    -- p_alphabet := array_to_string(ARRAY( select chars.cha from (select unnest(regexp_split_to_array(p_alphabet, '')) as cha EXCEPT select unnest(regexp_split_to_array(p_seps, '')) as cha) as chars  ), '');
+    -- this also doesn't prevserve the order
+    p_alphabet := hashids.clean_alphabet_from_seps(p_seps, p_alphabet);
+
+
+	p_seps := hashids.consistent_shuffle(p_seps, p_salt);
+
+	if (length(p_seps) = 0) or ((length(p_alphabet) / length(p_seps)) > v_sep_div) then
+		v_seps_length := cast( ceil( length(p_alphabet)/v_sep_div ) as integer);
+		if v_seps_length = 1 then
+			v_seps_length := 2;
+		end if;
+		if v_seps_length > length(p_seps) then
+			v_seps_diff := v_seps_length - length(p_seps);
+			p_seps := p_seps || SUBSTRING(p_alphabet, 1, v_seps_diff);
+			p_alphabet := SUBSTRING(p_alphabet, v_seps_diff + 1);
+		else
+			p_seps := SUBSTRING(p_seps, 1, v_seps_length + 1);
+		end if;
+	end if;
+
+	p_alphabet := hashids.consistent_shuffle(p_alphabet, p_salt);
+
+	v_guard_count := cast(ceil(length(p_alphabet) / v_guard_div ) as integer);
+
+	if length(p_alphabet) < 3 then
+		p_guards := SUBSTRING(p_seps, 1, v_guard_count);
+		p_seps := SUBSTRING(p_seps, v_guard_count + 1);
+	else
+		p_guards := SUBSTRING(p_alphabet, 1, v_guard_count);
+		p_alphabet := SUBSTRING(p_alphabet, v_guard_count + 1);
+	end if;
+
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.setup_alphabet(p_salt text, INOUT p_alphabet text, OUT p_seps text, OUT p_guards text) OWNER TO postgres;
+
+--
+-- Name: unhash(text, text, boolean); Type: FUNCTION; Schema: hashids; Owner: postgres
+--
+
+CREATE FUNCTION hashids.unhash(p_input text, p_alphabet text, p_zero_offset boolean DEFAULT true) RETURNS bigint
+    LANGUAGE plpgsql IMMUTABLE
+    AS $_$
+DECLARE
+    p_input ALIAS for $1;
+    p_alphabet ALIAS for $2;
+    p_zero_offset integer := case when $3 = true then 1 else 0 end ; -- adding an offset so that this can work with values from a zero based array language
+    v_input_length integer := length($1);
+    v_alphabet_length integer := length($2);
+    v_ret bigint := 0;
+    v_input_char char(1);
+    v_pos integer;
+    v_i integer := 1;
+BEGIN
+    for v_i in 1..v_input_length loop
+        v_input_char := SUBSTRING(p_input, (v_i), 1);
+        v_pos := POSITION(v_input_char in p_alphabet) - p_zero_offset; -- have to remove one to interface with .net because it is a zero based index
+        --raise notice '%[%] is % to position % in %', p_input, v_i, v_input_char, v_pos, p_alphabet;
+        --raise notice '  % + (% * power(%, % - % - 1)) == %', v_ret, v_pos, v_alphabet_length, v_input_length, (v_i - 1), v_ret + (v_pos * power(v_alphabet_length, v_input_length - (v_i-1) - 1));
+        v_ret := v_ret + (v_pos * power(v_alphabet_length, v_input_length - (v_i-p_zero_offset) - 1));
+    end loop;
+
+    RETURN v_ret;
+END;
+$_$;
+
+
+ALTER FUNCTION hashids.unhash(p_input text, p_alphabet text, p_zero_offset boolean) OWNER TO postgres;
+
+--
+-- Name: add_fk_constraints(text[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.add_fk_constraints(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      -- Logging the action
+      RAISE NOTICE 'Adding foreign key constraint to table %', _table_name;
+
+      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (blocknumber) REFERENCES blocks (number) ON DELETE CASCADE', 
+                     quote_ident(_table_name), 
+                     quote_ident(_table_name || '_blocknumber_fkey'));
+
+   END LOOP;
+END
+$$;
+
+
+ALTER FUNCTION public.add_fk_constraints(_table_names text[]) OWNER TO postgres;
+
+--
+-- Name: calculate_artist_coin_fee_earnings(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.calculate_artist_coin_fee_earnings(artist_coin_mint text) RETURNS TABLE(unclaimed_fees numeric, total_fees numeric)
+    LANGUAGE sql
+    AS $$
+    WITH
+    artist_positions AS (
+        SELECT
+            first_position AS position,
+            damm_v2_pool AS pool,
+            base_mint AS mint
+        FROM sol_meteora_dbc_migrations
+        WHERE base_mint = artist_coin_mint
+
+        UNION ALL
+
+        SELECT
+            position,
+            pool,
+            token_a_mint AS mint
+        FROM sol_meteora_damm_v2_initialize_custom_pool_instructions
+        WHERE token_a_mint = artist_coin_mint
+    ),
+    damm_v2_fees AS (
+        -- fee = totalLiquidity * feePerTokenStore
+        -- precision: (totalLiquidity * feePerTokenStore) >> 128
+        -- See: https://github.com/MeteoraAg/damm-v2-sdk/blob/70d1af59689039a1dc700dee8f741db48024d02d/src/helpers/utils.ts#L190-L191
+        SELECT
+            pool.token_a_mint AS mint,
+            (
+                pool.fee_b_per_liquidity
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS total,
+            (
+                (pool.fee_b_per_liquidity - position.fee_b_per_token_checkpoint)
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS unclaimed
+        FROM sol_meteora_damm_v2_pools pool
+        JOIN artist_positions p ON pool.account = p.pool
+        JOIN sol_meteora_damm_v2_positions position ON p.position = position.account
+        WHERE pool.token_a_mint = artist_coin_mint
+    ),
+    dbc_fees AS (
+        SELECT
+            base_mint AS mint,
+            total_trading_quote_fee / 2 AS total,
+            creator_quote_fee AS unclaimed
+        FROM artist_coin_pools
+        WHERE base_mint = artist_coin_mint
+    ),
+    all_fees AS (
+        SELECT * FROM damm_v2_fees
+        UNION ALL
+        SELECT * FROM dbc_fees
+    )
+    SELECT
+        COALESCE(FLOOR(SUM(unclaimed)), 0) AS unclaimed_fees,
+        COALESCE(FLOOR(SUM(total)), 0) AS total_fees
+    FROM artist_coins
+    LEFT JOIN all_fees USING (mint)
+    WHERE artist_coins.mint = artist_coin_mint;
+$$;
+
+
+ALTER FUNCTION public.calculate_artist_coin_fee_earnings(artist_coin_mint text) OWNER TO postgres;
+
+--
+-- Name: calculate_artist_coin_fees(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.calculate_artist_coin_fees(artist_coin_mint text) RETURNS TABLE(unclaimed_dbc_fees numeric, total_dbc_fees numeric, unclaimed_damm_v2_fees numeric, total_damm_v2_fees numeric, unclaimed_fees numeric, total_fees numeric)
+    LANGUAGE sql
+    AS $$
+    WITH
+    damm_fees AS (
+        -- fee = totalLiquidity * feePerTokenStore
+        -- precision: (totalLiquidity * feePerTokenStore) >> 128
+        -- See: https://github.com/MeteoraAg/damm-v2-sdk/blob/70d1af59689039a1dc700dee8f741db48024d02d/src/helpers/utils.ts#L190-L191
+        SELECT
+            pool.token_a_mint AS mint,
+            (
+                pool.fee_b_per_liquidity
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS total_damm_v2_fees,
+            (
+                (pool.fee_b_per_liquidity - position.fee_b_per_token_checkpoint)
+                * (
+                    position.unlocked_liquidity + position.vested_liquidity + position.permanent_locked_liquidity
+                )
+                / POWER (2, 128)
+                + position.fee_b_pending
+            ) AS unclaimed_damm_v2_fees
+        FROM sol_meteora_damm_v2_pools pool
+        JOIN sol_meteora_dbc_migrations migration ON migration.base_mint = pool.token_a_mint
+        JOIN sol_meteora_damm_v2_positions position ON position.account = migration.first_position
+        WHERE pool.token_a_mint = artist_coin_mint
+    ),
+    dbc_fees AS (
+        SELECT
+            base_mint AS mint,
+            total_trading_quote_fee / 2 AS total_dbc_fees,
+            creator_quote_fee AS unclaimed_dbc_fees
+        FROM artist_coin_pools
+        WHERE base_mint = artist_coin_mint
+    )
+    SELECT
+        FLOOR(COALESCE(dbc_fees.unclaimed_dbc_fees, 0)) AS unclaimed_dbc_fees,
+        FLOOR(COALESCE(dbc_fees.total_dbc_fees, 0)) AS total_dbc_fees,
+        FLOOR(COALESCE(damm_fees.unclaimed_damm_v2_fees, 0)) AS unclaimed_damm_v2_fees,
+        FLOOR(COALESCE(damm_fees.total_damm_v2_fees, 0)) AS total_damm_v2_fees,
+        FLOOR(COALESCE(dbc_fees.unclaimed_dbc_fees, 0) + COALESCE(damm_fees.unclaimed_damm_v2_fees, 0)) AS unclaimed_fees,
+        FLOOR(COALESCE(dbc_fees.total_dbc_fees, 0) + COALESCE(damm_fees.total_damm_v2_fees, 0)) AS total_fees
+    FROM artist_coins
+    LEFT JOIN dbc_fees USING (mint)
+    FULL OUTER JOIN damm_fees USING (mint)
+    WHERE artist_coins.mint = artist_coin_mint;
+$$;
+
+
+ALTER FUNCTION public.calculate_artist_coin_fees(artist_coin_mint text) OWNER TO postgres;
+
+--
+-- Name: calculate_artist_coin_locker(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.calculate_artist_coin_locker(artist_coin_mint text) RETURNS TABLE(address text, unlocked bigint, locked bigint, claimable bigint)
+    LANGUAGE sql
+    AS $$
+    WITH escrow AS (
+        SELECT
+            account,
+            amount_per_period,
+            number_of_period,
+            total_claimed_amount,
+            cliff_unlock_amount,
+            CASE WHEN to_timestamp(cliff_time) < NOW() THEN 0 ELSE cliff_unlock_amount END AS cliff_unlocked_amount,
+            LEAST(
+                FLOOR(
+                    (EXTRACT(EPOCH FROM NOW()) - vesting_start_time) / frequency
+                ),
+                number_of_period
+            ) AS periods_completed
+        FROM sol_locker_vesting_escrows
+        WHERE token_mint = artist_coin_mint
+    )
+    SELECT
+        account AS address,
+        cliff_unlocked_amount + periods_completed * amount_per_period AS unlocked,
+        cliff_unlock_amount - cliff_unlocked_amount + (number_of_period - periods_completed) * amount_per_period AS locked,
+        cliff_unlocked_amount + periods_completed * amount_per_period - total_claimed_amount AS claimable
+    FROM escrow;
+$$;
+
+
+ALTER FUNCTION public.calculate_artist_coin_locker(artist_coin_mint text) OWNER TO postgres;
+
+--
+-- Name: canonicalize_associated_wallet(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.canonicalize_associated_wallet() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NEW.chain = 'eth' AND NEW.wallet IS NOT NULL THEN
+        NEW.wallet := LOWER(NEW.wallet);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION public.canonicalize_associated_wallet() OWNER TO postgres;
+
+--
+-- Name: chat_allowed(integer, integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.chat_allowed(from_user_id integer, to_user_id integer) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  can_message BOOLEAN;
+  permission_row chat_permissions%ROWTYPE;
+BEGIN
+
+  -- explicit block
+  IF EXISTS (
+    SELECT 1
+    FROM chat_blocked_users
+    WHERE
+      -- don't allow blockee to message blocker
+      (blocker_user_id = to_user_id AND blockee_user_id = from_user_id)
+      -- also don't allower blocker to message blockee (prohibit one way send)
+      OR (blocker_user_id = from_user_id AND blockee_user_id = to_user_id)
+  ) THEN
+    RETURN FALSE;
+  END IF;
+
+  -- no permissions set... assume ok
+  SELECT COUNT(*) = 0 INTO can_message
+  FROM chat_permissions
+  WHERE user_id = to_user_id;
+
+  IF can_message THEN
+    RETURN TRUE;
+  END IF;
+
+  -- existing chat takes priority over permissions
+  SELECT COUNT(*) > 0 INTO can_message
+  FROM chat_member member_a
+  JOIN chat_member member_b USING (chat_id)
+  JOIN chat_message USING (chat_id)
+  WHERE member_a.user_id = from_user_id
+    AND member_b.user_id = to_user_id
+    AND (member_b.cleared_history_at IS NULL OR chat_message.created_at > member_b.cleared_history_at)
+  ;
+
+  IF can_message THEN
+    RETURN TRUE;
+  END IF;
+
+
+  -- check permissions in turn:
+  FOR permission_row IN select * from chat_permissions WHERE user_id = to_user_id AND allowed = TRUE
+  LOOP
+    CASE permission_row.permits
+
+      WHEN 'followees' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM follows
+          WHERE followee_user_id = from_user_id
+          AND follower_user_id = to_user_id
+          AND is_delete = false
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'followers' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM follows
+          WHERE follower_user_id = from_user_id
+          AND followee_user_id = to_user_id
+          AND is_delete = false
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'tippees' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM user_tips tip
+          WHERE receiver_user_id = from_user_id
+          AND sender_user_id = to_user_id
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'tippers' THEN
+        IF EXISTS (
+          SELECT 1
+          FROM user_tips tip
+          WHERE receiver_user_id = to_user_id
+          AND sender_user_id = from_user_id
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'verified' THEN
+        IF EXISTS (
+          SELECT 1 FROM USERS WHERE user_id = from_user_id AND is_verified = TRUE
+        ) THEN
+          RETURN TRUE;
+        END IF;
+
+      WHEN 'none' THEN
+        RETURN FALSE;
+
+      WHEN 'all' THEN
+        RETURN TRUE;
+
+      ELSE
+        RAISE WARNING 'unknown permits: %s', permission_row.permits;
+    END CASE;
+  END LOOP;
+
+  RETURN FALSE;
+
+END;
+$$;
+
+
+ALTER FUNCTION public.chat_allowed(from_user_id integer, to_user_id integer) OWNER TO postgres;
+
+--
+-- Name: chat_blast_audience(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.chat_blast_audience(blast_id_param text) RETURNS TABLE(blast_id text, to_user_id integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+
+  RETURN QUERY
+  -- follower_audience
+  SELECT chat_blast.blast_id, follower_user_id AS to_user_id
+  FROM follows
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'follower_audience'
+    AND follows.followee_user_id = chat_blast.from_user_id
+    AND follows.is_delete = false
+    AND follows.created_at < chat_blast.created_at
+
+  UNION
+
+  -- tipper_audience
+  SELECT chat_blast.blast_id, sender_user_id AS to_user_id
+  FROM user_tips tip
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'tipper_audience'
+    AND receiver_user_id = chat_blast.from_user_id
+    AND tip.created_at < chat_blast.created_at
+
+  UNION
+
+  -- remixer_audience (exclude tracks with access_authorities / programmable distribution)
+  SELECT chat_blast.blast_id, t.owner_id AS to_user_id
+  FROM tracks t
+  JOIN remixes ON remixes.child_track_id = t.track_id
+  JOIN tracks og ON remixes.parent_track_id = og.track_id
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'remixer_audience'
+    AND og.owner_id = chat_blast.from_user_id
+    AND t.owner_id != chat_blast.from_user_id
+    AND t.access_authorities IS NULL
+    AND og.access_authorities IS NULL
+    AND (
+      chat_blast.audience_content_id IS NULL
+      OR (
+        chat_blast.audience_content_type = 'track'
+        AND chat_blast.audience_content_id = og.track_id
+      )
+    )
+
+  UNION
+
+  -- customer_audience
+  SELECT chat_blast.blast_id, buyer_user_id AS to_user_id
+  FROM usdc_purchases p
+  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'customer_audience'
+    AND p.seller_user_id = chat_blast.from_user_id
+    AND (
+      chat_blast.audience_content_id IS NULL
+      OR (
+        chat_blast.audience_content_type = p.content_type::text
+        AND chat_blast.audience_content_id = p.content_id
+      )
+    )
+
+  UNION
+
+  -- coin_holder_audience
+  SELECT chat_blast.blast_id, sol_user_balances.user_id AS to_user_id
+  FROM chat_blast
+  JOIN artist_coins
+    ON artist_coins.user_id = chat_blast.from_user_id
+    -- Initial list of coin holders to check, filtered below to ensure they had coins at the time the blast was created
+  JOIN sol_user_balances
+    ON sol_user_balances.mint = artist_coins.mint
+  WHERE chat_blast.blast_id = blast_id_param
+    AND chat_blast.audience = 'coin_holder_audience'
+    AND sol_user_balances.user_id != chat_blast.from_user_id
+    AND user_mint_balance_at(
+      sol_user_balances.user_id,
+      artist_coins.mint,
+      chat_blast.created_at
+    ) >= POWER(10, artist_coins.decimals);
+
+END;
+$$;
+
+
+ALTER FUNCTION public.chat_blast_audience(blast_id_param text) OWNER TO postgres;
+
+--
+-- Name: clear_user_records(integer[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.clear_user_records(user_ids integer[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+begin
+
+  delete from "user_bank_accounts" where "ethereum_address" in (select "wallet" from "users" where "user_id" = any(user_ids));
+  delete from "usdc_user_bank_accounts" where "ethereum_address" in (select "wallet" from "users" where "user_id" = any(user_ids));
+
+  delete from "users" where "user_id" = any(user_ids);
+  delete from "aggregate_user" where "user_id" = any(user_ids);
+  delete from "aggregate_user_tips" where "sender_user_id" = any(user_ids);
+  delete from "aggregate_user_tips" where "receiver_user_id" = any(user_ids);
+  delete from "user_tips" where "sender_user_id" = any(user_ids);
+  delete from "user_tips" where "receiver_user_id" = any(user_ids);
+  delete from "user_challenges" where "user_id" = any(user_ids);
+  delete from "follows" where "follower_user_id" = any(user_ids);
+  delete from "follows" where "followee_user_id" = any(user_ids);
+  delete from "user_pubkeys" where "user_id" = any(user_ids);
+  delete from "user_events" where "user_id" = any(user_ids);
+  delete from "saves" where "user_id" = any(user_ids);
+  delete from "challenge_disbursements" where "user_id" = any(user_ids);
+  delete from "challenge_profile_completion" where "user_id" = any(user_ids);
+  delete from "subscriptions" where "subscriber_id" = any(user_ids);
+  delete from "associated_wallets" where "user_id" = any(user_ids);
+  delete from "plays" where "user_id" = any(user_ids);
+  delete from "related_artists" where "user_id" = any(user_ids);
+  delete from "trending_results" where "user_id" = any(user_ids);
+  delete from "supporter_rank_ups" where "sender_user_id" = any(user_ids);
+  delete from "supporter_rank_ups" where "receiver_user_id" = any(user_ids);
+  delete from "user_balance_changes" where "user_id" = any(user_ids);
+  delete from "user_listening_history" where "user_id" = any(user_ids);
+  delete from "challenge_listen_streak" where "user_id" = any(user_ids);
+  delete from "user_balances" where "user_id" = any(user_ids);
+  delete from "chat_permissions" where "user_id" = any(user_ids);
+  delete from "chat_message_reactions" where "user_id" = any(user_ids);
+  delete from "playlist_seen" where "user_id" = any(user_ids);
+  delete from "chat_ban" where "user_id" = any(user_ids);
+  delete from "chat_blocked_users" where "blocker_user_id" = any(user_ids);
+  delete from "chat_blocked_users" where "blockee_user_id" = any(user_ids);
+  delete from "chat_member" where "user_id" = any(user_ids);
+  delete from "chat_message" where "user_id" = any(user_ids);
+  delete from "user_delist_statuses" where "user_id" = any(user_ids);
+  delete from "grants" where "user_id" = any(user_ids);
+  delete from "notification_seen" where "user_id" = any(user_ids);
+  delete from "developer_apps" where "user_id" = any(user_ids);
+  delete from "reposts" where "user_id" = any(user_ids);
+  delete from "playlists" where "playlist_owner_id" = any(user_ids);
+  delete from "playlist_routes" where "owner_id" = any(user_ids);
+  delete from "track_delist_statuses" where "owner_id" = any(user_ids);
+  delete from "track_routes" where "owner_id" = any(user_ids);
+  delete from "tracks" where "owner_id" = any(user_ids);
+  delete from "usdc_purchases" where "buyer_user_id" = any(user_ids);
+  delete from "usdc_purchases" where "seller_user_id" = any(user_ids);
+
+end;
+$$;
+
+
+ALTER FUNCTION public.clear_user_records(user_ids integer[]) OWNER TO postgres;
+
+--
+-- Name: compute_user_score(bigint, bigint, bigint, bigint, bigint, boolean, boolean, bigint, bigint); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.compute_user_score(play_count bigint, follower_count bigint, challenge_count bigint, chat_block_count bigint, following_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, distinct_tracks_played bigint, karma bigint) RETURNS bigint
+    LANGUAGE sql IMMUTABLE
+    AS $$
+select (play_count / 2) + follower_count - challenge_count - (chat_block_count * 100) + karma + case
+        when following_count < 5 then -1
+        else 0
+    end + case
+        when is_audius_impersonator then -1000
+        else 0
+    end + case
+        when distinct_tracks_played <= 3 then -10
+        else 0
+    end + case
+        when not has_profile_picture then -100
+        else 0
+    end $$;
+
+
+ALTER FUNCTION public.compute_user_score(play_count bigint, follower_count bigint, challenge_count bigint, chat_block_count bigint, following_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, distinct_tracks_played bigint, karma bigint) OWNER TO postgres;
+
+--
+-- Name: country_to_iso_alpha2(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.country_to_iso_alpha2(country_name text) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    iso2_code TEXT;
+BEGIN
+    SELECT INTO iso2_code
+    CASE
+        -- standards
+        WHEN country_name ILIKE 'Andorra' THEN 'AD'
+        WHEN country_name ILIKE 'United Arab Emirates' THEN 'AE'
+        WHEN country_name ILIKE 'Afghanistan' THEN 'AF'
+        WHEN country_name ILIKE 'Antigua and Barbuda' THEN 'AG'
+        WHEN country_name ILIKE 'Anguilla' THEN 'AI'
+        WHEN country_name ILIKE 'Albania' THEN 'AL'
+        WHEN country_name ILIKE 'Armenia' THEN 'AM'
+        WHEN country_name ILIKE 'Netherlands Antilles' THEN 'AN'
+        WHEN country_name ILIKE 'Angola' THEN 'AO'
+        WHEN country_name ILIKE 'Antarctica' THEN 'AQ'
+        WHEN country_name ILIKE 'Argentina' THEN 'AR'
+        WHEN country_name ILIKE 'American Samoa' THEN 'AS'
+        WHEN country_name ILIKE 'Austria' THEN 'AT'
+        WHEN country_name ILIKE 'Australia' THEN 'AU'
+        WHEN country_name ILIKE 'Aruba' THEN 'AW'
+        WHEN country_name ILIKE 'Åland' THEN 'AX'
+        WHEN country_name ILIKE 'Azerbaijan' THEN 'AZ'
+        WHEN country_name ILIKE 'Bosnia and Herzegovina' THEN 'BA'
+        WHEN country_name ILIKE 'Barbados' THEN 'BB'
+        WHEN country_name ILIKE 'Bangladesh' THEN 'BD'
+        WHEN country_name ILIKE 'Belgium' THEN 'BE'
+        WHEN country_name ILIKE 'Burkina Faso' THEN 'BF'
+        WHEN country_name ILIKE 'Bulgaria' THEN 'BG'
+        WHEN country_name ILIKE 'Bahrain' THEN 'BH'
+        WHEN country_name ILIKE 'Burundi' THEN 'BI'
+        WHEN country_name ILIKE 'Benin' THEN 'BJ'
+        WHEN country_name ILIKE 'Saint Barthélemy' THEN 'BL'
+        WHEN country_name ILIKE 'Bermuda' THEN 'BM'
+        WHEN country_name ILIKE 'Brunei Darussalam' THEN 'BN'
+        WHEN country_name ILIKE 'Bolivia' THEN 'BO'
+        WHEN country_name ILIKE 'Brazil' THEN 'BR'
+        WHEN country_name ILIKE 'Bahamas' THEN 'BS'
+        WHEN country_name ILIKE 'Bhutan' THEN 'BT'
+        WHEN country_name ILIKE 'Bouvet Island' THEN 'BV'
+        WHEN country_name ILIKE 'Botswana' THEN 'BW'
+        WHEN country_name ILIKE 'Belarus' THEN 'BY'
+        WHEN country_name ILIKE 'Belize' THEN 'BZ'
+        WHEN country_name ILIKE 'Canada' THEN 'CA'
+        WHEN country_name ILIKE 'Cocos (Keeling) Islands' THEN 'CC'
+        WHEN country_name ILIKE 'Congo (Kinshasa)' THEN 'CD'
+        WHEN country_name ILIKE 'Central African Republic' THEN 'CF'
+        WHEN country_name ILIKE 'Congo (Brazzaville)' THEN 'CG'
+        WHEN country_name ILIKE 'Switzerland' THEN 'CH'
+        WHEN country_name ILIKE 'Côte d''Ivoire' THEN 'CI'
+        WHEN country_name ILIKE 'Cook Islands' THEN 'CK'
+        WHEN country_name ILIKE 'Chile' THEN 'CL'
+        WHEN country_name ILIKE 'Cameroon' THEN 'CM'
+        WHEN country_name ILIKE 'China' THEN 'CN'
+        WHEN country_name ILIKE 'Colombia' THEN 'CO'
+        WHEN country_name ILIKE 'Costa Rica' THEN 'CR'
+        WHEN country_name ILIKE 'Cuba' THEN 'CU'
+        WHEN country_name ILIKE 'Cape Verde' THEN 'CV'
+        WHEN country_name ILIKE 'Christmas Island' THEN 'CX'
+        WHEN country_name ILIKE 'Cyprus' THEN 'CY'
+        WHEN country_name ILIKE 'Czech Republic' THEN 'CZ'
+        WHEN country_name ILIKE 'Germany' THEN 'DE'
+        WHEN country_name ILIKE 'Djibouti' THEN 'DJ'
+        WHEN country_name ILIKE 'Denmark' THEN 'DK'
+        WHEN country_name ILIKE 'Dominica' THEN 'DM'
+        WHEN country_name ILIKE 'Dominican Republic' THEN 'DO'
+        WHEN country_name ILIKE 'Algeria' THEN 'DZ'
+        WHEN country_name ILIKE 'Ecuador' THEN 'EC'
+        WHEN country_name ILIKE 'Estonia' THEN 'EE'
+        WHEN country_name ILIKE 'Egypt' THEN 'EG'
+        WHEN country_name ILIKE 'Western Sahara' THEN 'EH'
+        WHEN country_name ILIKE 'Eritrea' THEN 'ER'
+        WHEN country_name ILIKE 'Spain' THEN 'ES'
+        WHEN country_name ILIKE 'Ethiopia' THEN 'ET'
+        WHEN country_name ILIKE 'Finland' THEN 'FI'
+        WHEN country_name ILIKE 'Fiji' THEN 'FJ'
+        WHEN country_name ILIKE 'Falkland Islands' THEN 'FK'
+        WHEN country_name ILIKE 'Micronesia' THEN 'FM'
+        WHEN country_name ILIKE 'Faroe Islands' THEN 'FO'
+        WHEN country_name ILIKE 'France' THEN 'FR'
+        WHEN country_name ILIKE 'Gabon' THEN 'GA'
+        WHEN country_name ILIKE 'United Kingdom' THEN 'GB'
+        WHEN country_name ILIKE 'Grenada' THEN 'GD'
+        WHEN country_name ILIKE 'Georgia' THEN 'GE'
+        WHEN country_name ILIKE 'French Guiana' THEN 'GF'
+        WHEN country_name ILIKE 'Guernsey' THEN 'GG'
+        WHEN country_name ILIKE 'Ghana' THEN 'GH'
+        WHEN country_name ILIKE 'Gibraltar' THEN 'GI'
+        WHEN country_name ILIKE 'Greenland' THEN 'GL'
+        WHEN country_name ILIKE 'Gambia' THEN 'GM'
+        WHEN country_name ILIKE 'Guinea' THEN 'GN'
+        WHEN country_name ILIKE 'Guadeloupe' THEN 'GP'
+        WHEN country_name ILIKE 'Equatorial Guinea' THEN 'GQ'
+        WHEN country_name ILIKE 'Greece' THEN 'GR'
+        WHEN country_name ILIKE 'South Georgia and South Sandwich Islands' THEN 'GS'
+        WHEN country_name ILIKE 'Guatemala' THEN 'GT'
+        WHEN country_name ILIKE 'Guam' THEN 'GU'
+        WHEN country_name ILIKE 'Guinea-Bissau' THEN 'GW'
+        WHEN country_name ILIKE 'Guyana' THEN 'GY'
+        WHEN country_name ILIKE 'Hong Kong' THEN 'HK'
+        WHEN country_name ILIKE 'Heard and McDonald Islands' THEN 'HM'
+        WHEN country_name ILIKE 'Honduras' THEN 'HN'
+        WHEN country_name ILIKE 'Croatia' THEN 'HR'
+        WHEN country_name ILIKE 'Haiti' THEN 'HT'
+        WHEN country_name ILIKE 'Hungary' THEN 'HU'
+        WHEN country_name ILIKE 'Indonesia' THEN 'ID'
+        WHEN country_name ILIKE 'Ireland' THEN 'IE'
+        WHEN country_name ILIKE 'Israel' THEN 'IL'
+        WHEN country_name ILIKE 'Isle of Man' THEN 'IM'
+        WHEN country_name ILIKE 'India' THEN 'IN'
+        WHEN country_name ILIKE 'British Indian Ocean Territory' THEN 'IO'
+        WHEN country_name ILIKE 'Iraq' THEN 'IQ'
+        WHEN country_name ILIKE 'Iran' THEN 'IR'
+        WHEN country_name ILIKE 'Iceland' THEN 'IS'
+        WHEN country_name ILIKE 'Italy' THEN 'IT'
+        WHEN country_name ILIKE 'Jersey' THEN 'JE'
+        WHEN country_name ILIKE 'Jamaica' THEN 'JM'
+        WHEN country_name ILIKE 'Jordan' THEN 'JO'
+        WHEN country_name ILIKE 'Japan' THEN 'JP'
+        WHEN country_name ILIKE 'Kenya' THEN 'KE'
+        WHEN country_name ILIKE 'Kyrgyzstan' THEN 'KG'
+        WHEN country_name ILIKE 'Cambodia' THEN 'KH'
+        WHEN country_name ILIKE 'Kiribati' THEN 'KI'
+        WHEN country_name ILIKE 'Comoros' THEN 'KM'
+        WHEN country_name ILIKE 'Saint Kitts and Nevis' THEN 'KN'
+        WHEN country_name ILIKE 'Korea, North' THEN 'KP'
+        WHEN country_name ILIKE 'Korea, South' THEN 'KR'
+        WHEN country_name ILIKE 'Kuwait' THEN 'KW'
+        WHEN country_name ILIKE 'Cayman Islands' THEN 'KY'
+        WHEN country_name ILIKE 'Kazakhstan' THEN 'KZ'
+        WHEN country_name ILIKE 'Laos' THEN 'LA'
+        WHEN country_name ILIKE 'Lebanon' THEN 'LB'
+        WHEN country_name ILIKE 'Saint Lucia' THEN 'LC'
+        WHEN country_name ILIKE 'Liechtenstein' THEN 'LI'
+        WHEN country_name ILIKE 'Sri Lanka' THEN 'LK'
+        WHEN country_name ILIKE 'Liberia' THEN 'LR'
+        WHEN country_name ILIKE 'Lesotho' THEN 'LS'
+        WHEN country_name ILIKE 'Lithuania' THEN 'LT'
+        WHEN country_name ILIKE 'Luxembourg' THEN 'LU'
+        WHEN country_name ILIKE 'Latvia' THEN 'LV'
+        WHEN country_name ILIKE 'Libya' THEN 'LY'
+        WHEN country_name ILIKE 'Morocco' THEN 'MA'
+        WHEN country_name ILIKE 'Monaco' THEN 'MC'
+        WHEN country_name ILIKE 'Moldova' THEN 'MD'
+        WHEN country_name ILIKE 'Montenegro' THEN 'ME'
+        WHEN country_name ILIKE 'Saint Martin (French part)' THEN 'MF'
+        WHEN country_name ILIKE 'Madagascar' THEN 'MG'
+        WHEN country_name ILIKE 'Marshall Islands' THEN 'MH'
+        WHEN country_name ILIKE 'Macedonia' THEN 'MK'
+        WHEN country_name ILIKE 'Mali' THEN 'ML'
+        WHEN country_name ILIKE 'Myanmar' THEN 'MM'
+        WHEN country_name ILIKE 'Mongolia' THEN 'MN'
+        WHEN country_name ILIKE 'Macau' THEN 'MO'
+        WHEN country_name ILIKE 'Northern Mariana Islands' THEN 'MP'
+        WHEN country_name ILIKE 'Martinique' THEN 'MQ'
+        WHEN country_name ILIKE 'Mauritania' THEN 'MR'
+        WHEN country_name ILIKE 'Montserrat' THEN 'MS'
+        WHEN country_name ILIKE 'Malta' THEN 'MT'
+        WHEN country_name ILIKE 'Mauritius' THEN 'MU'
+        WHEN country_name ILIKE 'Maldives' THEN 'MV'
+        WHEN country_name ILIKE 'Malawi' THEN 'MW'
+        WHEN country_name ILIKE 'Mexico' THEN 'MX'
+        WHEN country_name ILIKE 'Malaysia' THEN 'MY'
+        WHEN country_name ILIKE 'Mozambique' THEN 'MZ'
+        WHEN country_name ILIKE 'Namibia' THEN 'NA'
+        WHEN country_name ILIKE 'New Caledonia' THEN 'NC'
+        WHEN country_name ILIKE 'Niger' THEN 'NE'
+        WHEN country_name ILIKE 'Norfolk Island' THEN 'NF'
+        WHEN country_name ILIKE 'Nigeria' THEN 'NG'
+        WHEN country_name ILIKE 'Nicaragua' THEN 'NI'
+        WHEN country_name ILIKE 'Netherlands' THEN 'NL'
+        WHEN country_name ILIKE 'Norway' THEN 'NO'
+        WHEN country_name ILIKE 'Nepal' THEN 'NP'
+        WHEN country_name ILIKE 'Nauru' THEN 'NR'
+        WHEN country_name ILIKE 'Niue' THEN 'NU'
+        WHEN country_name ILIKE 'New Zealand' THEN 'NZ'
+        WHEN country_name ILIKE 'Oman' THEN 'OM'
+        WHEN country_name ILIKE 'Panama' THEN 'PA'
+        WHEN country_name ILIKE 'Peru' THEN 'PE'
+        WHEN country_name ILIKE 'French Polynesia' THEN 'PF'
+        WHEN country_name ILIKE 'Papua New Guinea' THEN 'PG'
+        WHEN country_name ILIKE 'Philippines' THEN 'PH'
+        WHEN country_name ILIKE 'Pakistan' THEN 'PK'
+        WHEN country_name ILIKE 'Poland' THEN 'PL'
+        WHEN country_name ILIKE 'Saint Pierre and Miquelon' THEN 'PM'
+        WHEN country_name ILIKE 'Pitcairn' THEN 'PN'
+        WHEN country_name ILIKE 'Puerto Rico' THEN 'PR'
+        WHEN country_name ILIKE 'Palestine' THEN 'PS'
+        WHEN country_name ILIKE 'Portugal' THEN 'PT'
+        WHEN country_name ILIKE 'Palau' THEN 'PW'
+        WHEN country_name ILIKE 'Paraguay' THEN 'PY'
+        WHEN country_name ILIKE 'Qatar' THEN 'QA'
+        WHEN country_name ILIKE 'Reunion' THEN 'RE'
+        WHEN country_name ILIKE 'Romania' THEN 'RO'
+        WHEN country_name ILIKE 'Serbia' THEN 'RS'
+        WHEN country_name ILIKE 'Russian Federation' THEN 'RU'
+        WHEN country_name ILIKE 'Rwanda' THEN 'RW'
+        WHEN country_name ILIKE 'Saudi Arabia' THEN 'SA'
+        WHEN country_name ILIKE 'Solomon Islands' THEN 'SB'
+        WHEN country_name ILIKE 'Seychelles' THEN 'SC'
+        WHEN country_name ILIKE 'Sudan' THEN 'SD'
+        WHEN country_name ILIKE 'Sweden' THEN 'SE'
+        WHEN country_name ILIKE 'Singapore' THEN 'SG'
+        WHEN country_name ILIKE 'Saint Helena' THEN 'SH'
+        WHEN country_name ILIKE 'Slovenia' THEN 'SI'
+        WHEN country_name ILIKE 'Svalbard and Jan Mayen Islands' THEN 'SJ'
+        WHEN country_name ILIKE 'Slovakia' THEN 'SK'
+        WHEN country_name ILIKE 'Sierra Leone' THEN 'SL'
+        WHEN country_name ILIKE 'San Marino' THEN 'SM'
+        WHEN country_name ILIKE 'Senegal' THEN 'SN'
+        WHEN country_name ILIKE 'Somalia' THEN 'SO'
+        WHEN country_name ILIKE 'Suriname' THEN 'SR'
+        WHEN country_name ILIKE 'Sao Tome and Principe' THEN 'ST'
+        WHEN country_name ILIKE 'El Salvador' THEN 'SV'
+        WHEN country_name ILIKE 'Syria' THEN 'SY'
+        WHEN country_name ILIKE 'Swaziland' THEN 'SZ'
+        WHEN country_name ILIKE 'Turks and Caicos Islands' THEN 'TC'
+        WHEN country_name ILIKE 'Chad' THEN 'TD'
+        WHEN country_name ILIKE 'French Southern Lands' THEN 'TF'
+        WHEN country_name ILIKE 'Togo' THEN 'TG'
+        WHEN country_name ILIKE 'Thailand' THEN 'TH'
+        WHEN country_name ILIKE 'Tajikistan' THEN 'TJ'
+        WHEN country_name ILIKE 'Tokelau' THEN 'TK'
+        WHEN country_name ILIKE 'Timor-Leste' THEN 'TL'
+        WHEN country_name ILIKE 'Turkmenistan' THEN 'TM'
+        WHEN country_name ILIKE 'Tunisia' THEN 'TN'
+        WHEN country_name ILIKE 'Tonga' THEN 'TO'
+        WHEN country_name ILIKE 'Turkey' THEN 'TR'
+        WHEN country_name ILIKE 'Trinidad and Tobago' THEN 'TT'
+        WHEN country_name ILIKE 'Tuvalu' THEN 'TV'
+        WHEN country_name ILIKE 'Taiwan' THEN 'TW'
+        WHEN country_name ILIKE 'Tanzania' THEN 'TZ'
+        WHEN country_name ILIKE 'Ukraine' THEN 'UA'
+        WHEN country_name ILIKE 'Uganda' THEN 'UG'
+        WHEN country_name ILIKE 'United States Minor Outlying Islands' THEN 'UM'
+        WHEN country_name ILIKE 'United States of America' THEN 'US'
+        WHEN country_name ILIKE 'Uruguay' THEN 'UY'
+        WHEN country_name ILIKE 'Uzbekistan' THEN 'UZ'
+        WHEN country_name ILIKE 'Vatican City' THEN 'VA'
+        WHEN country_name ILIKE 'Saint Vincent and the Grenadines' THEN 'VC'
+        WHEN country_name ILIKE 'Venezuela' THEN 'VE'
+        WHEN country_name ILIKE 'Virgin Islands, British' THEN 'VG'
+        WHEN country_name ILIKE 'Virgin Islands, U.S.' THEN 'VI'
+        WHEN country_name ILIKE 'Vietnam' THEN 'VN'
+        WHEN country_name ILIKE 'Vanuatu' THEN 'VU'
+        WHEN country_name ILIKE 'Wallis and Futuna Islands' THEN 'WF'
+        WHEN country_name ILIKE 'Samoa' THEN 'WS'
+        WHEN country_name ILIKE 'Yemen' THEN 'YE'
+        WHEN country_name ILIKE 'Mayotte' THEN 'YT'
+        WHEN country_name ILIKE 'South Africa' THEN 'ZA'
+        WHEN country_name ILIKE 'Zambia' THEN 'ZM'
+        WHEN country_name ILIKE 'Zimbabwe' THEN 'ZW'
+        WHEN country_name ILIKE 'Bonaire' THEN 'BQ'
+        WHEN country_name ILIKE 'Curaçao' THEN 'CW'
+        WHEN country_name ILIKE 'South Sudan' THEN 'SS'
+        WHEN country_name ILIKE 'Sint Maarten' THEN 'SX'
+        WHEN country_name ILIKE 'Kosovo' THEN 'XK'
+        -- audius exceptions
+        WHEN country_name ILIKE 'Aland Islands' THEN 'AX'
+        WHEN country_name ILIKE 'Bonaire, Saint Eustatius and Saba ' THEN 'BQ'
+        WHEN country_name ILIKE 'British Virgin Islands' THEN 'VG'
+        WHEN country_name ILIKE 'Brunei' THEN 'BN'
+        WHEN country_name ILIKE 'Cabo Verde' THEN 'CV'
+        WHEN country_name ILIKE 'Cocos Islands' THEN 'CC'
+        WHEN country_name ILIKE 'Curacao' THEN 'CW'
+        WHEN country_name ILIKE 'Czechia' THEN 'CZ'
+        WHEN country_name ILIKE 'Democratic Republic of the Congo' THEN 'CD'
+        WHEN country_name ILIKE 'Eswatini' THEN 'SZ'
+        WHEN country_name ILIKE 'Ivory Coast' THEN 'CI'
+        WHEN country_name ILIKE 'Macao' THEN 'MO'
+        WHEN country_name ILIKE 'North Macedonia' THEN 'MK'
+        WHEN country_name ILIKE 'Palestinian Territory' THEN 'PS'
+        WHEN country_name ILIKE 'Republic of the Congo' THEN 'CG'
+        WHEN country_name ILIKE 'Russia' THEN 'RU'
+        WHEN country_name ILIKE 'Saint Barthelemy' THEN 'BL'
+        WHEN country_name ILIKE 'Saint Martin' THEN 'MF'
+        WHEN country_name ILIKE 'South Korea' THEN 'KR'
+        WHEN country_name ILIKE 'The Netherlands' THEN 'NL'
+        WHEN country_name ILIKE 'Timor Leste' THEN 'TL'
+        WHEN country_name ILIKE 'U.S. Virgin Islands' THEN 'VI'
+        WHEN country_name ILIKE 'Wallis and Futuna' THEN 'WF'
+        WHEN country_name ILIKE 'United States' THEN 'US'
+        ELSE NULL
+    END;
+
+    RETURN iso2_code;
+END;
+$$;
+
+
+ALTER FUNCTION public.country_to_iso_alpha2(country_name text) OWNER TO postgres;
+
+--
+-- Name: delete_constraints_referencing_blocks(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.delete_constraints_referencing_blocks() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    constraint_record RECORD;
+BEGIN
+    FOR constraint_record IN (
+        SELECT
+            c.conname AS constraint_name,
+            conrelid::regclass AS referencing_table
+        FROM
+            pg_constraint c
+        JOIN
+            pg_attribute a ON a.attnum = ANY(c.conkey)
+        WHERE
+            confrelid = 'blocks'::regclass
+            AND contype = 'f'
+            AND pg_get_constraintdef(c.oid) NOT LIKE '%ON DELETE CASCADE%'
+        GROUP BY
+            c.conname, conrelid::regclass
+    )
+    LOOP
+        -- Drop the foreign key constraint
+        EXECUTE 'ALTER TABLE ' || constraint_record.referencing_table || ' DROP CONSTRAINT ' || constraint_record.constraint_name;
+    END LOOP;
+END;
+$$;
+
+
+ALTER FUNCTION public.delete_constraints_referencing_blocks() OWNER TO postgres;
+
+--
+-- Name: delete_is_current_false_rows(text[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.delete_is_current_false_rows(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      -- Logging the deletion
+      RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
+
+      EXECUTE format('DELETE FROM %s WHERE is_current = false', 
+                     quote_ident(_table_name));
+                     
+   END LOOP;
+END
+$$;
+
+
+ALTER FUNCTION public.delete_is_current_false_rows(_table_names text[]) OWNER TO postgres;
+
+--
+-- Name: delete_rows(text[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.delete_rows(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
+
+      EXECUTE format('DELETE FROM %s WHERE is_current = false', 
+                     quote_ident(_table_name));
+
+   END LOOP;
+END
+$$;
+
+
+ALTER FUNCTION public.delete_rows(_table_names text[]) OWNER TO postgres;
+
+--
+-- Name: drop_fk_constraints(text[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.drop_fk_constraints(_table_names text[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+   _table_name text;
+BEGIN
+   FOREACH _table_name IN ARRAY _table_names
+   LOOP
+      RAISE NOTICE 'Dropping foreign key constraint to table %', _table_name;
+      EXECUTE format('LOCK TABLE %s IN ACCESS EXCLUSIVE MODE', 
+                     quote_ident(_table_name));
+
+      EXECUTE format('ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s', 
+                     quote_ident(_table_name), 
+                     quote_ident(_table_name || '_blocknumber_fkey'));
+
+   END LOOP;
+END
+$$;
+
+
+ALTER FUNCTION public.drop_fk_constraints(_table_names text[]) OWNER TO postgres;
+
+--
+-- Name: find_track(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.find_track(url text) RETURNS TABLE(user_id integer, track_id integer)
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    segments text[];
+    v_handle text;
+    v_slug text;
+BEGIN
+    -- Split the URL into path segments
+    segments := string_to_array(regexp_replace(url, '^.+://[^/]+', ''), '/');
+
+    -- Remove empty segments
+    segments := segments[array_length(segments, 1) - array_upper(segments, 1) + 1:];
+
+    -- Retrieve the last two segments
+    v_slug := segments[array_upper(segments, 1)];
+    v_handle := segments[array_upper(segments, 1) - 1];
+
+    select u.user_id into user_id from users u where handle_lc = lower(v_handle);
+
+    select r.track_id
+    into track_id
+    from track_routes r
+    where r.slug = v_slug
+      and owner_id = user_id
+    order by is_current desc
+    limit 1;
+
+    return next;
+END;
+$$;
+
+
+ALTER FUNCTION public.find_track(url text) OWNER TO postgres;
+
+--
+-- Name: get_shadowbanned_users(integer[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.get_shadowbanned_users(user_ids integer[]) RETURNS TABLE(user_id integer)
+    LANGUAGE plpgsql
+    AS $$ begin return query with scoped_users as (
+        select users.user_id
+        from users
+        where users.user_id = any (user_ids)
+    ),
+    play_activity as (
+        select plays.user_id,
+            count(distinct date_trunc('minute', plays.created_at)) as play_count
+        from plays
+        where plays.user_id is not null
+            and plays.user_id in (
+                select scoped_users.user_id
+                from scoped_users
+            )
+        group by plays.user_id
+    ),
+    fast_challenge_completion as (
+        select users.user_id,
+            handle_lc,
+            users.created_at,
+            count(*) as challenge_count,
+            array_agg(user_challenges.challenge_id) as challenge_ids
+        from users
+            left join user_challenges on users.user_id = user_challenges.user_id
+        where user_challenges.is_complete
+            and user_challenges.completed_at - users.created_at <= interval '3 minutes'
+            and user_challenges.challenge_id not in ('m', 'b')
+            and users.user_id in (
+                select scoped_users.user_id
+                from scoped_users
+            )
+        group by users.user_id,
+            users.handle_lc,
+            users.created_at
+        order by users.created_at desc
+    ),
+    aggregate_scores as (
+        select users.user_id,
+            users.handle_lc,
+            users.created_at,
+            coalesce(play_activity.play_count, 0) as play_count,
+            coalesce(fast_challenge_completion.challenge_count, 0) as challenge_count,
+            coalesce(aggregate_user.following_count, 0) as following_count,
+            coalesce(aggregate_user.follower_count, 0) as follower_count
+        from users
+            left join play_activity on users.user_id = play_activity.user_id
+            left join fast_challenge_completion on users.user_id = fast_challenge_completion.user_id
+            left join aggregate_user on aggregate_user.user_id = users.user_id
+        where users.handle_lc is not null
+            and users.user_id in (
+                select scoped_users.user_id
+                from scoped_users
+            )
+        order by users.created_at desc
+    ),
+    computed_scores as (
+        select a.user_id,
+            a.handle_lc,
+            a.play_count,
+            a.follower_count,
+            a.challenge_count,
+            a.following_count,
+            (
+                a.play_count + a.follower_count - a.challenge_count + case
+                    when a.following_count < 5 then -1
+                    else 0
+                end
+            ) as overall_score
+        from aggregate_scores a
+    )
+select computed_scores.user_id
+from computed_scores
+where overall_score < 0;
+-- filter based on threshold
+end;
+$$;
+
+
+ALTER FUNCTION public.get_shadowbanned_users(user_ids integer[]) OWNER TO postgres;
+
+--
+-- Name: get_user_score(integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.get_user_score(target_user_id integer) RETURNS TABLE(user_id integer, handle_lc text, play_count bigint, distinct_tracks_played bigint, challenge_count bigint, following_count bigint, follower_count bigint, chat_block_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, karma bigint, score bigint)
+    LANGUAGE sql
+    AS $$ with chat_blocks as (
+        select c.blockee_user_id as user_id,
+            count(*) as block_count
+        from chat_blocked_users c
+        where c.blockee_user_id = target_user_id
+        group by c.blockee_user_id
+    ),
+    aggregate_scores as (
+        select u.user_id,
+            u.handle_lc,
+            coalesce(udph.hours_with_play, 0)::bigint as play_count,
+            coalesce(udpt.track_count, 0)::bigint as distinct_tracks_played,
+            coalesce(usf.challenge_count, 0)::bigint as challenge_count,
+            coalesce(au.following_count, 0) as following_count,
+            coalesce(au.follower_count, 0) as follower_count,
+            coalesce(cb.block_count, 0) as chat_block_count,
+            case
+                when (
+                    u.handle_lc ilike '%audius%'
+                    or lower(u.name) ilike '%audius%'
+                )
+                and u.is_verified = false then true
+                else false
+            end as is_audius_impersonator,
+            (u.profile_picture_sizes is not null) as has_profile_picture,
+            case
+                when (
+                    -- give max karma to users with more than 1000 followers
+                    -- karma is too slow for users with many followers
+                    au.follower_count > 1000
+                ) then 100
+                when (
+                    au.follower_count = 0
+                ) then 0
+                else (
+                    select LEAST(
+                            (sum(fau.follower_count) / 100)::bigint,
+                            100
+                        )
+                    from follows
+                        join aggregate_user fau on follows.follower_user_id = fau.user_id
+                    where follows.followee_user_id = target_user_id
+                        and fau.following_count < 10000 -- ignore users with too many following
+                        and follows.is_delete = false
+                )
+            end as karma
+        from users u
+            left join user_distinct_play_hours udph on u.user_id = udph.user_id
+            left join user_distinct_play_tracks udpt on u.user_id = udpt.user_id
+            left join user_score_features usf on u.user_id = usf.user_id
+            left join chat_blocks cb on u.user_id = cb.user_id
+            left join aggregate_user au on u.user_id = au.user_id
+        where u.user_id = target_user_id
+            and u.is_current
+            and u.handle_lc is not null
+    )
+select a.*,
+    compute_user_score(
+        a.play_count,
+        a.follower_count,
+        a.challenge_count,
+        a.chat_block_count,
+        a.following_count,
+        a.is_audius_impersonator,
+        a.has_profile_picture,
+        a.distinct_tracks_played,
+        a.karma
+    ) as score
+from aggregate_scores a;
+$$;
+
+
+ALTER FUNCTION public.get_user_score(target_user_id integer) OWNER TO postgres;
+
+--
+-- Name: get_user_score_test(integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.get_user_score_test(target_user_id integer) RETURNS TABLE(user_id integer, handle_lc text, play_count bigint, distinct_tracks_played bigint, challenge_count bigint, following_count bigint, follower_count bigint, chat_block_count bigint, is_audius_impersonator boolean, has_badwords boolean, karma bigint, score bigint)
+    LANGUAGE sql
+    AS $$ with play_activity as (
+        select p.user_id,
+            count(distinct date_trunc('day', p.created_at)) as play_count,
+            count(distinct p.play_item_id) as distinct_tracks_played
+        from plays p
+        where p.user_id = target_user_id
+        group by p.user_id
+    ),
+    fast_challenge_completion as (
+        select u.user_id,
+            u.handle_lc,
+            u.created_at,
+            count(*) as challenge_count,
+            array_agg(uc.challenge_id) as challenge_ids
+        from users u
+            left join user_challenges uc on u.user_id = uc.user_id
+        where u.user_id = target_user_id
+            and uc.is_complete
+            and uc.completed_at - u.created_at <= interval '3 minutes'
+            and uc.challenge_id not in ('m', 'b')
+        group by u.user_id,
+            u.handle_lc,
+            u.created_at
+    ),
+    chat_blocks as (
+        select c.blockee_user_id as user_id,
+            count(*) as block_count
+        from chat_blocked_users c
+        where c.blockee_user_id = target_user_id
+        group by c.blockee_user_id
+    ),
+    aggregate_scores as (
+        select u.user_id,
+            u.handle_lc,
+            coalesce(p.play_count, 0) as play_count,
+            coalesce(p.distinct_tracks_played, 0) as distinct_tracks_played,
+            coalesce(c.challenge_count, 0) as challenge_count,
+            coalesce(au.following_count, 0) as following_count,
+            coalesce(au.follower_count, 0) as follower_count,
+            coalesce(cb.block_count, 0) as chat_block_count,
+            case
+                when (
+                    u.handle_lc ilike '%audius%'
+                    or lower(u.name) ilike '%audius%'
+                )
+                and u.is_verified = false then true
+                else false
+            end as is_audius_impersonator,
+            case
+                when (
+                    exists (
+                        select 1
+                        from unnest(array['airdrop']) as badword
+                        where u.handle_lc ilike '%' || badword || '%'
+                           or lower(u.name) like '%' || badword || '%'
+                    )
+                )
+                and u.is_verified = false then true
+                else false
+            end as has_badwords,
+            case
+                when (
+                    -- give max karma to users with more than 1000 followers
+                    -- karma is too slow for users with many followers
+                    au.follower_count > 1000
+                ) then 100
+                when (
+                    au.follower_count = 0
+                ) then 0
+                else (
+                    select LEAST(
+                            (sum(fau.follower_count) / 100)::bigint,
+                            100
+                        )
+                    from follows
+                        join aggregate_user fau on follows.follower_user_id = fau.user_id
+                    where follows.followee_user_id = target_user_id
+                        and fau.following_count < 10000 -- ignore users with too many following
+                        and follows.is_delete = false
+                )
+            end as karma
+        from users u
+            left join play_activity p on u.user_id = p.user_id
+            left join fast_challenge_completion c on u.user_id = c.user_id
+            left join chat_blocks cb on u.user_id = cb.user_id
+            left join aggregate_user au on u.user_id = au.user_id
+        where u.user_id = target_user_id
+            and u.handle_lc is not null
+    )
+select a.*,
+    compute_user_score(
+        a.play_count,
+        a.follower_count,
+        a.challenge_count,
+        a.chat_block_count,
+        a.following_count,
+        a.is_audius_impersonator,
+        a.has_badwords,
+        a.distinct_tracks_played,
+        a.karma
+    ) as score
+from aggregate_scores a;
+$$;
+
+
+ALTER FUNCTION public.get_user_score_test(target_user_id integer) OWNER TO postgres;
+
+--
+-- Name: get_user_scores(integer[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.get_user_scores(target_user_ids integer[] DEFAULT NULL::integer[]) RETURNS TABLE(user_id integer, handle_lc text, play_count bigint, distinct_tracks_played bigint, follower_count bigint, following_count bigint, challenge_count bigint, chat_block_count bigint, is_audius_impersonator boolean, has_profile_picture boolean, karma bigint, score bigint)
+    LANGUAGE sql
+    AS $$ with chat_blocks as (
+        select chat_blocked_users.blockee_user_id as user_id,
+            count(*) as block_count
+        from chat_blocked_users
+            join users on chat_blocked_users.blockee_user_id = users.user_id
+        where target_user_ids is null
+            or chat_blocked_users.blockee_user_id = any(target_user_ids)
+        group by chat_blocked_users.blockee_user_id
+    ),
+    aggregate_scores as (
+        select users.user_id,
+            users.handle_lc,
+            coalesce(user_distinct_play_hours.hours_with_play, 0)::bigint as play_count,
+            coalesce(user_distinct_play_tracks.track_count, 0)::bigint as distinct_tracks_played,
+            coalesce(aggregate_user.following_count, 0) as following_count,
+            coalesce(aggregate_user.follower_count, 0) as follower_count,
+            coalesce(user_score_features.challenge_count, 0)::bigint as challenge_count,
+            coalesce(chat_blocks.block_count, 0) as chat_block_count,
+            case
+                when (
+                    users.handle_lc ilike '%audius%'
+                    or lower(users.name) ilike '%audius%'
+                )
+                and users.is_verified = false then true
+                else false
+            end as is_audius_impersonator,
+            (users.profile_picture_sizes is not null) as has_profile_picture,
+            case
+                when (
+                    -- give max karma to users with more than 1000 followers
+                    -- karma is too slow for users with many followers
+                    aggregate_user.follower_count > 1000
+                ) then 100
+                when (
+                    aggregate_user.follower_count = 0
+                ) then 0
+                else (
+                    select LEAST(
+                            (sum(fau.follower_count) / 100)::bigint,
+                            100
+                        )
+                    from follows
+                        join aggregate_user fau on follows.follower_user_id = fau.user_id
+                    where follows.followee_user_id = users.user_id
+                        and fau.following_count < 10000 -- ignore users with too many following
+                        and follows.is_delete = false
+                )
+            end as karma
+        from users
+            left join user_distinct_play_hours on users.user_id = user_distinct_play_hours.user_id
+            left join user_distinct_play_tracks on users.user_id = user_distinct_play_tracks.user_id
+            left join user_score_features on users.user_id = user_score_features.user_id
+            left join chat_blocks on users.user_id = chat_blocks.user_id
+            left join aggregate_user on aggregate_user.user_id = users.user_id
+        where users.handle_lc is not null
+            and users.is_current
+            and (
+                target_user_ids is null
+                or users.user_id = any(target_user_ids)
+            )
+    )
+select a.*,
+    compute_user_score(
+        a.play_count,
+        a.follower_count,
+        a.challenge_count,
+        a.chat_block_count,
+        a.following_count,
+        a.is_audius_impersonator,
+        a.has_profile_picture,
+        a.distinct_tracks_played,
+        a.karma
+    ) as score
+from aggregate_scores a;
+$$;
+
+
+ALTER FUNCTION public.get_user_scores(target_user_ids integer[]) OWNER TO postgres;
+
+--
+-- Name: handle_artist_coins_change(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_artist_coins_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF (OLD.mint IS NULL AND NEW.mint IS NOT NULL) 
+        OR (OLD.mint IS NOT NULL AND NEW.mint IS NULL)
+        OR OLD.mint != NEW.mint
+    THEN
+        PERFORM pg_notify('artist_coins_mint_changed', JSON_BUILD_OBJECT('new', NEW.mint, 'old', OLD.mint)::TEXT);
+    END IF;
+
+    IF (OLD.damm_v2_pool IS NULL AND NEW.damm_v2_pool IS NOT NULL) 
+        OR (OLD.damm_v2_pool IS NOT NULL AND NEW.damm_v2_pool IS NULL)
+        OR OLD.damm_v2_pool != NEW.damm_v2_pool
+    THEN
+        PERFORM pg_notify('artist_coins_damm_v2_pool_changed', JSON_BUILD_OBJECT('new', NEW.damm_v2_pool, 'old', OLD.damm_v2_pool)::TEXT);
+    END IF;
+    
+    RETURN NEW;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+            RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.handle_artist_coins_change() OWNER TO postgres;
+
+--
+-- Name: handle_associated_wallets(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_associated_wallets() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_mint    varchar;
+    v_user_id int;
+    v_wallet  text;
+    v_chain   text;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_user_id := OLD.user_id;
+        v_wallet  := OLD.wallet;
+        v_chain   := OLD.chain;
+    ELSE
+        v_user_id := NEW.user_id;
+        v_wallet  := NEW.wallet;
+        v_chain   := NEW.chain;
+    END IF;
+
+    -- Only act on INSERT, DELETE, or an is_delete flip on UPDATE — a no-op
+    -- metadata UPDATE shouldn't recompute balances (preserves prior behavior).
+    IF TG_OP = 'UPDATE' AND (NEW.is_delete IS NOT DISTINCT FROM OLD.is_delete) THEN
+        RETURN NULL;
+    END IF;
+
+    -- wAUDIO / artist-coin (sol) balances: recompute every sol mint this wallet
+    -- holds. For a chain=eth wallet this loop simply finds nothing.
+    FOR v_mint IN
+        SELECT DISTINCT mint FROM sol_token_account_balances WHERE owner = v_wallet
+    LOOP
+        PERFORM update_sol_user_balance_mint(v_user_id, v_mint);
+    END LOOP;
+
+    -- AUDIO (ETH-side) balance: linking / unlinking a chain=eth wallet changes
+    -- the user's aggregated eth_user_balances total.
+    IF v_chain = 'eth' THEN
+        PERFORM update_eth_user_balance(v_user_id);
+    END IF;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.handle_associated_wallets() OWNER TO postgres;
+
+--
+-- Name: handle_challenge_disbursement(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_challenge_disbursement() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  reward_manager_tx reward_manager_txs%ROWTYPE;
+	existing_notification integer;
+	reward_code_exists boolean;
+begin
+
+  select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
+
+  if reward_manager_tx is not null then
+		-- check if reward_codes table has an entry where code equals new.challenge_id
+		select exists(select 1 from reward_codes where code = new.challenge_id) into reward_code_exists;
+
+		if not reward_code_exists then
+			select id into existing_notification
+			from notification
+			where
+			type = 'challenge_reward' and
+			user_ids @> ARRAY[new.user_id] and
+			timestamp >= (new.created_at - interval '1 hour')
+			limit 1;
+
+			if existing_notification is null then
+				-- create a notification for the challenge disbursement
+				insert into notification
+				(slot, user_ids, timestamp, type, group_id, specifier, data)
+				values
+				(
+					new.slot,
+					ARRAY [new.user_id],
+					new.created_at,
+					'challenge_reward',
+					'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+					new.user_id,
+					json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+				)
+				on conflict do nothing;
+			end if;
+		end if;
+  end if;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_challenge_disbursement() OWNER TO postgres;
+
+--
+-- Name: handle_chat_blast(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_chat_blast() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  PERFORM pg_notify('chat_blast_inserted', json_build_object('blast_id', new.blast_id)::text);
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_chat_blast() OWNER TO postgres;
+
+--
+-- Name: handle_chat_message(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_chat_message() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  PERFORM pg_notify('chat_message_inserted', json_build_object('message_id', new.message_id)::text);
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_chat_message() OWNER TO postgres;
+
+--
+-- Name: handle_chat_message_reaction_changed(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_chat_message_reaction_changed() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  message_id text;
+  user_id bigint;
+  reaction text;
+begin
+  -- Get the values from either NEW or OLD record
+  if tg_op = 'DELETE' then
+    message_id := old.message_id;
+    user_id := old.user_id;
+    reaction := null; -- Set reaction to null for deletions
+  else
+    message_id := new.message_id;
+    user_id := new.user_id;
+    reaction := new.reaction;
+  end if;
+
+  PERFORM pg_notify('chat_message_reaction_changed', json_build_object(
+    'message_id', message_id,
+    'user_id', user_id,
+    'reaction', reaction
+  )::text);
+  return coalesce(new, old);
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_chat_message_reaction_changed() OWNER TO postgres;
+
+--
+-- Name: handle_comment(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comment() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  if new.entity_type = 'Track' then
+    insert into aggregate_track (track_id) 
+    values (new.entity_id) 
+    on conflict do nothing;
+  end if;
+
+  -- update agg track
+  if new.entity_type = 'Track' then
+    update aggregate_track 
+    set comment_count = (
+      select count(*)
+      from comments c
+      where
+          c.is_delete is false
+          and c.is_visible is true
+          and c.entity_type = new.entity_type
+          and c.entity_id = new.entity_id
+    )
+    where track_id = new.entity_id;
+  end if;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comment() OWNER TO postgres;
+
+--
+-- Name: handle_comment_mention(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comment_mention() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  c_row            record;
+  entity_user_id   int;
+  data_entity_ref  int;
+  is_self_mention  boolean;
+  mention_muted    boolean;
+  owner_mute       boolean;
+  is_owner_mention boolean;
+begin
+  if new.is_delete then
+    return null;
+  end if;
+
+  -- Fetch the parent comment for entity context + author.
+  select user_id, entity_type, entity_id, blocknumber, created_at, is_delete, is_visible
+    into c_row
+    from comments
+   where comment_id = new.comment_id
+   limit 1;
+  if not found or c_row.is_delete or not c_row.is_visible then
+    return null;
+  end if;
+
+  -- Self-mention is a no-op.
+  if new.user_id = c_row.user_id then
+    return null;
+  end if;
+
+  -- Resolve entity owner — used for the "owner has notifications off"
+  -- gate when the mention IS the owner.
+  if c_row.entity_type = 'Track' then
+    select t.owner_id into entity_user_id
+      from tracks t
+     where t.track_id = c_row.entity_id
+       and t.is_current = true
+     limit 1;
+    data_entity_ref := c_row.entity_id;
+  elsif c_row.entity_type = 'Event' then
+    select e.user_id into entity_user_id
+      from events e
+     where e.event_id = c_row.entity_id
+       and e.is_deleted = false
+     limit 1;
+    data_entity_ref := c_row.entity_id;
+  elsif c_row.entity_type = 'FanClub' then
+    entity_user_id  := c_row.entity_id;
+    data_entity_ref := c_row.entity_id;
+  else
+    return null;
+  end if;
+
+  is_owner_mention := (entity_user_id is not null and new.user_id = entity_user_id);
+
+  -- Mentioned user has muted the commenter — skip.
+  select exists (
+    select 1 from muted_users mu
+     where mu.user_id       = new.user_id
+       and mu.muted_user_id = c_row.user_id
+       and mu.is_delete     = false
+  ) into mention_muted;
+  if mention_muted then
+    return null;
+  end if;
+
+  -- If the mention is the entity owner AND the owner muted notifications
+  -- on this entity, skip — matches apps' track_owner_mention_mute logic.
+  if is_owner_mention then
+    select exists (
+      select 1 from comment_notification_settings cns
+       where cns.user_id     = entity_user_id
+         and cns.entity_type = c_row.entity_type
+         and cns.entity_id   = data_entity_ref
+         and cns.is_muted    = true
+    ) or exists (
+      select 1 from muted_users mu
+       where mu.user_id       = entity_user_id
+         and mu.muted_user_id = c_row.user_id
+         and mu.is_delete     = false
+    ) into owner_mute;
+    if owner_mute then
+      return null;
+    end if;
+  end if;
+
+  insert into notification
+    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      c_row.blocknumber,
+      ARRAY[new.user_id],
+      c_row.created_at,
+      'comment_mention',
+      new.user_id::text,
+      'comment_mention:' || new.comment_id,
+      jsonb_build_object(
+        'type',            c_row.entity_type,
+        'entity_id',       data_entity_ref,
+        'entity_user_id',  entity_user_id,
+        'comment_user_id', c_row.user_id,
+        'comment_id',      new.comment_id
+      )
+    )
+  on conflict do nothing;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comment_mention() OWNER TO postgres;
+
+--
+-- Name: handle_comment_notification(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comment_notification() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  entity_user_id   int;
+  data_entity_ref  int;
+  group_id_str     text;
+  is_reply         boolean;
+  owner_mentioned  boolean;
+  owner_mute       boolean;
+begin
+  if new.is_delete or not new.is_visible then
+    return null;
+  end if;
+
+  -- Resolve recipient (entity_user_id) + data.entity_id by entity_type.
+  if new.entity_type = 'Track' then
+    select t.owner_id into entity_user_id
+      from tracks t
+     where t.track_id = new.entity_id
+       and t.is_current = true
+     limit 1;
+    data_entity_ref := new.entity_id;
+  elsif new.entity_type = 'Event' then
+    select e.user_id into entity_user_id
+      from events e
+     where e.event_id = new.entity_id
+       and e.is_deleted = false
+     limit 1;
+    data_entity_ref := new.entity_id;
+  elsif new.entity_type = 'FanClub' then
+    -- For FanClub, entity_id IS the artist's user_id.
+    entity_user_id  := new.entity_id;
+    data_entity_ref := new.entity_id;
+  else
+    return null;
+  end if;
+
+  if entity_user_id is null then
+    return null;
+  end if;
+
+  -- Skip self-comment.
+  if new.user_id = entity_user_id then
+    return null;
+  end if;
+
+  -- Skip replies (they emit comment_thread instead, to the parent
+  -- comment author). Deferred so comment_threads is visible.
+  select exists (
+    select 1 from comment_threads where comment_id = new.comment_id
+  ) into is_reply;
+  if is_reply then
+    return null;
+  end if;
+
+  -- Skip if owner is mentioned in this comment (they get comment_mention
+  -- instead, also more specific). Deferred so comment_mentions is visible.
+  select exists (
+    select 1 from comment_mentions
+     where comment_id = new.comment_id
+       and user_id    = entity_user_id
+       and is_delete  = false
+  ) into owner_mentioned;
+  if owner_mentioned then
+    return null;
+  end if;
+
+  -- Skip if owner muted notifications on this entity (CommentNotificationSetting
+  -- with is_muted=true) OR muted this commenter (MutedUser).
+  select exists (
+    select 1 from comment_notification_settings cns
+     where cns.user_id     = entity_user_id
+       and cns.entity_type = new.entity_type
+       and cns.entity_id   = data_entity_ref
+       and cns.is_muted    = true
+  ) or exists (
+    select 1 from muted_users mu
+     where mu.user_id       = entity_user_id
+       and mu.muted_user_id = new.user_id
+       and mu.is_delete     = false
+  ) into owner_mute;
+  if owner_mute then
+    return null;
+  end if;
+
+  group_id_str := 'comment:' || data_entity_ref || ':type:' || new.entity_type;
+
+  insert into notification
+    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.blocknumber,
+      ARRAY[entity_user_id],
+      new.created_at,
+      'comment',
+      new.comment_id::text,
+      group_id_str,
+      jsonb_build_object(
+        'type',            new.entity_type,
+        'entity_id',       data_entity_ref,
+        'comment_user_id', new.user_id,
+        'comment_id',      new.comment_id
+      )
+    )
+  on conflict do nothing;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comment_notification() OWNER TO postgres;
+
+--
+-- Name: handle_comment_reaction(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comment_reaction() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  c_row            record;
+  entity_user_id   int;
+  data_entity_ref  int;
+  comment_owner_mute boolean;
+  owner_mute_extra   boolean;
+begin
+  if new.is_delete then
+    return null;
+  end if;
+
+  -- The comment being reacted to. Use the stored entity_type from the
+  -- comments row (apps notes clients have sometimes shipped wrong values
+  -- in the reaction's metadata).
+  select user_id, entity_type, entity_id, is_delete, is_visible
+    into c_row
+    from comments
+   where comment_id = new.comment_id
+   limit 1;
+  if not found or c_row.is_delete or not c_row.is_visible then
+    return null;
+  end if;
+
+  -- Self-react is a no-op.
+  if new.user_id = c_row.user_id then
+    return null;
+  end if;
+
+  -- Resolve entity context for the notification payload.
+  if c_row.entity_type = 'Track' then
+    select t.owner_id into entity_user_id
+      from tracks t
+     where t.track_id = c_row.entity_id
+       and t.is_current = true
+     limit 1;
+    data_entity_ref := c_row.entity_id;
+  elsif c_row.entity_type = 'Event' then
+    select e.user_id into entity_user_id
+      from events e
+     where e.event_id = c_row.entity_id
+       and e.is_deleted = false
+     limit 1;
+    data_entity_ref := c_row.entity_id;
+  elsif c_row.entity_type = 'FanClub' then
+    entity_user_id  := c_row.entity_id;
+    data_entity_ref := c_row.entity_id;
+  else
+    entity_user_id  := null;
+    data_entity_ref := c_row.entity_id;
+  end if;
+
+  -- Comment author muted notifications on this comment OR this reacter.
+  select exists (
+    select 1 from comment_notification_settings cns
+     where cns.user_id     = c_row.user_id
+       and cns.entity_type = 'Comment'
+       and cns.entity_id   = new.comment_id
+       and cns.is_muted    = true
+  ) or exists (
+    select 1 from muted_users mu
+     where mu.user_id       = c_row.user_id
+       and mu.muted_user_id = new.user_id
+       and mu.is_delete     = false
+  ) into comment_owner_mute;
+  if comment_owner_mute then
+    return null;
+  end if;
+
+  -- Apps' track_owner_mention_mute: if commenter is the entity owner
+  -- AND owner has notifications off on the entity, drop the reaction
+  -- notification too (their muted state shouldn't be circumvented by
+  -- a reaction notification).
+  if entity_user_id is not null and c_row.user_id = entity_user_id then
+    select exists (
+      select 1 from comment_notification_settings cns
+       where cns.user_id     = entity_user_id
+         and cns.entity_type = c_row.entity_type
+         and cns.entity_id   = data_entity_ref
+         and cns.is_muted    = true
+    ) or exists (
+      select 1 from muted_users mu
+       where mu.user_id       = entity_user_id
+         and mu.muted_user_id = new.user_id
+         and mu.is_delete     = false
+    ) into owner_mute_extra;
+    if owner_mute_extra then
+      return null;
+    end if;
+  end if;
+
+  insert into notification
+    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.blocknumber,
+      ARRAY[c_row.user_id],
+      new.created_at,
+      'comment_reaction',
+      new.user_id::text,
+      'comment_reaction:' || new.comment_id,
+      jsonb_build_object(
+        'type',            c_row.entity_type,
+        'entity_id',       data_entity_ref,
+        'entity_user_id',  entity_user_id,
+        'comment_id',      new.comment_id,
+        'reacter_user_id', new.user_id
+      )
+    )
+  on conflict do nothing;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comment_reaction() OWNER TO postgres;
+
+--
+-- Name: handle_comment_remix_contest_update(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comment_remix_contest_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  event_host_id     int;
+  contest_track_id  int;
+  recipient_id      int;
+  group_id_str      text;
+  data_jsonb        jsonb;
+begin
+  -- Cheap pre-filters first.
+  if new.entity_type <> 'Event' or new.is_delete or not new.is_visible then
+    return null;
+  end if;
+
+  -- Bail if this comment is a reply (a comment_threads row was inserted
+  -- alongside or before commit). Replies do not produce
+  -- remix_contest_update — only the host's top-level posts do.
+  if exists (
+    select 1 from comment_threads where comment_id = new.comment_id
+  ) then
+    return null;
+  end if;
+
+  -- The event must exist, must be a remix_contest, and the commenter
+  -- must be the host. entity_id on events is the parent track id.
+  select e.user_id, e.entity_id
+    into event_host_id, contest_track_id
+    from events e
+   where e.event_id = new.entity_id
+     and e.event_type = 'remix_contest'
+     and e.is_deleted = false
+   limit 1;
+
+  if event_host_id is null or event_host_id <> new.user_id then
+    return null;
+  end if;
+
+  group_id_str := 'remix_contest_update:' || new.comment_id || ':event:' || new.entity_id;
+  data_jsonb   := jsonb_build_object(
+    'event_id',       new.entity_id,
+    'entity_id',      contest_track_id,
+    'entity_user_id', event_host_id,
+    'comment_id',     new.comment_id
+  );
+
+  -- Fan out to subscribers, excluding the host (they have their own
+  -- view of the post).
+  for recipient_id in
+    select s.subscriber_id
+      from subscriptions s
+     where s.entity_type = 'Event'
+       and s.user_id = new.entity_id
+       and s.is_current = true
+       and s.is_delete = false
+       and s.subscriber_id <> event_host_id
+  loop
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      (
+        new.blocknumber,
+        ARRAY[recipient_id],
+        new.created_at,
+        'remix_contest_update',
+        recipient_id::text,
+        group_id_str,
+        data_jsonb
+      )
+    on conflict do nothing;
+  end loop;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comment_remix_contest_update() OWNER TO postgres;
+
+--
+-- Name: handle_comment_thread(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comment_thread() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  reply_row       record;
+  parent_row      record;
+  entity_user_id  int;
+  data_entity_ref int;
+  parent_mute     boolean;
+begin
+  -- The reply.
+  select user_id, blocknumber, created_at, is_delete, is_visible
+    into reply_row
+    from comments
+   where comment_id = new.comment_id
+   limit 1;
+  if not found or reply_row.is_delete or not reply_row.is_visible then
+    return null;
+  end if;
+
+  -- The parent — used for both recipient and the entity context the
+  -- notification payload includes.
+  select user_id, entity_type, entity_id
+    into parent_row
+    from comments
+   where comment_id = new.parent_comment_id
+   limit 1;
+  if not found then
+    return null;
+  end if;
+
+  -- Self-reply is a no-op.
+  if reply_row.user_id = parent_row.user_id then
+    return null;
+  end if;
+
+  -- Resolve the entity owner for the notification payload (matches the
+  -- entity-type switch in apps' comment.py).
+  if parent_row.entity_type = 'Track' then
+    select t.owner_id into entity_user_id
+      from tracks t
+     where t.track_id = parent_row.entity_id
+       and t.is_current = true
+     limit 1;
+    data_entity_ref := parent_row.entity_id;
+  elsif parent_row.entity_type = 'Event' then
+    select e.user_id into entity_user_id
+      from events e
+     where e.event_id = parent_row.entity_id
+       and e.is_deleted = false
+     limit 1;
+    data_entity_ref := parent_row.entity_id;
+  elsif parent_row.entity_type = 'FanClub' then
+    entity_user_id  := parent_row.entity_id;
+    data_entity_ref := parent_row.entity_id;
+  else
+    -- Unknown entity_type — emit without owner context rather than skip.
+    entity_user_id  := null;
+    data_entity_ref := parent_row.entity_id;
+  end if;
+
+  -- Parent author muted this thread or this user.
+  select exists (
+    select 1 from comment_notification_settings cns
+     where cns.user_id     = parent_row.user_id
+       and cns.entity_type = 'Comment'
+       and cns.entity_id   = new.parent_comment_id
+       and cns.is_muted    = true
+  ) or exists (
+    select 1 from muted_users mu
+     where mu.user_id       = parent_row.user_id
+       and mu.muted_user_id = reply_row.user_id
+       and mu.is_delete     = false
+  ) into parent_mute;
+  if parent_mute then
+    return null;
+  end if;
+
+  insert into notification
+    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      reply_row.blocknumber,
+      ARRAY[parent_row.user_id],
+      reply_row.created_at,
+      'comment_thread',
+      new.comment_id::text,
+      'comment_thread:' || new.parent_comment_id,
+      jsonb_build_object(
+        'type',            parent_row.entity_type,
+        'entity_id',       data_entity_ref,
+        'entity_user_id',  entity_user_id,
+        'comment_user_id', reply_row.user_id,
+        'comment_id',      new.comment_id
+      )
+    )
+  on conflict do nothing;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comment_thread() OWNER TO postgres;
+
+--
+-- Name: handle_comms_rpc_log(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_comms_rpc_log() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  -- Send notification with the signature (primary key) of the new rpc_log record
+  PERFORM pg_notify('rpc_log_inserted', json_build_object('sig', new.sig)::text);
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_comms_rpc_log() OWNER TO postgres;
+
+--
+-- Name: handle_dbc_pool(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_dbc_pool() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    PERFORM pg_notify('dbc_pools_changed', JSON_BUILD_OBJECT('new', NEW.account)::TEXT);
+    RETURN NEW;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+            RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.handle_dbc_pool() OWNER TO postgres;
+
+--
+-- Name: handle_eth_wallet_balance_change(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_eth_wallet_balance_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_user_id int;
+BEGIN
+    -- Skip metadata-only updates (e.g. an updated_at touch with no balance
+    -- delta) so we don't churn eth_user_balances for no reason.
+    IF TG_OP = 'UPDATE' AND NEW.balance IS NOT DISTINCT FROM OLD.balance THEN
+        RETURN NULL;
+    END IF;
+
+    FOR v_user_id IN
+        SELECT user_id
+          FROM users
+         WHERE LOWER(wallet) = NEW.wallet
+           AND is_current = TRUE
+
+        UNION
+
+        SELECT user_id
+          FROM associated_wallets
+         WHERE LOWER(wallet) = NEW.wallet
+           AND chain = 'eth'
+           AND is_current = TRUE
+           AND is_delete = FALSE
+    LOOP
+        PERFORM update_eth_user_balance(v_user_id);
+    END LOOP;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.handle_eth_wallet_balance_change() OWNER TO postgres;
+
+--
+-- Name: handle_event(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_event() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  notified_user_id int;
+  owner_user_id int;
+  track_is_public boolean;
+begin
+  -- Only proceed if this is a remix contest event
+  if new.event_type = 'remix_contest' and new.is_deleted = false then
+    -- Get the owner of the track and check if it's public
+    select owner_id, not is_unlisted into owner_user_id, track_is_public 
+    from tracks 
+    where is_current and track_id = new.entity_id 
+    limit 1;
+
+    -- Only create notifications if the track is public
+    if track_is_public then
+      -- Followers of the host, track savers, and users who follow the contest (event subscribers)
+      for notified_user_id in
+        select distinct user_id
+        from (
+          -- Get followers
+          select f.follower_user_id as user_id
+          from follows f
+          where f.followee_user_id = new.user_id
+            and f.is_current = true
+            and f.is_delete = false
+          union
+          -- Get users who favorited the track
+          select s.user_id
+          from saves s
+          where s.save_item_id = new.entity_id
+            and s.save_type = 'track'
+            and s.is_current = true
+            and s.is_delete = false
+          union
+          select sub.subscriber_id as user_id
+          from subscriptions sub
+          where sub.entity_type = 'Event'
+            and sub.user_id = new.event_id
+            and sub.is_current = true
+            and sub.is_delete = false
+        ) as users_to_notify
+      loop
+        -- Create a notification for this user
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+          (
+            new.blocknumber,
+            ARRAY[notified_user_id],
+            new.created_at,
+            'fan_remix_contest_started',
+            notified_user_id,
+            'fan_remix_contest_started:' || new.entity_id || ':user:' || new.user_id,
+            json_build_object(
+              'entity_user_id', owner_user_id,
+              'entity_id', new.entity_id
+            )
+          )
+        on conflict do nothing;
+      end loop;
+    end if;
+  end if;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_event() OWNER TO postgres;
+
+--
+-- Name: handle_fan_club_text_post(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_fan_club_text_post() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  artist_user_id  int;
+  recipient_id    int;
+  group_id_str    text;
+  data_jsonb      jsonb;
+  is_reply        boolean;
+begin
+  if new.entity_type <> 'FanClub' or new.is_delete or not new.is_visible then
+    return null;
+  end if;
+
+  -- Artist = new.entity_id (the fan club's owner). Post author must be
+  -- the artist; fan comments don't fan out.
+  artist_user_id := new.entity_id;
+  if new.user_id <> artist_user_id then
+    return null;
+  end if;
+
+  -- Skip replies — only root-level posts fan out.
+  select exists (
+    select 1 from comment_threads where comment_id = new.comment_id
+  ) into is_reply;
+  if is_reply then
+    return null;
+  end if;
+
+  group_id_str := 'fan_club_text_post:' || new.comment_id
+                  || ':user:' || artist_user_id;
+  data_jsonb   := jsonb_build_object(
+    'entity_user_id', artist_user_id,
+    'comment_id',     new.comment_id
+  );
+
+  -- Fan out: followers ∪ coin holders, excluding the artist.
+  for recipient_id in
+    select u
+      from (
+        select follower_user_id as u
+          from follows
+         where followee_user_id = artist_user_id
+           and is_current = true
+           and is_delete  = false
+        union
+        select sub.user_id as u
+          from sol_user_balances sub
+          join artist_coins ac on ac.mint = sub.mint
+         where ac.user_id   = artist_user_id
+           and sub.balance > 0
+      ) recipients
+     where u <> artist_user_id
+  loop
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      (
+        new.blocknumber,
+        ARRAY[recipient_id],
+        new.created_at,
+        'fan_club_text_post',
+        recipient_id::text,
+        group_id_str,
+        data_jsonb
+      )
+    on conflict do nothing;
+  end loop;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_fan_club_text_post() OWNER TO postgres;
+
+--
+-- Name: handle_follow(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_follow() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_follower_count int;
+  milestone integer;
+  delta int;
+  is_shadowbanned boolean;
+begin
+  insert into aggregate_user (user_id) values (new.followee_user_id) on conflict do nothing;
+  insert into aggregate_user (user_id) values (new.follower_user_id) on conflict do nothing;
+
+  -- transition-aware delta (active = not is_delete); 0 on no-op re-delivery
+  delta := (case when new.is_delete then 0 else 1 end)
+         - (case when tg_op = 'UPDATE' and old.is_delete is false then 1 else 0 end);
+
+  update aggregate_user 
+  set following_count = following_count + delta 
+  where user_id = new.follower_user_id;
+
+  update aggregate_user 
+  set follower_count = follower_count + delta
+  where user_id = new.followee_user_id
+  returning follower_count into new_follower_count;
+
+  -- create a milestone if applicable
+  select new_follower_count into milestone where new_follower_count in (10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000);
+  select score < 0 into is_shadowbanned from aggregate_user where user_id = new.follower_user_id;
+  if milestone is not null and new.is_delete is false and is_shadowbanned = false then
+      insert into milestones 
+        (id, name, threshold, blocknumber, slot, timestamp)
+      values
+        (new.followee_user_id, 'FOLLOWER_COUNT', milestone, new.blocknumber, new.slot, new.created_at)
+      on conflict do nothing;
+      insert into notification
+        (user_ids, type, group_id, specifier, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [new.followee_user_id],
+          'milestone_follower_count',
+          'milestone:FOLLOWER_COUNT:id:' || new.followee_user_id || ':threshold:' || milestone,
+          new.followee_user_id,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', 'FOLLOWER_COUNT', 'user_id', new.followee_user_id, 'threshold', milestone)
+        )
+    on conflict do nothing;
+  end if;
+
+  begin
+    -- create a notification for the followee
+    if new.is_delete is false and is_shadowbanned = false then
+      insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      values
+      (
+        new.blocknumber,
+        ARRAY [new.followee_user_id],
+        new.created_at,
+        'follow',
+        new.follower_user_id,
+        'follow:' || new.followee_user_id,
+        json_build_object('followee_user_id', new.followee_user_id, 'follower_user_id', new.follower_user_id)
+      )
+      on conflict do nothing;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end; 
+$$;
+
+
+ALTER FUNCTION public.handle_follow() OWNER TO postgres;
+
+--
+-- Name: handle_on_user_challenge(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_on_user_challenge() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  cooldown_days integer;
+  existing_notification integer;
+  listen_streak_value integer;
+begin
+    if (new.is_complete = true) then
+        -- attempt to insert a new notification, ignoring conflicts
+        select challenges.cooldown_days into cooldown_days from challenges where id = new.challenge_id;
+
+        if (cooldown_days is null or cooldown_days = 0) then
+            -- Check if there is an existing notification with the same fields in the last 15 minutes
+
+            if new.challenge_id not in ('tt', 'tp', 'tut', 'dvl') then
+                insert into notification
+                (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
+                values
+                (
+                    new.completed_blocknumber,
+                    ARRAY [new.user_id],
+                    new.completed_at,
+                    'claimable_reward',
+                    'claimable_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                    new.specifier,
+                    json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+                )
+                on conflict do nothing;
+            end if;
+
+            if new.challenge_id = 'e' then
+                select listen_streak into listen_streak_value
+                from challenge_listen_streak
+                where user_id = new.user_id
+                limit 1;
+            end if;
+
+            insert into notification
+            (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
+            values
+            (
+                new.completed_blocknumber,
+                ARRAY [new.user_id],
+                new.completed_at,
+                'challenge_reward',
+                'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                new.user_id,
+                case
+                    when new.challenge_id = 'e' then
+                        json_build_object(
+                            'specifier', new.specifier,
+                            'challenge_id', new.challenge_id,
+                            'amount', new.amount::text || '00000000',
+                            'listen_streak', coalesce(listen_streak_value, 0)
+                        )
+                    else
+                        json_build_object(
+                            'specifier', new.specifier,
+                            'challenge_id', new.challenge_id,
+                            'amount', new.amount::text || '00000000'
+                        )
+                end
+            )
+            on conflict do nothing;
+        else
+            -- transactional notifications cover this
+            if (new.challenge_id != 'b' and new.challenge_id != 's') then
+                select id into existing_notification
+                from notification
+                where
+                type = 'reward_in_cooldown' and
+                user_ids @> ARRAY[new.user_id] and
+                timestamp >= (new.completed_at - interval '1 hour')
+                limit 1;
+
+                if existing_notification is null then
+                    insert into notification
+                    (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
+                    values
+                    (
+                        new.completed_blocknumber,
+                        ARRAY [new.user_id],
+                        new.completed_at,
+                        'reward_in_cooldown',
+                        'reward_in_cooldown:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                        new.specifier,
+                        json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+                    )
+                    on conflict do nothing;
+                end if;
+            end if;
+        end if;
+
+        -- update user fast challenge count
+        INSERT INTO user_score_features (user_id, challenge_count, updated_at)
+        SELECT
+            NEW.user_id,
+            COUNT(*)::int AS challenge_count,
+            now()
+        FROM user_challenges uc
+        JOIN users u
+        ON u.user_id = uc.user_id
+        WHERE uc.user_id = NEW.user_id
+            AND uc.is_complete
+            AND uc.challenge_id NOT IN ('m','b')
+            AND uc.completed_at <= (u.created_at + interval '3 minutes')
+        ON CONFLICT (user_id) DO UPDATE
+            SET challenge_count = EXCLUDED.challenge_count,
+                updated_at      = EXCLUDED.updated_at
+        WHERE user_score_features.challenge_count IS DISTINCT FROM EXCLUDED.challenge_count;
+
+
+    end if;
+
+    return new;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_on_user_challenge() OWNER TO postgres;
+
+--
+-- Name: handle_play(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_play() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+    new_listen_count int;
+    milestone int;
+    owner_user_id int;
+begin
+
+    -- update aggregate_plays
+    insert into aggregate_plays (play_item_id, count) values (new.play_item_id, 0) on conflict do nothing;
+
+    update aggregate_plays
+        set count = count + 1
+        where play_item_id = new.play_item_id
+        returning count into new_listen_count;
+
+    -- update aggregate_monthly_plays
+    insert into aggregate_monthly_plays (play_item_id, timestamp, country, count)
+    values (new.play_item_id, date_trunc('month', new.created_at), coalesce(new.country, ''), 0)
+    on conflict do nothing;
+
+    update aggregate_monthly_plays
+        set count = count + 1
+        where play_item_id = new.play_item_id
+        and timestamp = date_trunc('month', new.created_at)
+        and country = coalesce(new.country, '');
+
+    select new_listen_count
+        into milestone
+        where new_listen_count in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
+
+    if milestone is not null then
+        insert into milestones
+            (id, name, threshold, slot, timestamp)
+        values
+            (new.play_item_id, 'LISTEN_COUNT', milestone, new.slot, new.created_at)
+        on conflict do nothing;
+        select tracks.owner_id into owner_user_id from tracks where is_current and track_id = new.play_item_id;
+        if owner_user_id is not null then
+            insert into notification
+                (user_ids, specifier, group_id, type, slot, timestamp, data)
+                values
+                (
+                    array[owner_user_id],
+                    owner_user_id,
+                    'milestone:LISTEN_COUNT:id:' || new.play_item_id || ':threshold:' || milestone,
+                    'milestone',
+                    new.slot,
+                    new.created_at,
+                    json_build_object('type', 'LISTEN_COUNT', 'track_id', new.play_item_id, 'threshold', milestone)
+                )
+            on conflict do nothing;
+        end if;
+    end if;
+
+    -- update listener's aggregates if applicable
+    if new.user_id is not null then
+        -- Insert or update user_distinct_play_hours
+        -- Only increment if the play's hour is newer than the user's last updated hour
+        insert into user_distinct_play_hours (user_id, hours_with_play, updated_at)
+        values (new.user_id, 1, date_trunc('hour', new.created_at))
+        on conflict (user_id) do update set
+            hours_with_play = case
+                when date_trunc('hour', new.created_at) > date_trunc('hour', user_distinct_play_hours.updated_at)
+                then user_distinct_play_hours.hours_with_play + 1
+                else user_distinct_play_hours.hours_with_play
+            end,
+            updated_at = case
+                when date_trunc('hour', new.created_at) > date_trunc('hour', user_distinct_play_hours.updated_at)
+                then new.created_at
+                else user_distinct_play_hours.updated_at
+            end;
+
+        -- update user_distinct_play_tracks
+        -- Only increment if this is the first time this user has played this track
+        insert into user_distinct_play_tracks (user_id, track_count, updated_at)
+        values (new.user_id, 1, new.created_at)
+        on conflict (user_id) do update set
+            track_count = case
+                when not exists (
+                    select 1 from plays p
+                    where p.user_id = new.user_id
+                    and p.play_item_id = new.play_item_id
+                    and p.id != new.id
+                )
+                then user_distinct_play_tracks.track_count + 1
+                else user_distinct_play_tracks.track_count
+            end,
+            updated_at = new.created_at;
+    end if;
+
+    return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_play() OWNER TO postgres;
+
+--
+-- Name: handle_playlist(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_playlist() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  track_owner_id int := 0;
+  track_item json;
+  subscriber_user_ids integer[];
+  old_row RECORD;
+  delta int := 0;
+begin
+
+  insert into aggregate_playlist (playlist_id, is_album) values (new.playlist_id, new.is_album) on conflict do nothing;
+
+  with expanded as (
+      select
+          jsonb_array_elements(prev_records->'playlists') as playlist
+      from
+          revert_blocks
+      where blocknumber = new.blocknumber
+  )
+  select
+      (playlist->>'is_private')::boolean as is_private,
+      (playlist->>'is_delete')::boolean as is_delete
+  into old_row
+  from
+      expanded
+  where
+      (playlist->>'playlist_id')::int = new.playlist_id
+  limit 1;
+
+  delta := 0;
+  if (new.is_delete = true and new.is_current = true) and (old_row.is_delete = false and old_row.is_private = false) then
+    delta := -1;
+  end if;
+
+  if (old_row is null and new.is_private = false) or (old_row.is_private = true and new.is_private = false) then
+    delta := 1;
+  end if;
+
+  if delta != 0 then
+    if new.is_album then
+      update aggregate_user
+      set album_count = album_count + delta
+      where user_id = new.playlist_owner_id;
+    else
+      update aggregate_user
+      set playlist_count = playlist_count + delta
+      where user_id = new.playlist_owner_id;
+    end if;
+  end if;
+  -- Create playlist notification
+  begin
+    if new.is_private = FALSE AND
+    new.is_delete = FALSE AND
+    (
+      new.created_at = new.updated_at OR
+      old_row.is_private = TRUE
+    )
+    then
+      select array(
+        select subscriber_id
+          from subscriptions
+          where is_current and
+          not is_delete and
+          user_id=new.playlist_owner_id
+      ) into subscriber_user_ids;
+      if array_length(subscriber_user_ids, 1)	> 0 then
+        insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          subscriber_user_ids,
+          new.updated_at,
+          'create',
+          new.playlist_owner_id,
+          'create:playlist_id:' || new.playlist_id,
+          json_build_object('playlist_id', new.playlist_id, 'is_album', new.is_album)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  begin
+    if new.is_delete IS FALSE and new.is_private IS FALSE then
+      for track_item IN select jsonb_array_elements from jsonb_array_elements(new.playlist_contents->'track_ids')
+      loop
+        -- Add notification for each track owner
+        if (track_item->>'time')::double precision::int >= extract(epoch from new.updated_at)::int then
+          select owner_id into track_owner_id from tracks where is_current and track_id=(track_item->>'track')::int;
+          if track_owner_id != new.playlist_owner_id then
+            insert into notification
+              (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+              (
+                new.blocknumber,
+                ARRAY [track_owner_id],
+                new.updated_at,
+                'track_added_to_playlist',
+                track_owner_id,
+                'track_added_to_playlist:playlist_id:' || new.playlist_id || ':track_id:' || (track_item->>'track')::int,
+                json_build_object('track_id', (track_item->>'track')::int, 'playlist_id', new.playlist_id, 'playlist_owner_id', new.playlist_owner_id)
+              )
+            on conflict do nothing;
+          end if;
+        end if;
+      end loop;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_playlist() OWNER TO postgres;
+
+--
+-- Name: handle_playlist_track(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_playlist_track() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  playlist_record RECORD;
+begin
+  select * into playlist_record from playlists where playlist_id = new.playlist_id limit 1;
+
+  -- Add notification for each purchaser
+  if playlist_record.is_stream_gated = true and jsonb_exists(playlist_record.stream_conditions, 'usdc_purchase') then
+    with album_purchasers as (
+      select distinct buyer_user_id
+        from usdc_purchases
+        where content_id = new.playlist_id
+        and content_type = 'album'
+    )
+      insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        select
+          playlist_record.blocknumber,
+          array [album_purchaser.buyer_user_id],
+          new.updated_at,
+          'track_added_to_purchased_album',
+          album_purchaser.buyer_user_id,
+          'track_added_to_purchased_album:playlist_id:' || new.playlist_id || ':track_id:' || new.track_id,
+          json_build_object('track_id', new.track_id, 'playlist_id', new.playlist_id, 'playlist_owner_id', playlist_record.playlist_owner_id)
+        from album_purchasers as album_purchaser;
+  end if;
+  
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_playlist_track() OWNER TO postgres;
+
+--
+-- Name: handle_reaction(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_reaction() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  tip_row notification%ROWTYPE;
+  tip_sender_user_id int;
+  tip_receiver_user_id int;
+  tip_amount bigint;
+begin
+
+  raise NOTICE 'start';
+  
+  if new.reaction_type = 'tip' then
+
+    raise NOTICE 'is tip';
+
+    SELECT amount, sender_user_id, receiver_user_id 
+    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id 
+    FROM user_tips ut 
+    WHERE ut.signature = new.reacted_to;
+    
+    raise NOTICE 'did select % %', tip_sender_user_id, tip_receiver_user_id;
+    raise NOTICE 'did select %', new.reacted_to;
+
+    IF tip_sender_user_id IS NOT NULL AND tip_receiver_user_id IS NOT NULL THEN
+      raise NOTICE 'have ids';
+
+      if new.reaction_value != 0 then
+        INSERT INTO notification
+          (user_ids, timestamp, type, specifier, group_id, data)
+        VALUES
+          (
+          ARRAY [tip_sender_user_id],
+          new.timestamp,
+          'reaction',
+          tip_receiver_user_id,
+          'reaction:' || 'reaction_to:' || new.reacted_to || ':reaction_type:' || new.reaction_type || ':reaction_value:' || new.reaction_value,
+          json_build_object(
+            'sender_wallet', new.sender_wallet,
+            'reaction_type', new.reaction_type,
+            'reacted_to', new.reacted_to,
+            'reaction_value', new.reaction_value,
+            'receiver_user_id', tip_receiver_user_id,
+            'sender_user_id', tip_sender_user_id,
+            'tip_amount', tip_amount::varchar(255)
+          )
+        )
+        on conflict do nothing;
+      end if;
+
+      -- find the notification for tip send - update the data to include reaction value
+      UPDATE notification
+      SET data = jsonb_set(data, '{reaction_value}', new.reaction_value::text::jsonb)
+      WHERE notification.group_id = 'tip_receive:user_id:' || tip_receiver_user_id || ':signature:' || new.reacted_to;
+    end if;
+  end if;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_reaction() OWNER TO postgres;
+
+--
+-- Name: handle_repost(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_repost() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_val int;
+  milestone_name text;
+  milestone integer;
+  owner_user_id int;
+  track_remix_of json;
+  is_remix_cosign boolean;
+  is_album boolean;
+  delta int;
+  entity_type text;
+  playlist_row record;
+  is_shadowbanned boolean;
+begin
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  if new.repost_type = 'track' then
+    insert into aggregate_track (track_id) values (new.repost_item_id) on conflict do nothing;
+
+    entity_type := 'track';
+  else
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.repost_item_id
+    and p.is_current
+    on conflict do nothing;
+
+    entity_type := 'playlist';
+
+    select ap.is_album into is_album
+    from aggregate_playlist ap
+    where ap.playlist_id = new.repost_item_id;
+  end if;
+
+  -- transition-aware delta (active = not is_delete); 0 on no-op re-delivery
+  delta := (case when new.is_delete then 0 else 1 end)
+         - (case when tg_op = 'UPDATE' and old.is_delete is false then 1 else 0 end);
+
+  -- update agg user
+  update aggregate_user
+  set repost_count = repost_count + delta
+  where user_id = new.user_id;
+
+  -- update agg track or playlist
+  if new.repost_type = 'track' then
+    milestone_name := 'TRACK_REPOST_COUNT';
+    update aggregate_track
+    set repost_count = repost_count + delta
+    where track_id = new.repost_item_id
+    returning repost_count into new_val;
+  	if new.is_delete IS FALSE then
+		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.repost_item_id;
+	  end if;
+  else
+    milestone_name := 'PLAYLIST_REPOST_COUNT';
+    update aggregate_playlist
+    set repost_count = repost_count + delta
+    where playlist_id = new.repost_item_id
+    returning repost_count into new_val;
+
+  	if new.is_delete IS FALSE then
+		  select playlist_owner_id into owner_user_id from playlists where is_current and playlist_id = new.repost_item_id;
+	  end if;
+  end if;
+
+  -- create a milestone if applicable
+  select new_val into milestone where new_val in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
+  select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
+
+  if new.is_delete = false and milestone is not null and owner_user_id is not null and is_shadowbanned = false then
+    insert into milestones 
+      (id, name, threshold, blocknumber, slot, timestamp)
+    values
+      (new.repost_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
+    on conflict do nothing;
+
+
+    if entity_type = 'track' then
+      insert into notification
+        (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [owner_user_id],
+          'milestone',
+          owner_user_id,
+          'milestone:' || milestone_name  || ':id:' || new.repost_item_id || ':threshold:' || milestone,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', milestone_name, 'track_id', new.repost_item_id, 'threshold', milestone)
+        )
+        on conflict do nothing;
+    else
+      insert into notification
+        (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [owner_user_id],
+          'milestone',
+          owner_user_id,
+          'milestone:' || milestone_name  || ':id:' || new.repost_item_id || ':threshold:' || milestone,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', milestone_name, 'playlist_id', new.repost_item_id, 'threshold', milestone, 'is_album', is_album)
+        )
+        on conflict do nothing;
+    end if;
+  end if;
+
+  begin
+    -- create a notification for the reposted content's owner
+    if new.is_delete is false and is_shadowbanned = false then
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      values
+      (
+        new.blocknumber,
+        ARRAY [owner_user_id],
+        new.created_at,
+        'repost',
+        new.user_id,
+        'repost:' || new.repost_item_id || ':type:'|| new.repost_type,
+        json_build_object('repost_item_id', new.repost_item_id, 'user_id', new.user_id, 'type', new.repost_type)
+      )
+      on conflict do nothing;
+    end if;
+
+	-- notify followees of the reposter who have reposted the same content
+	-- within the last month
+	if new.is_delete is false
+	and new.is_repost_of_repost is true
+  and is_shadowbanned = false then
+	with
+	    followee_repost_of_repost_ids as (
+	        select user_id
+	        from reposts r
+	        where
+	            r.repost_item_id = new.repost_item_id
+	            and new.created_at - INTERVAL '1 month' < r.created_at
+	            and new.created_at > r.created_at
+              and r.is_delete is false
+              and r.is_current is true
+	            and r.user_id in (
+	                select
+	                    followee_user_id
+	                from follows
+	                where
+	                    follower_user_id = new.user_id
+                      and is_delete is false
+                      and is_current is true
+	            )
+	    )
+	insert into notification
+		(blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+		SELECT blocknumber_val, user_ids_val, timestamp_val, type_val, specifier_val, group_id_val, data_val
+		FROM (
+			SELECT new.blocknumber AS blocknumber_val,
+			ARRAY(
+				SELECT user_id
+				FROM
+					followee_repost_of_repost_ids
+			) AS user_ids_val,
+			new.created_at AS timestamp_val,
+			'repost_of_repost' AS type_val,
+			new.user_id AS specifier_val,
+			'repost_of_repost:' || new.repost_item_id || ':type:' || new.repost_type AS group_id_val,
+			json_build_object(
+				'repost_of_repost_item_id',
+				new.repost_item_id,
+				'user_id',
+				new.user_id,
+				'type',
+        case 
+          when is_album then 'album'
+          else new.repost_type
+        end
+			) AS data_val
+		) sub
+		WHERE user_ids_val IS NOT NULL AND array_length(user_ids_val, 1) > 0
+		on conflict do nothing;
+	end if;
+
+    -- create a notification for remix cosign
+    if new.is_delete is false and new.repost_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
+      select
+        case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
+        from tracks
+        where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
+      if is_remix_cosign then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+          values
+          (
+            new.blocknumber,
+            ARRAY [owner_user_id],
+            new.created_at,
+            'cosign',
+            new.user_id,
+            'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.repost_item_id,
+            json_build_object('parent_track_id', (track_remix_of->'tracks'->0->>'parent_track_id')::int, 'track_id', new.repost_item_id, 'track_owner_id', owner_user_id)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_repost() OWNER TO postgres;
+
+--
+-- Name: handle_save(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_save() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_val int;
+  milestone_name text;
+  milestone integer;
+  owner_user_id int;
+  track_remix_of json;
+  is_remix_cosign boolean;
+  is_album boolean;
+  delta int;
+  entity_type text;
+  is_purchased boolean default false;
+  is_containing_album_purchased boolean default false;
+  is_shadowbanned boolean;
+begin
+
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  if new.save_type = 'track' then
+    insert into aggregate_track (track_id) values (new.save_item_id) on conflict do nothing;
+
+    entity_type := 'track';
+
+    -- check if the track has been purchased
+    select exists (
+        select 1
+        from usdc_purchases
+        where content_type = 'track'
+        and content_id = new.save_item_id
+        and buyer_user_id = new.user_id
+    ) into is_purchased;
+
+    -- check if the track is part of an album that has been purchased
+    select exists (
+      select 1
+      from
+        usdc_purchases
+        join playlist_tracks as pt
+        on content_id = pt.playlist_id
+      where track_id = new.save_item_id
+      and buyer_user_id = new.user_id
+    ) into is_containing_album_purchased;
+
+    is_purchased := is_purchased or is_containing_album_purchased;
+  else
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.save_item_id
+    and p.is_current
+    on conflict do nothing;
+    
+    select ap.is_album into is_album
+    from aggregate_playlist ap
+    where ap.playlist_id = new.save_item_id;
+
+    select exists (
+      select 1
+      from usdc_purchases
+      where content_type = 'album'
+      and content_id = new.save_item_id
+      and buyer_user_id = new.user_id
+    ) into is_purchased;
+  end if;
+
+  -- transition-aware delta (active = not is_delete); 0 on no-op re-delivery
+  delta := (case when new.is_delete then 0 else 1 end)
+         - (case when tg_op = 'UPDATE' and old.is_delete is false then 1 else 0 end);
+
+  -- update agg track or playlist
+  if new.save_type = 'track' then
+    milestone_name := 'TRACK_SAVE_COUNT';
+
+    update aggregate_track
+    set save_count = save_count + delta
+    where track_id = new.save_item_id
+    returning save_count into new_val;
+
+    -- update agg user
+    update aggregate_user
+    set track_save_count = track_save_count + delta
+    where user_id = new.user_id;
+
+  	if new.is_delete IS FALSE then
+		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.save_item_id;
+	  end if;
+  else
+    milestone_name := 'PLAYLIST_SAVE_COUNT';
+
+    update aggregate_playlist
+    set save_count = save_count + delta
+    where playlist_id = new.save_item_id
+    returning save_count into new_val;
+
+    if new.is_delete IS FALSE then
+		  select playlists.playlist_owner_id into owner_user_id from playlists where is_current and playlist_id = new.save_item_id;
+	  end if;
+
+  end if;
+
+  -- create a milestone if applicable
+  select new_val into milestone where new_val in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
+  select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
+
+  if new.is_delete = false and milestone is not null and is_shadowbanned = false then
+    insert into milestones 
+      (id, name, threshold, blocknumber, slot, timestamp)
+    values
+      (new.save_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
+    on conflict do nothing;
+
+    if entity_type = 'track' then
+      insert into notification
+      (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+      values
+      (
+        ARRAY [owner_user_id],
+        'milestone',
+        owner_user_id,
+        'milestone:' || milestone_name  || ':id:' || new.save_item_id || ':threshold:' || milestone,
+        new.blocknumber,
+        new.created_at,
+        json_build_object('type', milestone_name, 'track_id', new.save_item_id, 'threshold', milestone)
+      )
+      on conflict do nothing;
+    else
+      insert into notification
+        (user_ids, type, specifier, group_id, blocknumber, timestamp, data)
+        values
+        (
+          ARRAY [owner_user_id],
+          'milestone',
+          owner_user_id,
+          'milestone:' || milestone_name  || ':id:' || new.save_item_id || ':threshold:' || milestone,
+          new.blocknumber,
+          new.created_at,
+          json_build_object('type', milestone_name, 'playlist_id', new.save_item_id, 'threshold', milestone, 'is_album', is_album)
+        )
+        on conflict do nothing;
+    end if;
+  end if;
+
+  begin
+    -- create a notification for the saved content's owner
+    -- skip notification for purchased content as the purchase triggers its own notification
+    if new.is_delete is false and is_purchased is false and is_shadowbanned = false then
+      insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        ( 
+          new.blocknumber,
+          ARRAY [owner_user_id], 
+          new.created_at, 
+          'save',
+          new.user_id,
+          'save:' || new.save_item_id || ':type:'|| new.save_type,
+          json_build_object('save_item_id', new.save_item_id, 'user_id', new.user_id, 'type', new.save_type)
+        )
+      on conflict do nothing;
+    end if;
+
+    -- notify followees of the favoriter who have reposted the same content
+    -- within the last month
+    if new.is_delete is false
+    and new.is_save_of_repost is true
+    -- skip notification for tracks contained within a purchased album
+    -- the favorite of the album itself will still trigger this notification
+    and is_shadowbanned = false
+    and is_containing_album_purchased is false then
+    with
+        followee_save_repost_ids as (
+            select user_id
+            from reposts r
+            where
+                r.repost_item_id = new.save_item_id
+                and new.created_at - INTERVAL '1 month' < r.created_at
+                and new.created_at > r.created_at
+                and r.is_delete is false
+                and r.is_current is true
+                and r.repost_type::text = new.save_type::text
+                and r.user_id in
+                (
+                    select
+                        followee_user_id
+                    from follows
+                    where
+                        follower_user_id = new.user_id
+                        and is_delete is false
+                        and is_current is true
+                )
+        )
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      SELECT blocknumber_val, user_ids_val, timestamp_val, type_val, specifier_val, group_id_val, data_val
+      FROM (
+        SELECT new.blocknumber AS blocknumber_val,
+        ARRAY(
+          SELECT user_id
+          FROM
+            followee_save_repost_ids
+        ) AS user_ids_val,
+        new.created_at AS timestamp_val,
+        'save_of_repost' AS type_val,
+        new.user_id AS specifier_val,
+        'save_of_repost:' || new.save_item_id || ':type:' || new.save_type AS group_id_val,
+        json_build_object(
+          'save_of_repost_item_id',
+          new.save_item_id,
+          'user_id',
+          new.user_id,
+          'type',
+          case 
+            when is_album then 'album'
+            else new.save_type
+          end
+        ) AS data_val
+      ) sub
+      WHERE user_ids_val IS NOT NULL AND array_length(user_ids_val, 1) > 0
+      on conflict do nothing;
+    end if;
+
+    -- create a notification for remix cosign
+    if new.is_delete is false and new.save_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
+      select
+        case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
+        from tracks 
+        where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
+      if is_remix_cosign then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+          values
+          ( 
+            new.blocknumber,
+            ARRAY [owner_user_id], 
+            new.created_at, 
+            'cosign',
+            new.user_id,
+            'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.save_item_id,
+            json_build_object('parent_track_id', (track_remix_of->'tracks'->0->>'parent_track_id')::int, 'track_id', new.save_item_id, 'track_owner_id', owner_user_id)
+          )
+        on conflict do nothing;
+      end if;
+    end if;
+  exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+  end;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      raise;
+
+end; 
+$$;
+
+
+ALTER FUNCTION public.handle_save() OWNER TO postgres;
+
+--
+-- Name: handle_share(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_share() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  -- Ensure aggregate_user exists for this user
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+
+  if new.share_type = 'track' then
+    -- Ensure aggregate_track exists for this track
+    insert into aggregate_track (track_id) values (new.share_item_id) on conflict do nothing;
+  else
+    -- Ensure aggregate_playlist exists for this playlist
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.share_item_id
+    and p.is_current
+    on conflict do nothing;
+  end if;
+
+  -- Update aggregate statistics for tracks
+  if new.share_type = 'track' then
+    update aggregate_track
+    set share_count = (
+      select count(*)
+      from shares s
+      where s.share_type = new.share_type
+        and s.share_item_id = new.share_item_id
+    )
+    where track_id = new.share_item_id;
+
+    -- Update user's track share count
+    update aggregate_user
+    set track_share_count = (
+      select count(*)
+      from shares s
+      where s.user_id = new.user_id
+        and s.share_type = new.share_type
+    )
+    where user_id = new.user_id;
+  else
+    -- Update aggregate statistics for playlists/albums
+    update aggregate_playlist
+    set share_count = (
+      select count(*)
+      from shares s
+      where s.share_type = new.share_type
+        and s.share_item_id = new.share_item_id
+    )
+    where playlist_id = new.share_item_id;
+  end if;
+
+  return null;
+
+exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_share() OWNER TO postgres;
+
+--
+-- Name: handle_sol_claimable_accounts(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_sol_claimable_accounts() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_user_id int;
+BEGIN
+    FOR v_user_id IN
+        SELECT user_id
+        FROM users
+        WHERE users.wallet = NEW.ethereum_address
+    LOOP
+        PERFORM update_sol_user_balance_mint(v_user_id, NEW.mint);
+    END LOOP;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.handle_sol_claimable_accounts() OWNER TO postgres;
+
+--
+-- Name: handle_sol_purchase(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_sol_purchase() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  resolved_seller_user_id integer;
+begin
+  if new.is_valid is not true then
+    return null;
+  end if;
+
+  if new.content_type = 'track' then
+    select owner_id into resolved_seller_user_id
+      from tracks
+     where track_id = new.content_id
+       and is_current = true
+     limit 1;
+  else
+    select playlist_owner_id into resolved_seller_user_id
+      from playlists
+     where playlist_id = new.content_id
+       and is_current = true
+     limit 1;
+  end if;
+
+  if resolved_seller_user_id is null then
+    return null;
+  end if;
+
+  insert into notification
+        (slot, user_ids, timestamp, type, specifier, group_id, data)
+      values
+        (
+          new.slot,
+          ARRAY [resolved_seller_user_id],
+          new.created_at,
+          'usdc_purchase_seller',
+          new.buyer_user_id,
+          'usdc_purchase_seller:' || 'seller_user_id:' || resolved_seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+          json_build_object(
+              'content_type',   new.content_type,
+              'buyer_user_id',  new.buyer_user_id,
+              'seller_user_id', resolved_seller_user_id,
+              'amount',         new.amount,
+              'extra_amount',   null,
+              'content_id',     new.content_id,
+              'vendor',         null
+          )
+        ),
+        (
+          new.slot,
+          ARRAY [new.buyer_user_id],
+          new.created_at,
+          'usdc_purchase_buyer',
+          new.buyer_user_id,
+          'usdc_purchase_buyer:' || 'seller_user_id:' || resolved_seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+          json_build_object(
+              'content_type',   new.content_type,
+              'buyer_user_id',  new.buyer_user_id,
+              'seller_user_id', resolved_seller_user_id,
+              'amount',         new.amount,
+              'extra_amount',   null,
+              'content_id',     new.content_id,
+              'vendor',         null
+          )
+        )
+      on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_sol_purchase() OWNER TO postgres;
+
+--
+-- Name: handle_sol_reward_disbursement(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_sol_reward_disbursement() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  resolved_user_id integer;
+  existing_notification integer;
+  reward_code_exists boolean;
+begin
+  select users.user_id
+    into resolved_user_id
+    from users
+   where users.wallet = new.recipient_eth_address
+     and users.is_current = true
+   limit 1;
+
+  if resolved_user_id is null then
+    return null;
+  end if;
+
+  select exists(select 1 from reward_codes where code = new.challenge_id) into reward_code_exists;
+
+  if not reward_code_exists then
+    select id into existing_notification
+      from notification
+     where type = 'challenge_reward'
+       and user_ids @> ARRAY[resolved_user_id]
+       and timestamp >= (new.created_at - interval '1 hour')
+     limit 1;
+
+    if existing_notification is null then
+      insert into notification
+        (slot, user_ids, timestamp, type, group_id, specifier, data)
+      values
+        (
+          new.slot,
+          ARRAY [resolved_user_id],
+          new.created_at,
+          'challenge_reward',
+          'challenge_reward:' || resolved_user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+          resolved_user_id,
+          json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+        )
+        on conflict do nothing;
+    end if;
+  end if;
+
+  perform pg_notify(
+    'challenge_disbursed',
+    json_build_object(
+      'user_id', resolved_user_id,
+      'challenge_id', new.challenge_id,
+      'specifier', new.specifier,
+      'amount', new.amount,
+      'signature', new.signature,
+      'slot', new.slot
+    )::text
+  );
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_sol_reward_disbursement() OWNER TO postgres;
+
+--
+-- Name: handle_sol_token_balance_change(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_sol_token_balance_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_user_id int;
+BEGIN
+    INSERT INTO sol_token_account_balances (account, mint, owner, balance, slot, updated_at)
+    VALUES (NEW.account, NEW.mint, NEW.owner, NEW.balance, NEW.slot, NOW())
+    ON CONFLICT (account)
+    DO UPDATE SET
+        balance = EXCLUDED.balance,
+        slot = EXCLUDED.slot,
+        updated_at = NOW()
+        WHERE sol_token_account_balances.slot < EXCLUDED.slot;
+    
+    FOR v_user_id IN
+        SELECT user_id
+        FROM associated_wallets
+        WHERE wallet = NEW.owner
+          AND chain = 'sol'
+        UNION ALL
+        SELECT user_id
+        FROM users
+        JOIN sol_claimable_accounts ON sol_claimable_accounts.ethereum_address = users.wallet
+        WHERE sol_claimable_accounts.account = NEW.account
+          AND sol_claimable_accounts.mint = NEW.mint
+    LOOP
+        PERFORM update_sol_user_balance_mint(v_user_id, NEW.mint);
+    END LOOP;
+
+    RETURN NULL;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'An error occurred in %: %', TG_NAME, SQLERRM;
+        RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.handle_sol_token_balance_change() OWNER TO postgres;
+
+--
+-- Name: handle_sol_usdc_withdrawal(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_sol_usdc_withdrawal() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    users_row users%ROWTYPE;
+    mint_addr varchar;
+    memo_type_str varchar;
+    notification_type varchar;
+    change_value bigint;
+    balance_value bigint;
+    block_ts timestamp;
+begin
+  -- Resolve sender's mint + user via sol_claimable_accounts. Skip rows
+  -- whose from_account isn't a tracked user_bank, and skip non-USDC mints
+  -- (AUDIO is not part of the legacy withdrawal-notification surface).
+  select sca.mint into mint_addr
+    from sol_claimable_accounts sca
+   where sca.account = new.from_account
+   limit 1;
+  select u.* into users_row
+    from users u
+    join sol_claimable_accounts sca on sca.ethereum_address = u.wallet
+   where sca.account = new.from_account
+     and u.is_current = true
+   limit 1;
+
+  if mint_addr is null or mint_addr not in (
+        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', -- prod/stage USDC
+        '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y'  -- dev USDC
+      ) then
+    return null;
+  end if;
+
+  -- Look up memo type. The legacy trigger only notified for `transfer` and
+  -- `withdrawal` — so we skip prepare_withdrawal / internal_transfer /
+  -- recover_withdrawal to preserve that behavior.
+  select memo_type into memo_type_str
+    from sol_transfer_memo_types
+   where signature = new.signature and instruction_index = new.instruction_index;
+
+  if memo_type_str is null then
+    notification_type := 'usdc_transfer';
+  elsif memo_type_str = 'withdrawal' then
+    notification_type := 'usdc_withdrawal';
+  else
+    return null;
+  end if;
+
+  -- Pull the per-account balance change (sign + post-balance). Indexer
+  -- writes this in common.ProcessBalanceChanges before claimable_tokens
+  -- handling, so it's guaranteed to be visible.
+  select change, balance, block_timestamp
+    into change_value, balance_value, block_ts
+    from sol_token_account_balance_changes
+   where signature = new.signature
+     and account = new.from_account
+   limit 1;
+
+  insert into notification
+    (slot, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.slot,
+      ARRAY[users_row.user_id],
+      coalesce(block_ts, now()),
+      notification_type,
+      users_row.user_id,
+      notification_type || ':' || users_row.user_id || ':' || 'signature:' || new.signature,
+      json_build_object(
+        'user_id', users_row.user_id,
+        'user_bank', new.from_account,
+        'signature', new.signature,
+        'change', change_value,
+        'balance', balance_value,
+        'receiver_account', new.to_account
+      )
+    )
+    on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_sol_usdc_withdrawal() OWNER TO postgres;
+
+--
+-- Name: handle_supporter_rank_up(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_supporter_rank_up() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  user_bank_tx user_bank_txs%ROWTYPE;
+  dethroned_user_id int;
+begin
+  select * into user_bank_tx from user_bank_txs where user_bank_txs.slot = new.slot limit 1;
+
+  if user_bank_tx is not null then
+    -- create a notification for the sender and receiver
+    insert into notification
+      (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
+    values
+      (
+      -- supporting_rank_up notifs are sent to the sender of the tip
+        new.slot,
+        ARRAY [new.sender_user_id],
+        user_bank_tx.created_at,
+        'supporting_rank_up',
+        new.sender_user_id,
+        'supporting_rank_up:' || new.rank || ':slot:' || new.slot,
+        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank),
+        'supporting_rank_up'
+      ),
+      (
+      -- supporter_rank_up notifs are sent to the receiver of the tip
+        new.slot,
+        ARRAY [new.receiver_user_id],
+        user_bank_tx.created_at,
+        'supporter_rank_up',
+        new.receiver_user_id,
+        'supporter_rank_up:' || new.rank || ':slot:' || new.slot,
+        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank),
+        'supporter_rank_up'
+      )
+    on conflict do nothing;
+
+    if new.rank = 1 then
+      select sender_user_id into dethroned_user_id from supporter_rank_ups where rank=1 and receiver_user_id=new.receiver_user_id and slot < new.slot order by slot desc limit 1;
+      if dethroned_user_id is not NULL then
+        -- create a notification for the sender and receiver
+        insert into notification
+          (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
+        values
+          (
+            new.slot,
+            ARRAY [dethroned_user_id],
+            user_bank_tx.created_at,
+            'supporter_dethroned',
+            new.sender_user_id,
+            'supporter_dethroned:receiver_user_id:' || new.receiver_user_id || ':slot:' || new.slot,
+            json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'dethroned_user_id', dethroned_user_id),
+            'supporter_dethroned'
+          ) on conflict do nothing;
+
+      end if;
+    end if;
+
+  end if;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_supporter_rank_up() OWNER TO postgres;
+
+--
+-- Name: handle_tastemaker(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_tastemaker() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $_$
+declare
+  track_hex     text;
+  track_id_int  bigint;
+  owner_id_int  int;
+  action_str    text;
+begin
+  -- WHEN clause on the trigger gates challenge_id='t', but defend in
+  -- depth here too in case the trigger is invoked another way.
+  if new.challenge_id <> 't' then
+    return null;
+  end if;
+
+  -- Parse trailing hex segment "<user_hex>:t:<track_hex>" → track_id.
+  track_hex := split_part(new.specifier, ':', 3);
+  if track_hex !~ '^[0-9a-f]+$' then
+    return null;
+  end if;
+  track_id_int := ('x' || lpad(track_hex, 16, '0'))::bit(64)::bigint;
+  if track_id_int <= 0 then
+    return null;
+  end if;
+
+  select t.owner_id
+    into owner_id_int
+    from tracks t
+   where t.track_id = track_id_int
+     and t.is_current = true
+   limit 1;
+  if owner_id_int is null then
+    return null;
+  end if;
+
+  -- Repost takes precedence over save when a user is in both lists for
+  -- the same track — matches apps' dedupe_notifications_by_group_id
+  -- where repost_notifications win over save_notifications.
+  if exists (
+    select 1
+      from reposts
+     where user_id = new.user_id
+       and repost_item_id = track_id_int
+       and repost_type = 'track'
+       and is_current = true
+       and is_delete = false
+  ) then
+    action_str := 'repost';
+  else
+    action_str := 'save';
+  end if;
+
+  insert into notification
+    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.completed_blocknumber,
+      ARRAY[new.user_id],
+      new.completed_at,
+      'tastemaker',
+      track_id_int::text,
+      'tastemaker_user_id:' || new.user_id || ':tastemaker_item_id:' || track_id_int,
+      jsonb_build_object(
+        'tastemaker_item_id',       track_id_int,
+        'tastemaker_item_type',     'track',
+        'tastemaker_item_owner_id', owner_id_int,
+        'action',                   action_str,
+        'tastemaker_user_id',       new.user_id
+      )
+    )
+  on conflict do nothing;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$_$;
+
+
+ALTER FUNCTION public.handle_tastemaker() OWNER TO postgres;
+
+--
+-- Name: handle_track(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_track() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  parent_track_owner_id int;
+  subscriber_user_ids int[];
+begin
+  insert into aggregate_track (track_id) values (new.track_id) on conflict do nothing;
+  insert into aggregate_user (user_id) values (new.owner_id) on conflict do nothing;
+
+  update aggregate_user
+  set (track_count, total_track_count) = (
+    select
+      count(*) filter (where t.is_unlisted = false),
+      count(*)
+    from tracks t
+    where t.is_current is true
+      and t.is_delete = false
+      and t.is_available = true
+      and t.stem_of is null
+      and t.access_authorities is null
+      and t.owner_id = new.owner_id
+  )
+  where user_id = new.owner_id
+  ;
+
+  -- If new track or newly unlisted track, create notification
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.is_playlist_upload = FALSE THEN
+      select array(
+        select subscriber_id
+          from subscriptions
+          where is_current and
+          not is_delete and
+          user_id=new.owner_id
+      ) into subscriber_user_ids;
+
+      if array_length(subscriber_user_ids, 1)	> 0 then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          subscriber_user_ids,
+          new.updated_at,
+          'create',
+          new.track_id,
+          'create:track:user_id:' || new.owner_id,
+          json_build_object('track_id', new.track_id)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  -- If new remix or newly unlisted remix, create notification
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.remix_of is not null THEN
+      select owner_id into parent_track_owner_id from tracks where is_current and track_id = (new.remix_of->'tracks'->0->>'parent_track_id')::int limit 1;
+      if parent_track_owner_id is not null then
+        insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          ARRAY [parent_track_owner_id],
+          new.updated_at,
+          'remix',
+          new.owner_id,
+          'remix:track:' || new.track_id || ':parent_track:' || (new.remix_of->'tracks'->0->>'parent_track_id')::int,
+          json_build_object('track_id', new.track_id, 'parent_track_id', (new.remix_of->'tracks'->0->>'parent_track_id')::int)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+    when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  -- If new remix is a submission to an active remix contest, milestones and follower alerts
+  begin
+    if track_should_notify(OLD, new, TG_OP) AND new.remix_of is not null THEN
+      declare
+        contest_event_id int;
+        contest_creator_id int;
+        submission_count int;
+        milestone int;
+        parent_track_id int := (new.remix_of->'tracks'->0->>'parent_track_id')::int;
+        contest_follower int;
+      begin
+        select e.event_id, e.user_id
+        into contest_event_id, contest_creator_id
+        from events e
+        where e.event_type = 'remix_contest'
+          and e.is_deleted = false
+          and (e.end_date is null or e.end_date > now())
+          and e.entity_id = parent_track_id
+        limit 1;
+
+        if contest_event_id is not null then
+          -- Count submissions for this contest (only those after contest start)
+          select count(*) into submission_count
+          from tracks t
+          join events e on e.event_type = 'remix_contest'
+            and e.is_deleted = false
+            and e.entity_id = parent_track_id
+            and e.event_id = contest_event_id
+          where t.is_current = true
+            and t.is_delete = false
+            and t.remix_of is not null
+            and (t.remix_of->'tracks'->0->>'parent_track_id')::int = parent_track_id
+            and t.created_at >= e.created_at;
+
+          -- For each milestone, insert notification if this is the Nth submission
+          FOREACH milestone IN ARRAY ARRAY[1, 10, 50] LOOP
+            IF submission_count = milestone THEN
+              insert into notification
+                (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+                (
+                  new.blocknumber,
+                  ARRAY [contest_creator_id],
+                  new.updated_at,
+                  'artist_remix_contest_submissions',
+                  milestone || ':' || contest_event_id,
+                  'artist_remix_contest_submissions:' || contest_event_id || ':' || milestone,
+                  json_build_object(
+                    'event_id', contest_event_id,
+                    'milestone', milestone,
+                    'entity_id', parent_track_id
+                  )
+                )
+              on conflict do nothing;
+            END IF;
+          END LOOP;
+
+          -- Notify everyone following the contest (and the host) of a new submission,
+          -- excluding the submitter. The host is included even if they are not a
+          -- subscriber so they get a per-submission alert in addition to the
+          -- existing milestone-based artist_remix_contest_submissions notification.
+          for contest_follower in
+            select user_id from (
+              select s.subscriber_id as user_id
+                from subscriptions s
+               where s.entity_type = 'Event'
+                 and s.user_id = contest_event_id
+                 and s.is_current = true
+                 and s.is_delete = false
+              union
+              select contest_creator_id as user_id
+            ) recipients
+            where user_id != new.owner_id
+          loop
+            insert into notification
+              (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+            values
+              (
+                new.blocknumber,
+                ARRAY [contest_follower],
+                new.updated_at,
+                'fan_remix_contest_submission',
+                contest_follower,
+                'fan_remix_contest_submission:' || contest_event_id || ':submission:' || new.track_id,
+                json_build_object(
+                  'event_id', contest_event_id,
+                  'entity_id', parent_track_id,
+                  'entity_user_id', contest_creator_id,
+                  'submission_track_id', new.track_id,
+                  'submitter_user_id', new.owner_id
+                )
+              )
+            on conflict do nothing;
+          end loop;
+        end if;
+      end;
+    end if;
+    exception
+      when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  -- If a track with an active remix contest transitions from unlisted to public,
+  -- create fan_remix_contest_started notifications for the contest creator's
+  -- followers, the track's savers, and contest followers.
+  begin
+    if TG_OP = 'UPDATE' and OLD.is_unlisted = true and new.is_unlisted = false then
+      insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+      select
+        new.blocknumber,
+        ARRAY[u.user_id],
+        new.updated_at,
+        'fan_remix_contest_started',
+        u.user_id,
+        'fan_remix_contest_started:' || new.track_id || ':user:' || e.user_id,
+        json_build_object(
+          'entity_user_id', new.owner_id,
+          'entity_id', new.track_id
+        )
+      from events e
+      join lateral (
+        select f.follower_user_id as user_id
+          from follows f
+         where f.followee_user_id = e.user_id
+           and f.is_current = true
+           and f.is_delete = false
+        union
+        select s.user_id
+          from saves s
+         where s.save_item_id = new.track_id
+           and s.save_type = 'track'
+           and s.is_current = true
+           and s.is_delete = false
+        union
+        select sub.subscriber_id as user_id
+          from subscriptions sub
+         where sub.entity_type = 'Event'
+           and sub.user_id = e.event_id
+           and sub.is_current = true
+           and sub.is_delete = false
+      ) u on true
+      where e.event_type = 'remix_contest'
+        and e.is_deleted = false
+        and (e.end_date is null or e.end_date > now())
+        and e.entity_id = new.track_id
+      on conflict do nothing;
+    end if;
+    exception
+      when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+  end;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_track() OWNER TO postgres;
+
+--
+-- Name: handle_trending(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_trending() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  rank_int        int;
+  week_date       date;
+  entity_id_str   text;
+  entity_id_int   bigint;
+  notif_type      text;
+  trend_type      text;
+  ts_epoch        bigint;
+  data_jsonb      jsonb;
+begin
+  if new.challenge_id not in ('tt', 'tut') then
+    return null;
+  end if;
+
+  case new.challenge_id
+    when 'tt'  then notif_type := 'trending';             trend_type := 'TRACKS';
+    when 'tut' then notif_type := 'trending_underground'; trend_type := 'UNDERGROUND_TRACKS';
+  end case;
+
+  -- Specifier: "<YYYY-MM-DD>:<rank>"
+  begin
+    week_date := split_part(new.specifier, ':', 1)::date;
+    rank_int  := split_part(new.specifier, ':', 2)::int;
+  exception when others then
+    return null;
+  end;
+
+  -- Recover entity id from the trending_results row the processor wrote
+  -- earlier in this transaction. PK is (rank, type, version, week); we
+  -- pin to NEW.user_id so we ignore any unrelated version rows.
+  select id
+    into entity_id_str
+    from trending_results
+   where rank    = rank_int
+     and type    = trend_type
+     and week    = week_date
+     and user_id = new.user_id
+   limit 1;
+  if entity_id_str is null then
+    return null;
+  end if;
+  begin
+    entity_id_int := entity_id_str::bigint;
+  exception when others then
+    return null;
+  end;
+
+  -- timestamp suffix matches apps: epoch seconds of the recompute. We
+  -- use completed_at which is set by UpsertUserChallenge to now() on
+  -- the first insert — close enough to the recompute moment.
+  ts_epoch := extract(epoch from new.completed_at)::bigint;
+
+  data_jsonb := jsonb_build_object(
+    'time_range', 'week',
+    'genre',      'all',
+    'rank',       rank_int,
+    'track_id',   entity_id_int
+  );
+
+  insert into notification
+    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.completed_blocknumber,
+      ARRAY[new.user_id],
+      new.completed_at,
+      notif_type,
+      entity_id_int::text,
+      notif_type
+        || ':time_range:week:genre:all:rank:' || rank_int
+        || ':track_id:' || entity_id_int
+        || ':timestamp:' || ts_epoch,
+      data_jsonb
+    )
+  on conflict do nothing;
+
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_trending() OWNER TO postgres;
+
+--
+-- Name: handle_usdc_purchase(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_usdc_purchase() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+
+  -- insert seller/artist notification
+  INSERT INTO notification
+          (slot, user_ids, timestamp, type, specifier, group_id, data)
+        VALUES
+          (
+            new.slot,
+            ARRAY [new.seller_user_id],
+            new.created_at,
+            'usdc_purchase_seller',
+            new.buyer_user_id,
+            'usdc_purchase_seller:' || 'seller_user_id:' || new.seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+            json_build_object(
+                'content_type', new.content_type,
+                'buyer_user_id', new.buyer_user_id,
+                'seller_user_id', new.seller_user_id,
+                'amount', new.amount,
+                'extra_amount', new.extra_amount,
+                'content_id', new.content_id,
+                'vendor', new.vendor
+              )
+          ),
+          (
+            new.slot,
+            ARRAY [new.buyer_user_id],
+            new.created_at,
+            'usdc_purchase_buyer',
+            new.buyer_user_id,
+            'usdc_purchase_buyer:' || 'seller_user_id:' || new.seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+            json_build_object(
+                'content_type', new.content_type,
+                'buyer_user_id', new.buyer_user_id,
+                'seller_user_id', new.seller_user_id,
+                'amount', new.amount,
+                'extra_amount', new.extra_amount,
+                'content_id', new.content_id,
+                'vendor', new.vendor
+            )
+          )
+        on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end; 
+$$;
+
+
+ALTER FUNCTION public.handle_usdc_purchase() OWNER TO postgres;
+
+--
+-- Name: handle_usdc_withdrawal(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_usdc_withdrawal() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    users_row users%ROWTYPE;
+    notification_type varchar;
+begin
+
+  if new.transaction_type in ('transfer', 'withdrawal') and new.method = 'send' then
+    notification_type := 'usdc_' || new.transaction_type;
+    -- Fetch the corresponding user based on the wallet
+    select into users_row users.*
+    from users
+    join usdc_user_bank_accounts
+      on users.wallet = usdc_user_bank_accounts.ethereum_address
+    where usdc_user_bank_accounts.bank_account = new.user_bank;
+
+    -- Insert the new notification
+    insert into notification
+      (slot, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      (
+        new.slot,
+        ARRAY [users_row.user_id],
+        new.created_at,
+        notification_type,
+        users_row.user_id,
+        notification_type || ':' || users_row.user_id || ':' || 'signature:' || new.signature,
+        json_build_object(
+          'user_id', users_row.user_id,
+          'user_bank', new.user_bank,
+          'signature', new.signature,
+          'change', new.change,
+          'balance', new.balance,
+          'receiver_account', new.tx_metadata
+        )
+      )
+      on conflict do nothing;
+  end if;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_usdc_withdrawal() OWNER TO postgres;
+
+--
+-- Name: handle_user(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_user() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+begin
+  insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_user() OWNER TO postgres;
+
+--
+-- Name: handle_user_balance_change(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_user_balance_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  new_val int;
+  new_tier text;
+  new_tier_value int;
+  previous_tier text;
+  previous_tier_value int;
+begin
+  SELECT label, val into new_tier, new_tier_value
+  FROM (
+    VALUES ('bronze', 10::bigint), ('silver', 100::bigint), ('gold', 1000::bigint), ('platinum', 10000::bigint)
+  ) as tier (label, val)
+  WHERE
+    substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18))::bigint >= tier.val
+  ORDER BY 
+    tier.val DESC
+  limit 1;
+
+  SELECT label, val into previous_tier, previous_tier_value
+  FROM (
+    VALUES ('bronze', 10::bigint), ('silver', 100::bigint), ('gold', 1000::bigint), ('platinum', 10000::bigint)
+  ) as tier (label, val)
+  WHERE
+    substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18))::bigint >= tier.val
+  ORDER BY 
+    tier.val DESC
+  limit 1;
+
+  -- create a notification if the tier changes
+  if new_tier_value > previous_tier_value or (new_tier_value is not NULL and previous_tier_value is NULL) then
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      ( 
+        new.blocknumber,
+        ARRAY [new.user_id], 
+        new.updated_at, 
+        'tier_change',
+        new.user_id,
+        'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
+        json_build_object(
+          'new_tier', new_tier,
+          'new_tier_value', new_tier_value,
+          'current_value', new.current_balance
+        )
+      )
+    on conflict do nothing;
+    return null;
+  end if;
+
+  return null;
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_user_balance_change() OWNER TO postgres;
+
+--
+-- Name: handle_user_tip(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.handle_user_tip() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+
+  -- create a notification for the sender and receiver
+  insert into notification
+    (slot, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    ( 
+      new.slot,
+      ARRAY [new.receiver_user_id], 
+      new.created_at, 
+      'tip_receive',
+      new.receiver_user_id,
+      'tip_receive:user_id:' || new.receiver_user_id || ':signature:' || new.signature,
+      json_build_object(
+        'sender_user_id', new.sender_user_id,
+        'receiver_user_id', new.receiver_user_id,
+        'amount', new.amount,
+        'tx_signature', new.signature
+      )
+    ),
+    ( 
+      new.slot,
+      ARRAY [new.sender_user_id], 
+      new.created_at, 
+      'tip_send',
+      new.sender_user_id,
+      'tip_send:user_id:' || new.sender_user_id || ':signature:' || new.signature,
+      json_build_object(
+        'sender_user_id', new.sender_user_id,
+        'receiver_user_id', new.receiver_user_id,
+        'amount', new.amount,
+        'tx_signature', new.signature
+      )
+    )
+    on conflict do nothing;
+
+return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+
+end;
+$$;
+
+
+ALTER FUNCTION public.handle_user_tip() OWNER TO postgres;
+
+--
+-- Name: hex32_to_int(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.hex32_to_int(hex text) RETURNS integer
+    LANGUAGE sql IMMUTABLE
+    AS $_$
+  SELECT
+    CASE
+      WHEN hex ~ '^[0-9A-Fa-f]+$' AND length(hex) <= 8 THEN
+        (
+          (get_byte(decode(lpad(hex, 8, '0'), 'hex'), 0)::int << 24) |
+          (get_byte(decode(lpad(hex, 8, '0'), 'hex'), 1)::int << 16) |
+          (get_byte(decode(lpad(hex, 8, '0'), 'hex'), 2)::int <<  8) |
+          (get_byte(decode(lpad(hex, 8, '0'), 'hex'), 3)::int)
+        )
+      ELSE NULL
+    END
+$_$;
+
+
+ALTER FUNCTION public.hex32_to_int(hex text) OWNER TO postgres;
+
+--
+-- Name: id_decode(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.id_decode(p_id text) RETURNS integer
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $$
+begin
+  return (hashids.decode(p_id, 'azowernasdfoia', 5))[1]::integer;
+end;
+$$;
+
+
+ALTER FUNCTION public.id_decode(p_id text) OWNER TO postgres;
+
+--
+-- Name: id_encode(integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.id_encode(p_id integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE COST 300
+    AS $$
+begin
+  return hashids.encode(p_id, 'azowernasdfoia', 5);
+end;
+$$;
+
+
+ALTER FUNCTION public.id_encode(p_id integer) OWNER TO postgres;
+
+--
+-- Name: is_country_eur(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.is_country_eur(country text) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN
+        country = 'Afghanistan' OR
+        country = 'Albania' OR
+        country = 'Algeria' OR
+        country = 'American Samoa' OR
+        country = 'Andorra' OR
+        country = 'Angola' OR
+        country = 'Antigua and Barbuda' OR
+        country = 'Arab Emirates' OR
+        country = 'Armenia' OR
+        country = 'Aruba' OR
+        country = 'Australia' OR
+        country = 'Austria' OR
+        country = 'Azerbaijan' OR
+        country = 'Bahamas' OR
+        country = 'Bahrain' OR
+        country = 'Bangladesh' OR
+        country = 'Barbados' OR
+        country = 'Belarus' OR
+        country = 'Belgium' OR
+        country = 'Belize' OR
+        country = 'Benin' OR
+        country = 'Bermuda' OR
+        country = 'Bhutan' OR
+        country = 'Bolivia' OR
+        country = 'Bosnia and Herzegovina' OR
+        country = 'Botswana' OR
+        country = 'Brunei' OR
+        country = 'Bulgaria' OR
+        country = 'Burkina Faso' OR
+        country = 'Burma' OR
+        country = 'Burundi' OR
+        country = 'Cambodia' OR
+        country = 'Cameroon' OR
+        country = 'Cape Verde' OR
+        country = 'Cayman Islands' OR
+        country = 'Central African Republic' OR
+        country = 'Chad' OR
+        country = 'Channel Islands' OR
+        country = 'Chile' OR
+        country = 'China' OR
+        country = 'Colombia' OR
+        country = 'Comoros' OR
+        country = 'Congo' OR
+        country = 'Costa Rica' OR
+        country = 'Cote d''Ivoire' OR
+        country = 'Côte d''Ivoire' OR
+        country = 'Croatia' OR
+        country = 'Cuba' OR
+        country = 'Curacao' OR
+        country = 'Cyprus' OR
+        country = 'Czech Republic' OR
+        country = 'Czechia' OR
+        country = 'Democratic People''s Republic of Korea' OR
+        country = 'Democratic Republic of the Congo' OR
+        country = 'Denmark' OR
+        country = 'Djibouti' OR
+        country = 'Dominica' OR
+        country = 'Dominican Republic' OR
+        country = 'East Timor' OR
+        country = 'Ecuador' OR
+        country = 'Egypt' OR
+        country = 'El Salvador' OR
+        country = 'Equatorial Guinea' OR
+        country = 'Eritrea' OR
+        country = 'Estonia' OR
+        country = 'Eswatini' OR
+        country = 'Ethiopia' OR
+        country = 'Faroe Islands' OR
+        country = 'Fiji' OR
+        country = 'Finland' OR
+        country = 'France' OR
+        country = 'French Polynesia' OR
+        country = 'Gabon' OR
+        country = 'Gambia' OR
+        country = 'Gambia' OR
+        country = 'Georgia' OR
+        country = 'Germany' OR
+        country = 'Ghana' OR
+        country = 'Gibraltar' OR
+        country = 'Greece' OR
+        country = 'Guernsey' OR
+        country = 'Guinea-Bissau' OR
+        country = 'Guinea' OR
+        country = 'Holy See' OR
+        country = 'Hong Kong' OR
+        country = 'Hungary' OR
+        country = 'Iceland' OR
+        country = 'India' OR
+        country = 'Indonesia' OR
+        country = 'Iran' OR
+        country = 'Iraq' OR
+        country = 'Ireland' OR
+        country = 'Israel' OR
+        country = 'Italy' OR
+        country = 'Ivory Coast' OR
+        country = 'Japan' OR
+        country = 'Jersey' OR
+        country = 'Jordan' OR
+        country = 'Kazakhstan' OR
+        country = 'Kenya' OR
+        country = 'Kiribati' OR
+        country = 'Kosovo' OR
+        country = 'Kuwait' OR
+        country = 'Kyrgyzstan' OR
+        country = 'Laos' OR
+        country = 'Latvia' OR
+        country = 'Lebanon' OR
+        country = 'Lesotho' OR
+        country = 'Liberia' OR
+        country = 'Libya' OR
+        country = 'Liechtenstein' OR
+        country = 'Lithuania' OR
+        country = 'Lituania' OR
+        country = 'Luxembourg' OR
+        country = 'Macau' OR
+        country = 'Macedonia' OR
+        country = 'Madagascar' OR
+        country = 'Malawi' OR
+        country = 'Malaysia' OR
+        country = 'Maldives' OR
+        country = 'Mali' OR
+        country = 'Malta' OR
+        country = 'Marshall Islands' OR
+        country = 'Mauritania' OR
+        country = 'Mauritius' OR
+        country = 'Micronesia' OR
+        country = 'Monaco' OR
+        country = 'Mongolia' OR
+        country = 'Montenegro' OR
+        country = 'Morocco' OR
+        country = 'Mozambique' OR
+        country = 'Myanmar' OR
+        country = 'Namibia' OR
+        country = 'Nauru' OR
+        country = 'Nepal' OR
+        country = 'Netherlands' OR
+        country = 'New Zealand' OR
+        country = 'Niger' OR
+        country = 'Nigeria' OR
+        country = 'Niue' OR
+        country = 'North Korea' OR
+        country = 'North Macedonia' OR
+        country = 'Norway' OR
+        country = 'Oman' OR
+        country = 'Pakistan' OR
+        country = 'Palau' OR
+        country = 'Palestine' OR
+        country = 'Palestinian Territory' OR
+        country = 'Papua New Guinea' OR
+        country = 'Paraguay' OR
+        country = 'Peru' OR
+        country = 'Philippines' OR
+        country = 'Poland' OR
+        country = 'Portugal' OR
+        country = 'Qatar' OR
+        country = 'Reunion' OR
+        country = 'Romania' OR
+        country = 'Rwanda' OR
+        country = 'Samoa' OR
+        country = 'San Marino' OR
+        country = 'Sao Tome and Principe' OR
+        country = 'Saudi Arabia' OR
+        country = 'Senegal' OR
+        country = 'Serbia' OR
+        country = 'Seychelles' OR
+        country = 'Sierra Leone' OR
+        country = 'Singapore' OR
+        country = 'Slovakia' OR
+        country = 'Slovenia' OR
+        country = 'Solomon Islands' OR
+        country = 'Somalia' OR
+        country = 'South Africa' OR
+        country = 'South Korea' OR
+        country = 'South Sudan' OR
+        country = 'Spain' OR
+        country = 'Sri Lanka' OR
+        country = 'Sudan' OR
+        country = 'Suriname' OR
+        country = 'Swaziland' OR
+        country = 'Sweden' OR
+        country = 'Switzerland' OR
+        country = 'Syria' OR
+        country = 'Taiwan' OR
+        country = 'Tajikistan' OR
+        country = 'Tanzania' OR
+        country = 'Thailand' OR
+        country = 'Timor Leste' OR
+        country = 'Togo' OR
+        country = 'Tonga' OR
+        country = 'Trinidad and Tobago' OR
+        country = 'Tunisia' OR
+        country = 'Turkey' OR
+        country = 'Turkmenistan' OR
+        country = 'Turks and Caicos Islands' OR
+        country = 'Tuvalu' OR
+        country = 'Uganda' OR
+        country = 'Ukraine' OR
+        country = 'United Arab Emirates' OR
+        country = 'United Kingdom' OR
+        country = 'Uruguay' OR
+        country = 'Uzbekistan' OR
+        country = 'Vanuatu' OR
+        country = 'Vatican City' OR
+        country = 'Venezuela' OR
+        country = 'Vietnam' OR
+        country = 'Virgin Islands' OR
+        country = 'Western Sahara' OR
+        country = 'Yemen' OR
+        country = 'Zambia' OR
+        country = 'Zimbabwe' OR
+
+        -- country codes
+        country = 'AD' OR
+        country = 'AE' OR
+        country = 'AF' OR
+        country = 'AG' OR
+        country = 'AL' OR
+        country = 'AM' OR
+        country = 'AO' OR
+        country = 'AS' OR
+        country = 'AT' OR
+        country = 'AU' OR
+        country = 'AW' OR
+        country = 'AZ' OR
+        country = 'BA' OR
+        country = 'BB' OR
+        country = 'BD' OR
+        country = 'BE' OR
+        country = 'BF' OR
+        country = 'BG' OR
+        country = 'BH' OR
+        country = 'BI' OR
+        country = 'BJ' OR
+        country = 'BM' OR
+        country = 'BN' OR
+        country = 'BO' OR
+        country = 'BS' OR
+        country = 'BT' OR
+        country = 'BW' OR
+        country = 'BY' OR
+        country = 'BZ' OR
+        country = 'CF' OR
+        country = 'CG' OR
+        country = 'CH' OR
+        country = 'CI' OR
+        country = 'CL' OR
+        country = 'CM' OR
+        country = 'CN' OR
+        country = 'CO' OR
+        country = 'CR' OR
+        country = 'CU' OR
+        country = 'CV' OR
+        country = 'CW' OR
+        country = 'CY' OR
+        country = 'CZ' OR
+        country = 'DE' OR
+        country = 'DJ' OR
+        country = 'DK' OR
+        country = 'DM' OR
+        country = 'DO' OR
+        country = 'DZ' OR
+        country = 'EC' OR
+        country = 'EE' OR
+        country = 'EG' OR
+        country = 'EH' OR
+        country = 'ER' OR
+        country = 'ES' OR
+        country = 'ET' OR
+        country = 'FI' OR
+        country = 'FJ' OR
+        country = 'FO' OR
+        country = 'FR' OR
+        country = 'GA' OR
+        country = 'GB' OR
+        country = 'GD' OR
+        country = 'GE' OR
+        country = 'GG' OR
+        country = 'GH' OR
+        country = 'GI' OR
+        country = 'GM' OR
+        country = 'GN' OR
+        country = 'GQ' OR
+        country = 'GR' OR
+        country = 'GT' OR
+        country = 'GU' OR
+        country = 'GW' OR
+        country = 'GY' OR
+        country = 'HK' OR
+        country = 'HN' OR
+        country = 'HR' OR
+        country = 'HT' OR
+        country = 'HU' OR
+        country = 'ID' OR
+        country = 'IE' OR
+        country = 'IL' OR
+        country = 'IM' OR
+        country = 'IN' OR
+        country = 'IQ' OR
+        country = 'IS' OR
+        country = 'IT' OR
+        country = 'JE' OR
+        country = 'JM' OR
+        country = 'JO' OR
+        country = 'JP' OR
+        country = 'KE' OR
+        country = 'KG' OR
+        country = 'KH' OR
+        country = 'KI' OR
+        country = 'KM' OR
+        country = 'KN' OR
+        country = 'KP' OR
+        country = 'KR' OR
+        country = 'KW' OR
+        country = 'KY' OR
+        country = 'KZ' OR
+        country = 'LA' OR
+        country = 'LB' OR
+        country = 'LC' OR
+        country = 'LI' OR
+        country = 'LK' OR
+        country = 'LR' OR
+        country = 'LS' OR
+        country = 'LT' OR
+        country = 'LU' OR
+        country = 'LV' OR
+        country = 'LY' OR
+        country = 'MA' OR
+        country = 'MC' OR
+        country = 'MD' OR
+        country = 'ME' OR
+        country = 'MG' OR
+        country = 'MH' OR
+        country = 'MK' OR
+        country = 'ML' OR
+        country = 'MM' OR
+        country = 'MN' OR
+        country = 'MO' OR
+        country = 'MR' OR
+        country = 'MS' OR
+        country = 'MT' OR
+        country = 'MU' OR
+        country = 'MV' OR
+        country = 'MW' OR
+        country = 'MY' OR
+        country = 'MZ' OR
+        country = 'NA' OR
+        country = 'NE' OR
+        country = 'NG' OR
+        country = 'NI' OR
+        country = 'NL' OR
+        country = 'NO' OR
+        country = 'NP' OR
+        country = 'NR' OR
+        country = 'NU' OR
+        country = 'NZ' OR
+        country = 'OM' OR
+        country = 'PA' OR
+        country = 'PE' OR
+        country = 'PF' OR
+        country = 'PG' OR
+        country = 'PH' OR
+        country = 'PK' OR
+        country = 'PL' OR
+        country = 'PM' OR
+        country = 'PN' OR
+        country = 'PR' OR
+        country = 'PS' OR
+        country = 'PT' OR
+        country = 'PW' OR
+        country = 'PY' OR
+        country = 'QA' OR
+        country = 'RE' OR
+        country = 'RO' OR
+        country = 'RS' OR
+        country = 'RW' OR
+        country = 'SA' OR
+        country = 'SB' OR
+        country = 'SC' OR
+        country = 'SD' OR
+        country = 'SE' OR
+        country = 'SG' OR
+        country = 'SI' OR
+        country = 'SK' OR
+        country = 'SL' OR
+        country = 'SM' OR
+        country = 'SN' OR
+        country = 'SO' OR
+        country = 'SR' OR
+        country = 'SS' OR
+        country = 'ST' OR
+        country = 'SV' OR
+        country = 'SX' OR
+        country = 'SY' OR
+        country = 'SZ' OR
+        country = 'TC' OR
+        country = 'TD' OR
+        country = 'TG' OR
+        country = 'TH' OR
+        country = 'TJ' OR
+        country = 'TK' OR
+        country = 'TL' OR
+        country = 'TM' OR
+        country = 'TN' OR
+        country = 'TO' OR
+        country = 'TR' OR
+        country = 'TT' OR
+        country = 'TV' OR
+        country = 'TW' OR
+        country = 'TZ' OR
+        country = 'UA' OR
+        country = 'UG' OR
+        country = 'UY' OR
+        country = 'UZ' OR
+        country = 'VA' OR
+        country = 'VC' OR
+        country = 'VE' OR
+        country = 'VG' OR
+        country = 'VI' OR
+        country = 'VN' OR
+        country = 'VU' OR
+        country = 'WS' OR
+        country = 'XK' OR
+        country = 'YE' OR
+        country = 'ZA' OR
+        country = 'ZM' OR
+        country = 'ZW'
+        ;
+END;
+$$;
+
+
+ALTER FUNCTION public.is_country_eur(country text) OWNER TO postgres;
+
+--
+-- Name: log_message(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.log_message(message_text text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE '% %', pg_backend_pid(), message_text;
+END;
+$$;
+
+
+ALTER FUNCTION public.log_message(message_text text) OWNER TO postgres;
+
+--
+-- Name: notify_new_block(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.notify_new_block() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  perform pg_notify('new_block', json_build_object(
+    'block_height', new.block_height,
+    'proposer_address', new.proposer_address
+  )::text);
+  return new;
+end;
+$$;
+
+
+ALTER FUNCTION public.notify_new_block() OWNER TO postgres;
+
+--
+-- Name: notify_new_plays(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.notify_new_plays() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  perform pg_notify('new_plays', json_build_object(
+    'user_id', new.user_id,
+    'track_id', new.track_id,
+    'city', new.city,
+    'region', new.region,
+    'country', new.country,
+    'block_height', new.block_height
+  )::text);
+  return new;
+end;
+$$;
+
+
+ALTER FUNCTION public.notify_new_plays() OWNER TO postgres;
+
+--
+-- Name: notify_pending_purchase_revalidation(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.notify_pending_purchase_revalidation() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_content_type text;
+  v_content_id int;
+  v_blocknumber int;
+begin
+  if tg_table_name = 'tracks' then
+    v_content_type := 'track';
+    v_content_id := new.track_id;
+  elsif tg_table_name = 'playlists' then
+    v_content_type := 'album';
+    v_content_id := new.playlist_id;
+  else
+    return null;
+  end if;
+
+  v_blocknumber := new.blocknumber;
+  if v_blocknumber is null then
+    return null;
+  end if;
+
+  -- Cheap EXISTS guard: tracks/playlists update churn dwarfs the pending
+  -- purchase set, so it's almost always a no-op. Uses sol_purchases_valid_idx
+  -- + sol_purchases_content_idx.
+  if exists (
+    select 1 from sol_purchases sp
+    where sp.content_id = v_content_id
+      and sp.content_type = v_content_type
+      and sp.is_valid is null
+      and sp.valid_after_blocknumber <= v_blocknumber
+  ) then
+    perform pg_notify(
+      'pending_purchase_revalidation',
+      v_content_type || ':' || v_content_id::text
+    );
+  end if;
+
+  return null;
+exception
+  when others then
+    -- Never let a notify failure break a tracks/playlists write. The sweep
+    -- will catch any pending rows that don't get notified.
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.notify_pending_purchase_revalidation() OWNER TO postgres;
+
+--
+-- Name: on_new_notification_row(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.on_new_notification_row() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  PERFORM pg_notify(TG_TABLE_NAME, json_build_object('notification_id', new.id)::text);
+  return null;
+end; 
+$$;
+
+
+ALTER FUNCTION public.on_new_notification_row() OWNER TO postgres;
+
+--
+-- Name: on_new_notification_seen_row(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.on_new_notification_seen_row() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id)::text);
+  return null;
+end; 
+$$;
+
+
+ALTER FUNCTION public.on_new_notification_seen_row() OWNER TO postgres;
+
+--
+-- Name: on_new_row(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.on_new_row() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  case TG_TABLE_NAME
+    when 'tracks' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('track_id', new.track_id, 'updated_at', new.updated_at, 'created_at', new.created_at, 'blocknumber', new.blocknumber)::text);
+    when 'users' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id, 'blocknumber', new.blocknumber)::text);
+      -- Dedicated verification-transition channel.
+      --
+      -- The Go ETL writes `users` in place (single is_current row per user; it
+      -- bumps blocknumber rather than appending a versioned row), so consumers
+      -- can no longer reconstruct the "previous" verification state from the
+      -- `users` table or from revert_blocks. But because the update is in place,
+      -- this AFTER trigger's OLD row holds the true pre-update state. Emit on a
+      -- separate channel only for the genuine false -> true transition (or a
+      -- brand-new row that arrives already verified) so downstream listeners
+      -- (e.g. the verified-notifications Slack bot) fire exactly once instead of
+      -- on every profile edit by an already-verified user.
+      if new.is_verified and (TG_OP = 'INSERT' or not coalesce(old.is_verified, false)) then
+        PERFORM pg_notify('user_verified', json_build_object('user_id', new.user_id, 'blocknumber', new.blocknumber)::text);
+      end if;
+    when 'playlists' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('playlist_id', new.playlist_id)::text);
+    else
+      PERFORM pg_notify(TG_TABLE_NAME, to_json(new)::text);
+  end case;
+  return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.on_new_row() OWNER TO postgres;
+
+--
+-- Name: price_from_sqrt_price(numeric, integer, integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.price_from_sqrt_price(sqrt_price numeric, base_decimals integer, quote_decimals integer DEFAULT 8) RETURNS numeric
+    LANGUAGE sql
+    AS $$
+    SELECT
+        -- See: https://github.com/MeteoraAg/dynamic-bonding-curve-sdk/blob/a5519bf920935a9438fa200e067fffc6c6e40e27/packages/dynamic-bonding-curve/src/helpers/common.ts#L198
+        ((sqrt_price * sqrt_price) * POWER(10, base_decimals - quote_decimals)) / POWER(2, 128) AS price
+$$;
+
+
+ALTER FUNCTION public.price_from_sqrt_price(sqrt_price numeric, base_decimals integer, quote_decimals integer) OWNER TO postgres;
+
+--
+-- Name: process_grant_change(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.process_grant_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+    matched_user_id integer;
+begin
+    -- fetch the user_id where wallet matches grantee_address
+    select user_id into matched_user_id from users where lower(wallet) = lower(NEW.grantee_address);
+    
+    if matched_user_id is not null then
+        -- if the grant is newly created (i.e. the grant is not deleted, is not approved yet, and was just created indicated by created timestamp = last updated timestamp) OR grant went from deleted (revoked) to not deleted and is not approved yet...
+        if (TG_OP = 'INSERT' and NEW.is_revoked = FALSE and NEW.is_approved is null and NEW.created_at = NEW.updated_at or
+            (TG_OP = 'UPDATE' and NEW.is_revoked = FALSE and OLD.is_revoked = TRUE and NEW.is_approved is null))
+        then
+            -- ... create a "request_manager" notification
+            insert into notification
+                    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+                  values
+                    (
+                      new.blocknumber,
+                      array [matched_user_id],
+                      new.updated_at,
+                      'request_manager',
+                      new.user_id,
+                      'request_manager:' || 'grantee_user_id:' || matched_user_id || ':grantee_address:' || new.grantee_address || ':user_id:' || new.user_id || ':updated_at:' || new.updated_at ||
+                      ':created_at:' || new.created_at,
+                      json_build_object(
+                          'grantee_user_id', matched_user_id,
+                          'grantee_address', new.grantee_address,
+                          'user_id', new.user_id
+                        )
+                    )
+                  on conflict do nothing;
+        -- otherwise, if the grant is approved and not deleted (revoked)...
+        elsif (TG_OP = 'INSERT' and NEW.is_approved = TRUE and NEW.is_revoked = FALSE) or
+            (TG_OP = 'UPDATE' and NEW.is_approved = TRUE and (OLD.is_approved != TRUE) and NEW.is_revoked = FALSE)
+        then
+            -- ... create a "approve_manager_request" notification
+            insert into notification
+                    (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+                  values
+                    (
+                      new.blocknumber,
+                      array [new.user_id],
+                      new.updated_at,
+                      'approve_manager_request',
+                      matched_user_id,
+                      'approve_manager_request:' || 'grantee_user_id:' || matched_user_id || ':grantee_address:' || new.grantee_address || ':user_id:' || new.user_id || ':created_at:' || new.created_at,
+                      json_build_object(
+                          'grantee_user_id', matched_user_id,
+                          'grantee_address', new.grantee_address,
+                          'user_id', new.user_id
+                        )
+                    )
+                  on conflict do nothing;
+        end if;
+    end if;
+    return null;
+exception
+  when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end; 
+$$;
+
+
+ALTER FUNCTION public.process_grant_change() OWNER TO postgres;
+
+--
+-- Name: process_track_collaborator_change(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.process_track_collaborator_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+    -- A newly created pending invite (created_at = updated_at distinguishes a
+    -- fresh insert from a reconciled re-write), or a row resurrected back to
+    -- pending: notify the invited collaborator.
+    if (TG_OP = 'INSERT' and NEW.status = 'pending' and NEW.created_at = NEW.updated_at) or
+       (TG_OP = 'UPDATE' and NEW.status = 'pending' and OLD.status is distinct from 'pending')
+    then
+        insert into notification
+                (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+                (
+                  new.blocknumber,
+                  array [new.collaborator_user_id],
+                  new.updated_at,
+                  'track_collaborator_invite',
+                  new.invited_by,
+                  'track_collaborator_invite:' || 'track_id:' || new.track_id ||
+                    ':collaborator_user_id:' || new.collaborator_user_id ||
+                    ':inviter_user_id:' || new.invited_by,
+                  json_build_object(
+                      'track_id', new.track_id,
+                      'collaborator_user_id', new.collaborator_user_id,
+                      'inviter_user_id', new.invited_by
+                    )
+                )
+              on conflict do nothing;
+    -- Invite accepted: notify the inviter (track owner).
+    elsif (TG_OP = 'UPDATE' and NEW.status = 'accepted' and OLD.status is distinct from 'accepted') or
+          (TG_OP = 'INSERT' and NEW.status = 'accepted')
+    then
+        insert into notification
+                (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+              values
+                (
+                  new.blocknumber,
+                  array [new.invited_by],
+                  new.updated_at,
+                  'track_collaborator_accept',
+                  new.collaborator_user_id,
+                  'track_collaborator_accept:' || 'track_id:' || new.track_id ||
+                    ':collaborator_user_id:' || new.collaborator_user_id ||
+                    ':inviter_user_id:' || new.invited_by,
+                  json_build_object(
+                      'track_id', new.track_id,
+                      'collaborator_user_id', new.collaborator_user_id,
+                      'inviter_user_id', new.invited_by
+                    )
+                )
+              on conflict do nothing;
+    end if;
+    return null;
+exception
+  when others then
+      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+      return null;
+end;
+$$;
+
+
+ALTER FUNCTION public.process_track_collaborator_change() OWNER TO postgres;
+
+--
+-- Name: recreate_trending_params(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.recreate_trending_params() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    create materialized view public.trending_params as
+    select
+    t.track_id,
+    t.release_date,
+    t.genre,
+    t.owner_id,
+    ap.play_count,
+    au.follower_count as owner_follower_count,
+    coalesce(aggregate_track.repost_count, 0) as repost_count,
+    coalesce(aggregate_track.save_count, 0) as save_count,
+    coalesce(repost_week.repost_count, (0) :: bigint) as repost_week_count,
+    coalesce(repost_month.repost_count, (0) :: bigint) as repost_month_count,
+    coalesce(repost_year.repost_count, (0) :: bigint) as repost_year_count,
+    coalesce(save_week.repost_count, (0) :: bigint) as save_week_count,
+    coalesce(save_month.repost_count, (0) :: bigint) as save_month_count,
+    coalesce(save_year.repost_count, (0) :: bigint) as save_year_count,
+    coalesce(karma.karma, (0) :: numeric) as karma
+    from
+    (
+        (
+            (
+                (
+                (
+                    (
+                        (
+                            (
+                            (
+                                (
+                                    public.tracks t
+                                    left join (
+                                        select
+                                        ap_1.count as play_count,
+                                        ap_1.play_item_id
+                                        from
+                                        public.aggregate_plays ap_1
+                                    ) ap on ((ap.play_item_id = t.track_id))
+                                )
+                                left join (
+                                    select
+                                        au_1.user_id,
+                                        au_1.follower_count
+                                    from
+                                        public.aggregate_user au_1
+                                ) au on ((au.user_id = t.owner_id))
+                            )
+                            left join (
+                                select
+                                    aggregate_track_1.track_id,
+                                    aggregate_track_1.repost_count,
+                                    aggregate_track_1.save_count
+                                from
+                                    public.aggregate_track aggregate_track_1
+                            ) aggregate_track on ((aggregate_track.track_id = t.track_id))
+                            )
+                            left join (
+                            select
+                                r.repost_item_id as track_id,
+                                count(r.repost_item_id) as repost_count
+                            from
+                                public.reposts r
+                            where
+                                (
+                                    (r.is_current is true)
+                                    and (r.repost_type = 'track' :: public.reposttype)
+                                    and (r.is_delete is false)
+                                    and (r.created_at > (now() - '1 year' :: interval))
+                                )
+                            group by
+                                r.repost_item_id
+                            ) repost_year on ((repost_year.track_id = t.track_id))
+                        )
+                        left join (
+                            select
+                            r.repost_item_id as track_id,
+                            count(r.repost_item_id) as repost_count
+                            from
+                            public.reposts r
+                            where
+                            (
+                                (r.is_current is true)
+                                and (r.repost_type = 'track' :: public.reposttype)
+                                and (r.is_delete is false)
+                                and (r.created_at > (now() - '1 mon' :: interval))
+                            )
+                            group by
+                            r.repost_item_id
+                        ) repost_month on ((repost_month.track_id = t.track_id))
+                    )
+                    left join (
+                        select
+                            r.repost_item_id as track_id,
+                            count(r.repost_item_id) as repost_count
+                        from
+                            public.reposts r
+                        where
+                            (
+                            (r.is_current is true)
+                            and (r.repost_type = 'track' :: public.reposttype)
+                            and (r.is_delete is false)
+                            and (r.created_at > (now() - '7 days' :: interval))
+                            )
+                        group by
+                            r.repost_item_id
+                    ) repost_week on ((repost_week.track_id = t.track_id))
+                )
+                left join (
+                    select
+                        r.save_item_id as track_id,
+                        count(r.save_item_id) as repost_count
+                    from
+                        public.saves r
+                    where
+                        (
+                            (r.is_current is true)
+                            and (r.save_type = 'track' :: public.savetype)
+                            and (r.is_delete is false)
+                            and (r.created_at > (now() - '1 year' :: interval))
+                        )
+                    group by
+                        r.save_item_id
+                ) save_year on ((save_year.track_id = t.track_id))
+                )
+                left join (
+                select
+                    r.save_item_id as track_id,
+                    count(r.save_item_id) as repost_count
+                from
+                    public.saves r
+                where
+                    (
+                        (r.is_current is true)
+                        and (r.save_type = 'track' :: public.savetype)
+                        and (r.is_delete is false)
+                        and (r.created_at > (now() - '1 mon' :: interval))
+                    )
+                group by
+                    r.save_item_id
+                ) save_month on ((save_month.track_id = t.track_id))
+            )
+            left join (
+                select
+                r.save_item_id as track_id,
+                count(r.save_item_id) as repost_count
+                from
+                public.saves r
+                where
+                (
+                    (r.is_current is true)
+                    and (r.save_type = 'track' :: public.savetype)
+                    and (r.is_delete is false)
+                    and (r.created_at > (now() - '7 days' :: interval))
+                )
+                group by
+                r.save_item_id
+            ) save_week on ((save_week.track_id = t.track_id))
+        )
+        left join (
+            select
+                save_and_reposts.item_id as track_id,
+                sum(au_1.follower_count) as karma
+            from
+                (
+                (
+                    select
+                        r_and_s.user_id,
+                        r_and_s.item_id
+                    from
+                        (
+                            (
+                            select
+                                reposts.user_id,
+                                reposts.repost_item_id as item_id
+                            from
+                                public.reposts
+                            where
+                                (
+                                    (reposts.is_delete is false)
+                                    and (reposts.is_current is true)
+                                    and (
+                                        reposts.repost_type = 'track' :: public.reposttype
+                                    )
+                                )
+                            union
+                            all
+                            select
+                                saves.user_id,
+                                saves.save_item_id as item_id
+                            from
+                                public.saves
+                            where
+                                (
+                                    (saves.is_delete is false)
+                                    and (saves.is_current is true)
+                                    and (saves.save_type = 'track' :: public.savetype)
+                                )
+                            ) r_and_s
+                            join public.users on ((r_and_s.user_id = users.user_id))
+                        )
+                    where
+                        (
+                            (
+                            (users.cover_photo is not null)
+                            or (users.cover_photo_sizes is not null)
+                            )
+                            and (
+                            (users.profile_picture is not null)
+                            or (users.profile_picture_sizes is not null)
+                            )
+                            and (users.bio is not null)
+                        )
+                ) save_and_reposts
+                join public.aggregate_user au_1 on ((save_and_reposts.user_id = au_1.user_id))
+                )
+            group by
+                save_and_reposts.item_id
+        ) karma on ((karma.track_id = t.track_id))
+    )
+    where
+    (
+        (t.is_current is true)
+        and (t.is_delete is false)
+        and (t.is_unlisted is false)
+        and (t.stem_of is null)
+    ) with no data;
+
+    create index trending_params_track_id_idx on public.trending_params using btree (track_id);
+END;
+$$;
+
+
+ALTER FUNCTION public.recreate_trending_params() OWNER TO postgres;
+
+--
+-- Name: refresh_all_user_scores(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.refresh_all_user_scores() RETURNS TABLE(acquired boolean, diff_rows bigint, updated_rows bigint)
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_lock_key bigint := hashtext('refresh_all_user_scores');
+  v_diff bigint := 0;
+  v_upd  bigint := 0;
+  v_got  boolean;
+begin
+  v_got := pg_try_advisory_lock(v_lock_key);
+  if not v_got then
+    acquired     := false;
+    diff_rows    := 0;
+    updated_rows := 0;
+    return next;
+    return;
+  end if;
+
+  begin
+    create temp table _scores_new (
+      user_id int primary key,
+      score   int
+    ) on commit drop;
+
+    insert into _scores_new (user_id, score)
+    select s.user_id, s.score
+    from get_user_scores() as s
+    join aggregate_user au using (user_id)
+    where au.score is distinct from s.score;
+
+    get diagnostics v_diff = row_count;
+    create index on _scores_new (user_id);
+
+    update aggregate_user au
+    set score = sn.score
+    from _scores_new sn
+    where au.user_id = sn.user_id;
+
+    get diagnostics v_upd = row_count;
+
+    acquired     := true;
+    diff_rows    := v_diff;
+    updated_rows := v_upd;
+    return next;
+
+  exception when others then
+    perform pg_advisory_unlock(v_lock_key);
+    raise;
+  end;
+
+  perform pg_advisory_unlock(v_lock_key);
+end
+$$;
+
+
+ALTER FUNCTION public.refresh_all_user_scores() OWNER TO postgres;
+
+--
+-- Name: refresh_user_scores_all(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.refresh_user_scores_all() RETURNS TABLE(acquired boolean, diff_rows bigint, updated_rows bigint)
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_lock_key bigint := hashtext('refresh_user_scores_all');
+  v_diff bigint := 0;
+  v_upd  bigint := 0;
+  v_got  boolean;
+begin
+  v_got := pg_try_advisory_lock(v_lock_key);
+  if not v_got then
+    acquired     := false;
+    diff_rows    := 0;
+    updated_rows := 0;
+    return next;
+    return;
+  end if;
+
+  begin
+    create temp table _scores_new (
+      user_id int primary key,
+      score   int
+    ) on commit drop;
+
+    insert into _scores_new (user_id, score)
+    select s.user_id, s.score
+    from get_user_scores() as s
+    join aggregate_user au using (user_id)
+    where au.score is distinct from s.score;
+
+    get diagnostics v_diff = row_count;
+    create index on _scores_new (user_id);
+
+    -- 1b) Fast targeted update
+    update aggregate_user au
+    set score = sn.score
+    from _scores_new sn
+    where au.user_id = sn.user_id;
+
+    get diagnostics v_upd = row_count;
+
+    -- 1c) Return stats
+    acquired     := true;
+    diff_rows    := v_diff;
+    updated_rows := v_upd;
+    return next;
+
+  exception when others then
+    perform pg_advisory_unlock(v_lock_key);
+    raise;
+  end;
+
+  perform pg_advisory_unlock(v_lock_key);
+end
+$$;
+
+
+ALTER FUNCTION public.refresh_user_scores_all() OWNER TO postgres;
+
+--
+-- Name: table_exists(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.table_exists(text) RETURNS boolean
+    LANGUAGE sql
+    AS $_$
+  SELECT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = $1)
+$_$;
+
+
+ALTER FUNCTION public.table_exists(text) OWNER TO postgres;
+
+--
+-- Name: table_has_column(text, text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.table_has_column(text, text) RETURNS boolean
+    LANGUAGE sql
+    AS $_$
+  SELECT EXISTS (SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND column_name = $2)
+$_$;
+
+
+ALTER FUNCTION public.table_has_column(text, text) OWNER TO postgres;
+
+--
+-- Name: table_has_constraint(text, text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.table_has_constraint(text, text) RETURNS boolean
+    LANGUAGE sql
+    AS $_$
+  SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = $1::regclass AND conname = $2)
+$_$;
+
+
+ALTER FUNCTION public.table_has_constraint(text, text) OWNER TO postgres;
+
+--
+-- Name: to_date_safe(character varying, character varying); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.to_date_safe(p_date character varying, p_format character varying) RETURNS date
+    LANGUAGE plpgsql
+    AS $$
+        DECLARE
+            ret_date DATE;
+        BEGIN
+            IF p_date = '' THEN
+                RETURN NULL;
+            END IF;
+            RETURN to_date( p_date, p_format );
+        EXCEPTION
+        WHEN others THEN
+            RETURN null;
+        END;
+        $$;
+
+
+ALTER FUNCTION public.to_date_safe(p_date character varying, p_format character varying) OWNER TO postgres;
+
+--
+-- Name: to_timestamp_safe(character varying, character varying); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.to_timestamp_safe(p_timestamp character varying, p_format character varying) RETURNS timestamp without time zone
+    LANGUAGE plpgsql
+    AS $$
+  DECLARE
+      ret_timestamp TIMESTAMP;
+  BEGIN
+      IF p_timestamp = '' THEN
+          RETURN NULL;
+      END IF;
+      RETURN to_timestamp( p_timestamp, p_format );
+  EXCEPTION
+  WHEN others THEN
+      RETURN null;
+  END;
+  $$;
+
+
+ALTER FUNCTION public.to_timestamp_safe(p_timestamp character varying, p_format character varying) OWNER TO postgres;
+
+--
+-- Name: track_is_public(record); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.track_is_public(track record) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+begin
+  return track.is_unlisted = false
+     and track.is_available = true
+     and track.is_delete = false
+     and track.stem_of is null
+     and track.access_authorities is null;
+end
+$$;
+
+
+ALTER FUNCTION public.track_is_public(track record) OWNER TO postgres;
+
+--
+-- Name: validate_territory_codes(text[]); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.validate_territory_codes(codes text[]) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $_$
+begin
+    -- null is valid
+    if codes is null then
+        return true;
+    end if;
+    
+    -- array must have at least one element
+    if array_length(codes, 1) is null then
+        return false;
+    end if;
+    
+    -- check each element to make sure it's a 2 letter ISO code
+    for i in 1..array_length(codes, 1) loop
+        if codes[i] !~ '^[A-Z]{2}$' then
+            return false;
+        end if;
+    end loop;
+    
+    return true;
+end;
+$_$;
+
+
+ALTER FUNCTION public.validate_territory_codes(codes text[]) OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: tracks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.tracks (
+    blockhash character varying,
+    track_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    owner_id integer NOT NULL,
+    title text,
+    cover_art character varying,
+    tags character varying,
+    genre character varying,
+    mood character varying,
+    credits_splits character varying,
+    create_date character varying,
+    file_type character varying,
+    metadata_multihash character varying,
+    blocknumber integer,
+    created_at timestamp without time zone NOT NULL,
+    description character varying,
+    isrc character varying,
+    iswc character varying,
+    license character varying,
+    updated_at timestamp without time zone NOT NULL,
+    cover_art_sizes character varying,
+    is_unlisted boolean DEFAULT false NOT NULL,
+    field_visibility jsonb,
+    route_id character varying,
+    stem_of jsonb,
+    remix_of jsonb,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer,
+    is_available boolean DEFAULT true NOT NULL,
+    stream_conditions jsonb,
+    track_cid character varying,
+    is_playlist_upload boolean DEFAULT false NOT NULL,
+    duration integer DEFAULT 0,
+    ai_attribution_user_id integer,
+    preview_cid character varying,
+    audio_upload_id character varying,
+    preview_start_seconds double precision,
+    release_date timestamp without time zone,
+    track_segments jsonb DEFAULT '[]'::jsonb NOT NULL,
+    is_scheduled_release boolean DEFAULT false NOT NULL,
+    is_downloadable boolean DEFAULT false NOT NULL,
+    download_conditions jsonb,
+    is_original_available boolean DEFAULT false NOT NULL,
+    orig_file_cid character varying,
+    orig_filename character varying,
+    playlists_containing_track integer[] DEFAULT '{}'::integer[] NOT NULL,
+    placement_hosts text,
+    ddex_app character varying,
+    ddex_release_ids jsonb,
+    artists jsonb,
+    resource_contributors jsonb,
+    indirect_resource_contributors jsonb,
+    rights_controller jsonb,
+    copyright_line jsonb,
+    producer_copyright_line jsonb,
+    parental_warning_type character varying,
+    playlists_previously_containing_track jsonb DEFAULT jsonb_build_object() NOT NULL,
+    allowed_api_keys text[],
+    bpm double precision,
+    musical_key character varying,
+    audio_analysis_error_count integer DEFAULT 0 NOT NULL,
+    is_custom_bpm boolean DEFAULT false,
+    is_custom_musical_key boolean DEFAULT false,
+    comments_disabled boolean DEFAULT false,
+    pinned_comment_id integer,
+    cover_original_song_title character varying,
+    cover_original_artist character varying,
+    is_owned_by_user boolean DEFAULT false NOT NULL,
+    is_stream_gated boolean DEFAULT false,
+    is_download_gated boolean DEFAULT false,
+    no_ai_use boolean DEFAULT false,
+    parental_warning public.parental_warning_type,
+    territory_codes text[],
+    access_authorities text[],
+    CONSTRAINT check_territory_codes CHECK (public.validate_territory_codes(territory_codes))
+);
+
+
+ALTER TABLE public.tracks OWNER TO postgres;
+
+--
+-- Name: COLUMN tracks.cover_original_song_title; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.tracks.cover_original_song_title IS 'Title of the original song if this track is a cover';
+
+
+--
+-- Name: COLUMN tracks.cover_original_artist; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.tracks.cover_original_artist IS 'Artist of the original song if this track is a cover';
+
+
+--
+-- Name: COLUMN tracks.is_owned_by_user; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.tracks.is_owned_by_user IS 'Indicates whether the track is owned by the user for publishing payouts';
+
+
+--
+-- Name: track_should_notify(public.tracks, record, character varying); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.track_should_notify(old_track public.tracks, new_track record, tg_op character varying) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+begin
+  if tg_op = 'UPDATE' and old_track.track_id is not null then
+    return not track_is_public(old_track) and track_is_public(new_track);
+  else
+    return tg_op = 'INSERT'
+      and track_is_public(new_track)
+    ;
+  end if;
+end
+$$;
+
+
+ALTER FUNCTION public.track_should_notify(old_track public.tracks, new_track record, tg_op character varying) OWNER TO postgres;
+
+--
+-- Name: update_eth_user_balance(integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.update_eth_user_balance(p_user_id integer) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO eth_user_balances (user_id, balance, updated_at, created_at)
+    SELECT
+        p_user_id,
+        COALESCE(SUM(ewb.balance), 0),
+        NOW(),
+        NOW()
+    FROM eth_wallet_balances ewb
+    WHERE ewb.wallet IN (
+        -- eth_wallet_balances PK is lowercase hex; users.wallet can be
+        -- mixed-case, associated_wallets are canonical lowercase (0207).
+        SELECT LOWER(wallet)
+          FROM users
+         WHERE user_id = p_user_id
+           AND is_current = TRUE
+           AND wallet IS NOT NULL
+
+        UNION ALL
+
+        SELECT LOWER(wallet)
+          FROM associated_wallets
+         WHERE user_id = p_user_id
+           AND chain = 'eth'
+           AND is_current = TRUE
+           AND is_delete = FALSE
+    )
+    ON CONFLICT (user_id)
+    DO UPDATE SET
+        balance = EXCLUDED.balance,
+        updated_at = NOW();
+END;
+$$;
+
+
+ALTER FUNCTION public.update_eth_user_balance(p_user_id integer) OWNER TO postgres;
+
+--
+-- Name: update_sol_user_balance_mint(integer, character varying); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.update_sol_user_balance_mint(p_user_id integer, p_mint character varying) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO sol_user_balances
+        (user_id, mint, balance, updated_at, created_at)
+    SELECT
+        p_user_id,
+        p_mint,
+        SUM(balance),
+        NOW(),
+        NOW()
+    FROM (
+        SELECT 
+            p_user_id AS user_id, 
+            COALESCE(balance, 0) AS balance
+        FROM associated_wallets 
+        JOIN sol_token_account_balances AS associated_wallet_balances
+            ON associated_wallet_balances.owner = associated_wallets.wallet
+            AND associated_wallet_balances.mint = p_mint
+        WHERE associated_wallets.user_id = p_user_id
+            AND associated_wallets.chain = 'sol'
+            AND associated_wallets.is_delete = FALSE
+
+        UNION ALL
+
+        SELECT 
+            p_user_id AS user_id, 
+            COALESCE(balance, 0) AS balance
+        FROM users
+        JOIN sol_claimable_accounts
+            ON sol_claimable_accounts.ethereum_address = users.wallet
+            AND sol_claimable_accounts.mint = p_mint
+        JOIN sol_token_account_balances
+            ON sol_token_account_balances.account = sol_claimable_accounts.account
+        WHERE users.user_id = p_user_id
+    ) AS balances
+    GROUP BY user_id
+    ON CONFLICT (user_id, mint)
+    DO UPDATE SET
+        balance = EXCLUDED.balance,
+        updated_at = NOW();
+END;
+$$;
+
+
+ALTER FUNCTION public.update_sol_user_balance_mint(p_user_id integer, p_mint character varying) OWNER TO postgres;
+
+--
+-- Name: user_mint_balance_at(integer, text, timestamp with time zone); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.user_mint_balance_at(p_user_id integer, p_mint text, p_cutoff timestamp with time zone) RETURNS bigint
+    LANGUAGE sql STABLE PARALLEL SAFE
+    AS $$
+WITH owners AS (
+  SELECT aw.wallet AS owner_address
+  FROM associated_wallets aw
+  WHERE aw.user_id = p_user_id
+    AND aw.chain = 'sol'
+    AND aw.is_delete = FALSE
+),
+accounts AS (
+  SELECT sca.account
+  FROM users u
+  JOIN sol_claimable_accounts sca
+    ON sca.ethereum_address = u.wallet
+  WHERE u.user_id = p_user_id
+),
+latest AS (
+  SELECT DISTINCT ON (s.mint, s.account) s.balance
+  FROM (
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.account IN (SELECT account FROM accounts)
+
+    UNION ALL
+
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.owner IN (SELECT owner_address FROM owners)
+  ) AS s
+  ORDER BY s.mint, s.account, s.block_timestamp DESC, s.slot DESC
+)
+SELECT COALESCE(SUM(balance), 0)::bigint
+FROM latest;
+$$;
+
+
+ALTER FUNCTION public.user_mint_balance_at(p_user_id integer, p_mint text, p_cutoff timestamp with time zone) OWNER TO postgres;
+
+--
+-- Name: audius_ts_dict; Type: TEXT SEARCH DICTIONARY; Schema: public; Owner: postgres
+--
+
+CREATE TEXT SEARCH DICTIONARY public.audius_ts_dict (
+    TEMPLATE = pg_catalog.simple );
+
+
+ALTER TEXT SEARCH DICTIONARY public.audius_ts_dict OWNER TO postgres;
+
+--
+-- Name: audius_ts_config; Type: TEXT SEARCH CONFIGURATION; Schema: public; Owner: postgres
+--
+
+CREATE TEXT SEARCH CONFIGURATION public.audius_ts_config (
+    PARSER = pg_catalog."default" );
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR asciiword WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR word WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR numword WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR email WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR url WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR host WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR sfloat WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR version WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword_numpart WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword_part WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword_asciipart WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR numhword WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR asciihword WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR hword WITH public.audius_ts_dict;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR url_path WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR file WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR "float" WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR "int" WITH simple;
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
+    ADD MAPPING FOR uint WITH simple;
+
+
+ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config OWNER TO postgres;
+
+--
+-- Name: access_keys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.access_keys (
+    id integer NOT NULL,
+    track_id text NOT NULL,
+    pub_key text NOT NULL
+);
+
+
+ALTER TABLE public.access_keys OWNER TO postgres;
+
+--
+-- Name: access_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.access_keys_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.access_keys_id_seq OWNER TO postgres;
+
+--
+-- Name: access_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.access_keys_id_seq OWNED BY public.access_keys.id;
+
+
+--
+-- Name: aggregate_daily_app_name_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_daily_app_name_metrics (
+    id integer NOT NULL,
+    application_name character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.aggregate_daily_app_name_metrics OWNER TO postgres;
+
+--
+-- Name: aggregate_daily_app_name_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.aggregate_daily_app_name_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.aggregate_daily_app_name_metrics_id_seq OWNER TO postgres;
+
+--
+-- Name: aggregate_daily_app_name_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.aggregate_daily_app_name_metrics_id_seq OWNED BY public.aggregate_daily_app_name_metrics.id;
+
+
+--
+-- Name: aggregate_daily_total_users_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_daily_total_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    personal_count integer
+);
+
+
+ALTER TABLE public.aggregate_daily_total_users_metrics OWNER TO postgres;
+
+--
+-- Name: aggregate_daily_total_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.aggregate_daily_total_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.aggregate_daily_total_users_metrics_id_seq OWNER TO postgres;
+
+--
+-- Name: aggregate_daily_total_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.aggregate_daily_total_users_metrics_id_seq OWNED BY public.aggregate_daily_total_users_metrics.id;
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_daily_unique_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    summed_count integer,
+    personal_count integer
+);
+
+
+ALTER TABLE public.aggregate_daily_unique_users_metrics OWNER TO postgres;
+
+--
+-- Name: aggregate_daily_unique_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.aggregate_daily_unique_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.aggregate_daily_unique_users_metrics_id_seq OWNER TO postgres;
+
+--
+-- Name: aggregate_daily_unique_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.aggregate_daily_unique_users_metrics_id_seq OWNED BY public.aggregate_daily_unique_users_metrics.id;
+
+
+--
+-- Name: plays; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.plays (
+    id integer NOT NULL,
+    user_id integer,
+    source character varying,
+    play_item_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    slot integer,
+    signature character varying,
+    city character varying,
+    region character varying,
+    country character varying
+);
+
+
+ALTER TABLE public.plays OWNER TO postgres;
+
+--
+-- Name: aggregate_interval_plays; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.aggregate_interval_plays AS
+ SELECT tracks.track_id,
+    tracks.genre,
+    tracks.created_at,
+    COALESCE(week_listen_counts.count, (0)::bigint) AS week_listen_counts,
+    COALESCE(month_listen_counts.count, (0)::bigint) AS month_listen_counts
+   FROM ((public.tracks
+     LEFT JOIN ( SELECT plays.play_item_id,
+            count(plays.id) AS count
+           FROM public.plays
+          WHERE (plays.created_at > (now() - '7 days'::interval))
+          GROUP BY plays.play_item_id) week_listen_counts ON ((week_listen_counts.play_item_id = tracks.track_id)))
+     LEFT JOIN ( SELECT plays.play_item_id,
+            count(plays.id) AS count
+           FROM public.plays
+          WHERE (plays.created_at > (now() - '1 mon'::interval))
+          GROUP BY plays.play_item_id) month_listen_counts ON ((month_listen_counts.play_item_id = tracks.track_id)))
+  WHERE ((tracks.is_current IS TRUE) AND (tracks.is_delete IS FALSE) AND (tracks.is_unlisted IS FALSE) AND (tracks.stem_of IS NULL))
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.aggregate_interval_plays OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_app_name_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_monthly_app_name_metrics (
+    id integer NOT NULL,
+    application_name character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.aggregate_monthly_app_name_metrics OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_app_name_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.aggregate_monthly_app_name_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.aggregate_monthly_app_name_metrics_id_seq OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_app_name_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.aggregate_monthly_app_name_metrics_id_seq OWNED BY public.aggregate_monthly_app_name_metrics.id;
+
+
+--
+-- Name: aggregate_monthly_plays; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_monthly_plays (
+    play_item_id integer NOT NULL,
+    "timestamp" date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    count integer NOT NULL,
+    country text DEFAULT ''::text NOT NULL
+);
+
+
+ALTER TABLE public.aggregate_monthly_plays OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_total_users_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_monthly_total_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    personal_count integer
+);
+
+
+ALTER TABLE public.aggregate_monthly_total_users_metrics OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_total_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.aggregate_monthly_total_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.aggregate_monthly_total_users_metrics_id_seq OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_total_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.aggregate_monthly_total_users_metrics_id_seq OWNED BY public.aggregate_monthly_total_users_metrics.id;
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_monthly_unique_users_metrics (
+    id integer NOT NULL,
+    count integer NOT NULL,
+    "timestamp" date NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    summed_count integer,
+    personal_count integer
+);
+
+
+ALTER TABLE public.aggregate_monthly_unique_users_metrics OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_unique_users_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.aggregate_monthly_unique_users_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.aggregate_monthly_unique_users_metrics_id_seq OWNER TO postgres;
+
+--
+-- Name: aggregate_monthly_unique_users_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.aggregate_monthly_unique_users_metrics_id_seq OWNED BY public.aggregate_monthly_unique_users_metrics.id;
+
+
+--
+-- Name: aggregate_playlist; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_playlist (
+    playlist_id integer NOT NULL,
+    is_album boolean,
+    repost_count integer DEFAULT 0,
+    save_count integer DEFAULT 0,
+    share_count integer DEFAULT 0
+);
+
+
+ALTER TABLE public.aggregate_playlist OWNER TO postgres;
+
+--
+-- Name: aggregate_plays; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_plays (
+    play_item_id integer NOT NULL,
+    count bigint
+);
+
+
+ALTER TABLE public.aggregate_plays OWNER TO postgres;
+
+--
+-- Name: aggregate_track; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_track (
+    track_id integer NOT NULL,
+    repost_count integer DEFAULT 0 NOT NULL,
+    save_count integer DEFAULT 0 NOT NULL,
+    comment_count integer DEFAULT 0,
+    share_count integer DEFAULT 0
+);
+
+
+ALTER TABLE public.aggregate_track OWNER TO postgres;
+
+--
+-- Name: aggregate_user; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_user (
+    user_id integer NOT NULL,
+    track_count bigint DEFAULT 0,
+    playlist_count bigint DEFAULT 0,
+    album_count bigint DEFAULT 0,
+    follower_count bigint DEFAULT 0,
+    following_count bigint DEFAULT 0,
+    repost_count bigint DEFAULT 0,
+    track_save_count bigint DEFAULT 0,
+    supporter_count integer DEFAULT 0 NOT NULL,
+    supporting_count integer DEFAULT 0 NOT NULL,
+    dominant_genre character varying,
+    dominant_genre_count integer DEFAULT 0,
+    score integer DEFAULT 0,
+    total_track_count bigint DEFAULT 0,
+    track_share_count integer DEFAULT 0
+);
+
+
+ALTER TABLE public.aggregate_user OWNER TO postgres;
+
+--
+-- Name: aggregate_user_tips; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aggregate_user_tips (
+    sender_user_id integer NOT NULL,
+    receiver_user_id integer NOT NULL,
+    amount bigint NOT NULL
+);
+
+
+ALTER TABLE public.aggregate_user_tips OWNER TO postgres;
+
+--
+-- Name: album_price_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.album_price_history (
+    playlist_id integer NOT NULL,
+    splits jsonb NOT NULL,
+    total_price_cents bigint NOT NULL,
+    blocknumber integer NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.album_price_history OWNER TO postgres;
+
+--
+-- Name: alembic_version; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.alembic_version (
+    version_num character varying(32) NOT NULL
+);
+
+
+ALTER TABLE public.alembic_version OWNER TO postgres;
+
+--
+-- Name: anti_abuse_blocked_users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.anti_abuse_blocked_users (
+    handle_lc character varying(255) NOT NULL,
+    is_blocked boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.anti_abuse_blocked_users OWNER TO postgres;
+
+--
+-- Name: api_access_keys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.api_access_keys (
+    api_key character varying(255) NOT NULL,
+    api_access_key character varying(255) NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    CONSTRAINT api_access_keys_api_key_lowercase_check CHECK (((api_key)::text = lower((api_key)::text)))
+);
+
+
+ALTER TABLE public.api_access_keys OWNER TO postgres;
+
+--
+-- Name: api_keys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.api_keys (
+    api_key character varying(255) NOT NULL,
+    api_secret character varying(255),
+    rps integer DEFAULT 10 NOT NULL,
+    rpm integer DEFAULT 500000 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    CONSTRAINT api_keys_api_key_lowercase_check CHECK (((api_key)::text = lower((api_key)::text)))
+);
+
+
+ALTER TABLE public.api_keys OWNER TO postgres;
+
+--
+-- Name: api_metrics_apps; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.api_metrics_apps (
+    date date NOT NULL,
+    api_key character varying(255) NOT NULL,
+    app_name character varying(255) NOT NULL,
+    request_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.api_metrics_apps OWNER TO postgres;
+
+--
+-- Name: api_metrics_apps_unique; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.api_metrics_apps_unique (
+    date date NOT NULL,
+    app_name character varying(255) NOT NULL,
+    hll_sketch bytea,
+    total_count bigint DEFAULT 0 NOT NULL,
+    unique_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.api_metrics_apps_unique OWNER TO postgres;
+
+--
+-- Name: TABLE api_metrics_apps_unique; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.api_metrics_apps_unique IS 'Stores HLL sketches for tracking unique users per application. app_name stores the identifier (api_key if present, otherwise app_name from request).';
+
+
+--
+-- Name: api_metrics_counts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.api_metrics_counts (
+    date date NOT NULL,
+    hll_sketch bytea,
+    total_count bigint DEFAULT 0 NOT NULL,
+    unique_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.api_metrics_counts OWNER TO postgres;
+
+--
+-- Name: api_metrics_routes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.api_metrics_routes (
+    date date NOT NULL,
+    route_pattern character varying(512) NOT NULL,
+    method character varying(10) NOT NULL,
+    request_count bigint DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.api_metrics_routes OWNER TO postgres;
+
+--
+-- Name: app_name_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.app_name_metrics (
+    application_name character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    id bigint NOT NULL,
+    ip character varying
+);
+
+
+ALTER TABLE public.app_name_metrics OWNER TO postgres;
+
+--
+-- Name: app_name_metrics_all_time; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.app_name_metrics_all_time AS
+ SELECT app_name_metrics.application_name AS name,
+    sum(app_name_metrics.count) AS count
+   FROM public.app_name_metrics
+  GROUP BY app_name_metrics.application_name
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.app_name_metrics_all_time OWNER TO postgres;
+
+--
+-- Name: app_name_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.app_name_metrics ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.app_name_metrics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: app_name_metrics_trailing_month; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_month AS
+ SELECT app_name_metrics.application_name AS name,
+    sum(app_name_metrics.count) AS count
+   FROM public.app_name_metrics
+  WHERE (app_name_metrics."timestamp" > (now() - '1 mon'::interval))
+  GROUP BY app_name_metrics.application_name
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.app_name_metrics_trailing_month OWNER TO postgres;
+
+--
+-- Name: app_name_metrics_trailing_week; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_week AS
+ SELECT app_name_metrics.application_name AS name,
+    sum(app_name_metrics.count) AS count
+   FROM public.app_name_metrics
+  WHERE (app_name_metrics."timestamp" > (now() - '7 days'::interval))
+  GROUP BY app_name_metrics.application_name
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.app_name_metrics_trailing_week OWNER TO postgres;
+
+--
+-- Name: artist_coin_pools; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.artist_coin_pools (
+    address text NOT NULL,
+    base_mint text NOT NULL,
+    quote_mint text,
+    token_decimals integer,
+    base_reserve numeric,
+    quote_reserve numeric,
+    migration_base_threshold numeric,
+    migration_quote_threshold numeric,
+    protocol_quote_fee numeric,
+    partner_quote_fee numeric,
+    creator_base_fee numeric,
+    creator_quote_fee numeric,
+    price double precision,
+    price_usd double precision,
+    curve_progress double precision,
+    is_migrated boolean,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    claimed_creator_base_fee numeric DEFAULT 0,
+    claimed_creator_quote_fee numeric DEFAULT 0,
+    total_trading_quote_fee numeric,
+    creator_wallet_address text
+);
+
+
+ALTER TABLE public.artist_coin_pools OWNER TO postgres;
+
+--
+-- Name: COLUMN artist_coin_pools.claimed_creator_base_fee; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.artist_coin_pools.claimed_creator_base_fee IS 'Total creator fees claimed in base token (artist coin)';
+
+
+--
+-- Name: COLUMN artist_coin_pools.claimed_creator_quote_fee; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.artist_coin_pools.claimed_creator_quote_fee IS 'Total creator fees claimed in quote token (USDC/AUDIO)';
+
+
+--
+-- Name: artist_coin_stats; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.artist_coin_stats (
+    mint text NOT NULL,
+    market_cap double precision,
+    fdv double precision,
+    liquidity double precision,
+    last_trade_unix_time bigint,
+    last_trade_human_time text,
+    price double precision,
+    history_24h_price double precision,
+    price_change_24h_percent double precision,
+    unique_wallet_24h integer,
+    unique_wallet_history_24h integer,
+    unique_wallet_24h_change_percent double precision,
+    total_supply double precision,
+    circulating_supply double precision,
+    holder integer,
+    trade_24h integer,
+    trade_history_24h integer,
+    trade_24h_change_percent double precision,
+    sell_24h integer,
+    sell_history_24h integer,
+    sell_24h_change_percent double precision,
+    buy_24h integer,
+    buy_history_24h integer,
+    buy_24h_change_percent double precision,
+    v_24h double precision,
+    v_24h_usd double precision,
+    v_history_24h double precision,
+    v_history_24h_usd double precision,
+    v_24h_change_percent double precision,
+    v_buy_24h double precision,
+    v_buy_24h_usd double precision,
+    v_buy_history_24h double precision,
+    v_buy_history_24h_usd double precision,
+    v_buy_24h_change_percent double precision,
+    v_sell_24h double precision,
+    v_sell_24h_usd double precision,
+    v_sell_history_24h double precision,
+    v_sell_history_24h_usd double precision,
+    v_sell_24h_change_percent double precision,
+    number_markets integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    total_volume double precision,
+    total_volume_usd double precision,
+    volume_buy double precision,
+    volume_buy_usd double precision,
+    volume_sell double precision,
+    volume_sell_usd double precision,
+    buy integer,
+    sell integer,
+    total_trade integer
+);
+
+
+ALTER TABLE public.artist_coin_stats OWNER TO postgres;
+
+--
+-- Name: artist_coins; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.artist_coins (
+    mint character varying NOT NULL,
+    ticker character varying NOT NULL,
+    user_id integer NOT NULL,
+    decimals integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    logo_uri text,
+    description text,
+    name text DEFAULT ''::text NOT NULL,
+    has_discord boolean DEFAULT false NOT NULL,
+    updated_at timestamp without time zone DEFAULT now(),
+    link_1 text,
+    link_2 text,
+    link_3 text,
+    link_4 text,
+    damm_v2_pool text,
+    banner_image_url text
+);
+
+
+ALTER TABLE public.artist_coins OWNER TO postgres;
+
+--
+-- Name: TABLE artist_coins; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.artist_coins IS 'Stores the token mints for artist coins that the indexer is tracking and their tickers.';
+
+
+--
+-- Name: COLUMN artist_coins.damm_v2_pool; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.artist_coins.damm_v2_pool IS 'The canonical DAMM V2 pool address for this artist coin, if any. Used in solana indexer.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pools; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pools (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    token_a_mint text NOT NULL,
+    token_b_mint text NOT NULL,
+    token_a_vault text NOT NULL,
+    token_b_vault text NOT NULL,
+    whitelisted_vault text NOT NULL,
+    partner text NOT NULL,
+    liquidity numeric NOT NULL,
+    protocol_a_fee bigint NOT NULL,
+    protocol_b_fee bigint NOT NULL,
+    partner_a_fee bigint NOT NULL,
+    partner_b_fee bigint NOT NULL,
+    sqrt_min_price numeric NOT NULL,
+    sqrt_max_price numeric NOT NULL,
+    sqrt_price numeric NOT NULL,
+    activation_point bigint NOT NULL,
+    activation_type smallint NOT NULL,
+    pool_status smallint NOT NULL,
+    token_a_flag smallint NOT NULL,
+    token_b_flag smallint NOT NULL,
+    collect_fee_mode smallint NOT NULL,
+    pool_type smallint NOT NULL,
+    version smallint NOT NULL,
+    fee_a_per_liquidity numeric NOT NULL,
+    fee_b_per_liquidity numeric NOT NULL,
+    permanent_lock_liquidity numeric NOT NULL,
+    creator text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_pools OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pools; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pools IS 'Tracks DAMM V2 pool state. Join with sol_meteora_damm_v2_pool_metrics, sol_meteora_damm_v2_pool_fees, sol_meteora_damm_v2_pool_base_fees, and sol_meteora_damm_v2_pool_dynamic_fees for full pool state.';
+
+
+--
+-- Name: sol_meteora_dbc_configs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_configs (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    quote_mint text NOT NULL,
+    fee_claimer text NOT NULL,
+    leftover_receiver text NOT NULL,
+    collect_fee_mode smallint NOT NULL,
+    migration_option smallint NOT NULL,
+    activation_type smallint,
+    token_decimal smallint,
+    version smallint,
+    token_type smallint,
+    quote_token_flag smallint,
+    partner_locked_lp_percentage smallint,
+    partner_lp_percentage smallint,
+    creator_locked_lp_percentage smallint,
+    creator_lp_percentage smallint,
+    migration_fee_option smallint,
+    fixed_token_supply_flag smallint,
+    creator_trading_fee_percentage smallint,
+    token_update_authority smallint,
+    migration_fee_percentage smallint,
+    creator_migration_fee_percentage smallint,
+    swap_base_amount bigint,
+    migration_quote_threshold bigint,
+    migration_base_threshold bigint,
+    migration_sqrt_price numeric,
+    pre_migration_token_supply bigint,
+    post_migration_token_supply bigint,
+    migrated_collect_fee_mode smallint,
+    migrated_dynamic_fee smallint,
+    migrated_pool_fee_bps smallint,
+    sqrt_start_price numeric,
+    curve jsonb,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_configs OWNER TO postgres;
+
+--
+-- Name: sol_meteora_dbc_pools; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_pools (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    config text NOT NULL,
+    creator text NOT NULL,
+    base_mint text NOT NULL,
+    base_vault text NOT NULL,
+    quote_vault text NOT NULL,
+    base_reserve bigint NOT NULL,
+    quote_reserve bigint NOT NULL,
+    protocol_base_fee bigint NOT NULL,
+    protocol_quote_fee bigint NOT NULL,
+    partner_base_fee bigint NOT NULL,
+    partner_quote_fee bigint NOT NULL,
+    sqrt_price numeric NOT NULL,
+    activation_point bigint NOT NULL,
+    pool_type smallint NOT NULL,
+    is_migrated smallint NOT NULL,
+    is_partner_withdraw_surplus smallint NOT NULL,
+    is_protocol_withdraw_surplus smallint NOT NULL,
+    migration_progress smallint NOT NULL,
+    is_withdraw_leftover smallint NOT NULL,
+    is_creator_withdraw_surplus smallint NOT NULL,
+    migration_fee_withdraw_status smallint NOT NULL,
+    finish_curve_timestamp bigint NOT NULL,
+    creator_base_fee bigint NOT NULL,
+    creator_quote_fee bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_pools OWNER TO postgres;
+
+--
+-- Name: artist_coin_prices; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.artist_coin_prices AS
+ WITH dbc AS (
+         SELECT artist_coins_1.mint,
+            ((public.price_from_sqrt_price(dbc_pool.sqrt_price, artist_coins_1.decimals))::double precision * dbc_quote_token.price) AS price
+           FROM (((public.artist_coins artist_coins_1
+             JOIN public.sol_meteora_dbc_pools dbc_pool ON (((dbc_pool.base_mint = (artist_coins_1.mint)::text) AND (dbc_pool.is_migrated = 0))))
+             JOIN public.sol_meteora_dbc_configs dbc_config ON ((dbc_config.account = dbc_pool.config)))
+             JOIN public.artist_coin_stats dbc_quote_token ON ((dbc_quote_token.mint = dbc_config.quote_mint)))
+          WHERE (dbc_pool.is_migrated = 0)
+        ), damm_v2 AS (
+         SELECT artist_coins_1.mint,
+            ((public.price_from_sqrt_price(damm_v2_pool.sqrt_price, artist_coins_1.decimals))::double precision * damm_v2_quote_token.price) AS price
+           FROM ((public.artist_coins artist_coins_1
+             JOIN public.sol_meteora_damm_v2_pools damm_v2_pool ON ((damm_v2_pool.token_a_mint = (artist_coins_1.mint)::text)))
+             JOIN public.artist_coin_stats damm_v2_quote_token ON ((damm_v2_quote_token.mint = damm_v2_pool.token_b_mint)))
+        )
+ SELECT artist_coins.mint,
+    damm_v2.price AS damm_v2_price,
+    dbc.price AS dbc_price,
+    pools.price_usd AS pools_price_usd,
+    stats.price AS stats_price,
+    COALESCE(damm_v2.price, dbc.price, pools.price_usd, stats.price) AS price
+   FROM ((((public.artist_coins
+     LEFT JOIN dbc ON (((artist_coins.mint)::text = (dbc.mint)::text)))
+     LEFT JOIN damm_v2 ON (((artist_coins.mint)::text = (damm_v2.mint)::text)))
+     LEFT JOIN public.artist_coin_pools pools ON ((pools.base_mint = (artist_coins.mint)::text)))
+     LEFT JOIN public.artist_coin_stats stats ON ((stats.mint = (artist_coins.mint)::text)));
+
+
+ALTER VIEW public.artist_coin_prices OWNER TO postgres;
+
+--
+-- Name: VIEW artist_coin_prices; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON VIEW public.artist_coin_prices IS 'View that provides artist coin prices using DAMM V2 pool if available, DBC pools if not and still applicable, artist_coin_pools.price_usd as fallback, and artist_coin_stats.price as final fallback (primarily for AUDIO and other tokens without pools). Makes use of the price of the quote token (AUDIO) from Birdeye if using a pool.';
+
+
+--
+-- Name: associated_wallets; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.associated_wallets (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    wallet character varying NOT NULL,
+    blockhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    chain public.wallet_chain NOT NULL
+);
+
+
+ALTER TABLE public.associated_wallets OWNER TO postgres;
+
+--
+-- Name: associated_wallets_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.associated_wallets_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.associated_wallets_id_seq OWNER TO postgres;
+
+--
+-- Name: associated_wallets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.associated_wallets_id_seq OWNED BY public.associated_wallets.id;
+
+
+--
+-- Name: audio_transactions_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.audio_transactions_history (
+    user_bank character varying NOT NULL,
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    transaction_type character varying NOT NULL,
+    method character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    transaction_created_at timestamp without time zone NOT NULL,
+    change numeric NOT NULL,
+    balance numeric NOT NULL,
+    tx_metadata character varying
+);
+
+
+ALTER TABLE public.audio_transactions_history OWNER TO postgres;
+
+--
+-- Name: audius_data_txs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.audius_data_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL
+);
+
+
+ALTER TABLE public.audius_data_txs OWNER TO postgres;
+
+--
+-- Name: blocks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.blocks (
+    blockhash character varying NOT NULL,
+    parenthash character varying,
+    number integer
+);
+
+
+ALTER TABLE public.blocks OWNER TO postgres;
+
+--
+-- Name: challenge_disbursements; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.challenge_disbursements (
+    challenge_id character varying NOT NULL,
+    user_id integer NOT NULL,
+    specifier character varying NOT NULL,
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    amount character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.challenge_disbursements OWNER TO postgres;
+
+--
+-- Name: challenge_listen_streak; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.challenge_listen_streak (
+    user_id integer NOT NULL,
+    last_listen_date timestamp without time zone,
+    listen_streak integer NOT NULL
+);
+
+
+ALTER TABLE public.challenge_listen_streak OWNER TO postgres;
+
+--
+-- Name: challenge_listen_streak_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.challenge_listen_streak_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.challenge_listen_streak_user_id_seq OWNER TO postgres;
+
+--
+-- Name: challenge_listen_streak_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.challenge_listen_streak_user_id_seq OWNED BY public.challenge_listen_streak.user_id;
+
+
+--
+-- Name: challenge_profile_completion; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.challenge_profile_completion (
+    user_id integer NOT NULL,
+    profile_description boolean NOT NULL,
+    profile_name boolean NOT NULL,
+    profile_picture boolean NOT NULL,
+    profile_cover_photo boolean NOT NULL,
+    follows boolean NOT NULL,
+    favorites boolean NOT NULL,
+    reposts boolean NOT NULL
+);
+
+
+ALTER TABLE public.challenge_profile_completion OWNER TO postgres;
+
+--
+-- Name: challenge_profile_completion_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.challenge_profile_completion_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.challenge_profile_completion_user_id_seq OWNER TO postgres;
+
+--
+-- Name: challenge_profile_completion_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.challenge_profile_completion_user_id_seq OWNED BY public.challenge_profile_completion.user_id;
+
+
+--
+-- Name: challenges; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.challenges (
+    id character varying NOT NULL,
+    type public.challengetype NOT NULL,
+    amount character varying NOT NULL,
+    active boolean NOT NULL,
+    step_count integer,
+    starting_block integer,
+    weekly_pool integer,
+    cooldown_days integer
+);
+
+
+ALTER TABLE public.challenges OWNER TO postgres;
+
+--
+-- Name: chat; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat (
+    chat_id text NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    last_message_at timestamp without time zone NOT NULL,
+    last_message text,
+    last_message_is_plaintext boolean DEFAULT false
+);
+
+
+ALTER TABLE public.chat OWNER TO postgres;
+
+--
+-- Name: chat_ban; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_ban (
+    user_id integer NOT NULL,
+    is_banned boolean NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.chat_ban OWNER TO postgres;
+
+--
+-- Name: chat_blast; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_blast (
+    blast_id text NOT NULL,
+    from_user_id integer NOT NULL,
+    audience text NOT NULL,
+    audience_content_id integer,
+    plaintext text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    audience_content_type text
+);
+
+
+ALTER TABLE public.chat_blast OWNER TO postgres;
+
+--
+-- Name: chat_blocked_users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_blocked_users (
+    blocker_user_id integer NOT NULL,
+    blockee_user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.chat_blocked_users OWNER TO postgres;
+
+--
+-- Name: chat_member; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_member (
+    chat_id text NOT NULL,
+    user_id integer NOT NULL,
+    cleared_history_at timestamp without time zone,
+    invited_by_user_id integer NOT NULL,
+    invite_code text NOT NULL,
+    last_active_at timestamp without time zone,
+    unread_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    is_hidden boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.chat_member OWNER TO postgres;
+
+--
+-- Name: chat_message; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_message (
+    message_id text NOT NULL,
+    chat_id text NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    ciphertext text,
+    blast_id text
+);
+
+
+ALTER TABLE public.chat_message OWNER TO postgres;
+
+--
+-- Name: chat_message_reactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_message_reactions (
+    user_id integer NOT NULL,
+    message_id text NOT NULL,
+    reaction text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.chat_message_reactions OWNER TO postgres;
+
+--
+-- Name: chat_permissions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.chat_permissions (
+    user_id integer NOT NULL,
+    permits text DEFAULT 'all'::text NOT NULL,
+    updated_at timestamp without time zone DEFAULT to_timestamp((0)::double precision) NOT NULL,
+    allowed boolean DEFAULT true NOT NULL
+);
+
+
+ALTER TABLE public.chat_permissions OWNER TO postgres;
+
+--
+-- Name: cid_data; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.cid_data (
+    cid character varying NOT NULL,
+    type character varying,
+    data jsonb
+);
+
+
+ALTER TABLE public.cid_data OWNER TO postgres;
+
+--
+-- Name: claimed_prizes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.claimed_prizes (
+    id integer NOT NULL,
+    wallet character varying NOT NULL,
+    signature character varying NOT NULL,
+    mint character varying NOT NULL,
+    amount bigint NOT NULL,
+    prize_id character varying NOT NULL,
+    prize_name character varying NOT NULL,
+    prize_type character varying,
+    action_data jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.claimed_prizes OWNER TO postgres;
+
+--
+-- Name: TABLE claimed_prizes; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.claimed_prizes IS 'Stores claimed prizes where users pay tokens to claim and win prizes.';
+
+
+--
+-- Name: claimed_prizes_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.claimed_prizes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.claimed_prizes_id_seq OWNER TO postgres;
+
+--
+-- Name: claimed_prizes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.claimed_prizes_id_seq OWNED BY public.claimed_prizes.id;
+
+
+--
+-- Name: collectibles; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.collectibles (
+    user_id integer NOT NULL,
+    data jsonb NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.collectibles OWNER TO postgres;
+
+--
+-- Name: TABLE collectibles; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.collectibles IS 'Stores collectibles data for users';
+
+
+--
+-- Name: COLUMN collectibles.user_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.collectibles.user_id IS 'User ID of the person who owns the collectibles';
+
+
+--
+-- Name: COLUMN collectibles.data; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.collectibles.data IS 'Data about the collectibles';
+
+
+--
+-- Name: COLUMN collectibles.blockhash; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.collectibles.blockhash IS 'Blockhash of the most recent block that changed the collectibles data';
+
+
+--
+-- Name: COLUMN collectibles.blocknumber; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.collectibles.blocknumber IS 'Block number of the most recent block that changed the collectibles data';
+
+
+--
+-- Name: comment_mentions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.comment_mentions (
+    comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.comment_mentions OWNER TO postgres;
+
+--
+-- Name: comment_notification_settings; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.comment_notification_settings (
+    user_id integer NOT NULL,
+    entity_id integer NOT NULL,
+    entity_type text NOT NULL,
+    is_muted boolean DEFAULT false,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.comment_notification_settings OWNER TO postgres;
+
+--
+-- Name: comment_reactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.comment_reactions (
+    comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.comment_reactions OWNER TO postgres;
+
+--
+-- Name: comment_reports; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.comment_reports (
+    comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.comment_reports OWNER TO postgres;
+
+--
+-- Name: comment_threads; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.comment_threads (
+    comment_id integer NOT NULL,
+    parent_comment_id integer NOT NULL
+);
+
+
+ALTER TABLE public.comment_threads OWNER TO postgres;
+
+--
+-- Name: comments; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.comments (
+    comment_id integer NOT NULL,
+    text text NOT NULL,
+    user_id integer NOT NULL,
+    entity_id integer NOT NULL,
+    entity_type text NOT NULL,
+    track_timestamp_s bigint,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    is_visible boolean DEFAULT true,
+    is_edited boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer,
+    is_members_only boolean DEFAULT false NOT NULL,
+    video_url text
+);
+
+
+ALTER TABLE public.comments OWNER TO postgres;
+
+--
+-- Name: core_app_state; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_app_state (
+    block_height bigint NOT NULL,
+    app_hash bytea NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.core_app_state OWNER TO postgres;
+
+--
+-- Name: core_blocks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_blocks (
+    rowid bigint NOT NULL,
+    height bigint NOT NULL,
+    chain_id text NOT NULL,
+    hash text NOT NULL,
+    proposer text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.core_blocks OWNER TO postgres;
+
+--
+-- Name: core_blocks_rowid_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_blocks_rowid_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_blocks_rowid_seq OWNER TO postgres;
+
+--
+-- Name: core_blocks_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_blocks_rowid_seq OWNED BY public.core_blocks.rowid;
+
+
+--
+-- Name: core_db_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_db_migrations (
+    id text NOT NULL,
+    applied_at timestamp with time zone
+);
+
+
+ALTER TABLE public.core_db_migrations OWNER TO postgres;
+
+--
+-- Name: core_deals; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_deals (
+    address text NOT NULL,
+    ern_address text NOT NULL,
+    entity_type text NOT NULL,
+    entity_index integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.core_deals OWNER TO postgres;
+
+--
+-- Name: core_ern; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_ern (
+    id bigint NOT NULL,
+    address text NOT NULL,
+    index bigint NOT NULL,
+    tx_hash text NOT NULL,
+    sender text NOT NULL,
+    message_control_type smallint NOT NULL,
+    raw_message bytea NOT NULL,
+    raw_acknowledgment bytea NOT NULL,
+    block_height bigint NOT NULL
+);
+
+
+ALTER TABLE public.core_ern OWNER TO postgres;
+
+--
+-- Name: core_ern_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_ern_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_ern_id_seq OWNER TO postgres;
+
+--
+-- Name: core_ern_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_ern_id_seq OWNED BY public.core_ern.id;
+
+
+--
+-- Name: core_indexed_blocks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_indexed_blocks (
+    blockhash character varying NOT NULL,
+    parenthash character varying,
+    chain_id text NOT NULL,
+    height integer NOT NULL,
+    plays_slot integer DEFAULT 0,
+    em_block integer
+);
+
+
+ALTER TABLE public.core_indexed_blocks OWNER TO postgres;
+
+--
+-- Name: core_mead; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_mead (
+    id bigint NOT NULL,
+    address text NOT NULL,
+    tx_hash text NOT NULL,
+    index bigint NOT NULL,
+    sender text NOT NULL,
+    resource_addresses text[] DEFAULT '{}'::text[],
+    release_addresses text[] DEFAULT '{}'::text[],
+    raw_message bytea NOT NULL,
+    raw_acknowledgment bytea NOT NULL,
+    block_height bigint NOT NULL
+);
+
+
+ALTER TABLE public.core_mead OWNER TO postgres;
+
+--
+-- Name: core_mead_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_mead_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_mead_id_seq OWNER TO postgres;
+
+--
+-- Name: core_mead_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_mead_id_seq OWNED BY public.core_mead.id;
+
+
+--
+-- Name: core_parties; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_parties (
+    address text NOT NULL,
+    ern_address text NOT NULL,
+    entity_type text NOT NULL,
+    entity_index integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.core_parties OWNER TO postgres;
+
+--
+-- Name: core_pie; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_pie (
+    id bigint NOT NULL,
+    address text NOT NULL,
+    tx_hash text NOT NULL,
+    index bigint NOT NULL,
+    sender text NOT NULL,
+    party_addresses text[] DEFAULT '{}'::text[],
+    raw_message bytea NOT NULL,
+    raw_acknowledgment bytea NOT NULL,
+    block_height bigint NOT NULL
+);
+
+
+ALTER TABLE public.core_pie OWNER TO postgres;
+
+--
+-- Name: core_pie_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_pie_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_pie_id_seq OWNER TO postgres;
+
+--
+-- Name: core_pie_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_pie_id_seq OWNED BY public.core_pie.id;
+
+
+--
+-- Name: core_releases; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_releases (
+    address text NOT NULL,
+    ern_address text NOT NULL,
+    entity_type text NOT NULL,
+    entity_index integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.core_releases OWNER TO postgres;
+
+--
+-- Name: core_resources; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_resources (
+    address text NOT NULL,
+    ern_address text NOT NULL,
+    entity_type text NOT NULL,
+    entity_index integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.core_resources OWNER TO postgres;
+
+--
+-- Name: core_rewards; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_rewards (
+    id bigint NOT NULL,
+    address text NOT NULL,
+    index bigint NOT NULL,
+    tx_hash text NOT NULL,
+    sender text NOT NULL,
+    reward_id text NOT NULL,
+    name text NOT NULL,
+    amount bigint NOT NULL,
+    claim_authorities text[] DEFAULT '{}'::text[],
+    raw_message bytea NOT NULL,
+    block_height bigint NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.core_rewards OWNER TO postgres;
+
+--
+-- Name: core_rewards_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_rewards_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_rewards_id_seq OWNER TO postgres;
+
+--
+-- Name: core_rewards_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_rewards_id_seq OWNED BY public.core_rewards.id;
+
+
+--
+-- Name: core_transactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_transactions (
+    rowid bigint NOT NULL,
+    block_id bigint NOT NULL,
+    index integer NOT NULL,
+    tx_hash text NOT NULL,
+    transaction bytea NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.core_transactions OWNER TO postgres;
+
+--
+-- Name: core_transactions_rowid_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_transactions_rowid_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_transactions_rowid_seq OWNER TO postgres;
+
+--
+-- Name: core_transactions_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_transactions_rowid_seq OWNED BY public.core_transactions.rowid;
+
+
+--
+-- Name: core_tx_stats; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_tx_stats (
+    id integer NOT NULL,
+    tx_type text NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.core_tx_stats OWNER TO postgres;
+
+--
+-- Name: core_tx_stats_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_tx_stats_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_tx_stats_id_seq OWNER TO postgres;
+
+--
+-- Name: core_tx_stats_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_tx_stats_id_seq OWNED BY public.core_tx_stats.id;
+
+
+--
+-- Name: core_uploads; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_uploads (
+    id bigint NOT NULL,
+    uploader_address text NOT NULL,
+    cid text NOT NULL,
+    transcoded_cid text NOT NULL,
+    upid text NOT NULL,
+    upload_signature text NOT NULL,
+    validator_address text NOT NULL,
+    validator_signature text NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL
+);
+
+
+ALTER TABLE public.core_uploads OWNER TO postgres;
+
+--
+-- Name: core_uploads_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_uploads_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_uploads_id_seq OWNER TO postgres;
+
+--
+-- Name: core_uploads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_uploads_id_seq OWNED BY public.core_uploads.id;
+
+
+--
+-- Name: core_validators; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.core_validators (
+    rowid integer NOT NULL,
+    pub_key text NOT NULL,
+    endpoint text NOT NULL,
+    eth_address text NOT NULL,
+    comet_address text NOT NULL,
+    eth_block text NOT NULL,
+    node_type text NOT NULL,
+    sp_id text NOT NULL,
+    comet_pub_key text NOT NULL
+);
+
+
+ALTER TABLE public.core_validators OWNER TO postgres;
+
+--
+-- Name: core_validators_rowid_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.core_validators_rowid_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.core_validators_rowid_seq OWNER TO postgres;
+
+--
+-- Name: core_validators_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.core_validators_rowid_seq OWNED BY public.core_validators.rowid;
+
+
+--
+-- Name: countries; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.countries (
+    iso character(2) NOT NULL,
+    name character varying(80) NOT NULL,
+    nicename character varying(80) NOT NULL,
+    iso3 character(3) DEFAULT NULL::bpchar,
+    numcode smallint,
+    phonecode integer NOT NULL
+);
+
+
+ALTER TABLE public.countries OWNER TO postgres;
+
+--
+-- Name: dashboard_wallet_users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.dashboard_wallet_users (
+    wallet character varying NOT NULL,
+    user_id integer NOT NULL,
+    is_delete boolean DEFAULT false NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    txhash character varying NOT NULL
+);
+
+
+ALTER TABLE public.dashboard_wallet_users OWNER TO postgres;
+
+--
+-- Name: delist_status_cursor; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.delist_status_cursor (
+    host text NOT NULL,
+    entity public.delist_entity NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE public.delist_status_cursor OWNER TO postgres;
+
+--
+-- Name: developer_apps; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.developer_apps (
+    address character varying NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer,
+    name character varying NOT NULL,
+    is_personal_access boolean DEFAULT false NOT NULL,
+    is_delete boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying NOT NULL,
+    is_current boolean NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    description character varying(255),
+    image_url character varying
+);
+
+
+ALTER TABLE public.developer_apps OWNER TO postgres;
+
+--
+-- Name: email_access; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.email_access (
+    id integer NOT NULL,
+    email_owner_user_id integer NOT NULL,
+    receiving_user_id integer NOT NULL,
+    grantor_user_id integer NOT NULL,
+    encrypted_key text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    is_initial boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.email_access OWNER TO postgres;
+
+--
+-- Name: TABLE email_access; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.email_access IS 'Tracks who has access to encrypted emails';
+
+
+--
+-- Name: COLUMN email_access.email_owner_user_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.email_access.email_owner_user_id IS 'The user ID of the email owner';
+
+
+--
+-- Name: COLUMN email_access.receiving_user_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.email_access.receiving_user_id IS 'The user ID of the person granted access';
+
+
+--
+-- Name: COLUMN email_access.grantor_user_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.email_access.grantor_user_id IS 'The user ID of the person who granted access';
+
+
+--
+-- Name: COLUMN email_access.encrypted_key; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.email_access.encrypted_key IS 'The symmetric key (SK) encrypted for the receiving user';
+
+
+--
+-- Name: email_access_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.email_access_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.email_access_id_seq OWNER TO postgres;
+
+--
+-- Name: email_access_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.email_access_id_seq OWNED BY public.email_access.id;
+
+
+--
+-- Name: encrypted_emails; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.encrypted_emails (
+    id integer NOT NULL,
+    email_owner_user_id integer NOT NULL,
+    encrypted_email text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.encrypted_emails OWNER TO postgres;
+
+--
+-- Name: TABLE encrypted_emails; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.encrypted_emails IS 'Stores encrypted email addresses';
+
+
+--
+-- Name: COLUMN encrypted_emails.email_owner_user_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.encrypted_emails.email_owner_user_id IS 'The user ID of the email owner';
+
+
+--
+-- Name: COLUMN encrypted_emails.encrypted_email; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.encrypted_emails.encrypted_email IS 'The encrypted email address (base64 encoded)';
+
+
+--
+-- Name: encrypted_emails_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.encrypted_emails_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.encrypted_emails_id_seq OWNER TO postgres;
+
+--
+-- Name: encrypted_emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.encrypted_emails_id_seq OWNED BY public.encrypted_emails.id;
+
+
+--
+-- Name: eth_active_proposals; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_active_proposals (
+    id bigint NOT NULL,
+    proposer text NOT NULL,
+    submission_block_number bigint NOT NULL,
+    target_contract_registry_key text NOT NULL,
+    target_contract_address text NOT NULL,
+    call_value bigint NOT NULL,
+    function_signature text NOT NULL,
+    call_data text NOT NULL
+);
+
+
+ALTER TABLE public.eth_active_proposals OWNER TO postgres;
+
+--
+-- Name: eth_blocks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_blocks (
+    last_scanned_block integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.eth_blocks OWNER TO postgres;
+
+--
+-- Name: eth_blocks_last_scanned_block_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.eth_blocks_last_scanned_block_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.eth_blocks_last_scanned_block_seq OWNER TO postgres;
+
+--
+-- Name: eth_blocks_last_scanned_block_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.eth_blocks_last_scanned_block_seq OWNED BY public.eth_blocks.last_scanned_block;
+
+
+--
+-- Name: eth_db_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_db_migrations (
+    version bigint NOT NULL,
+    dirty boolean NOT NULL
+);
+
+
+ALTER TABLE public.eth_db_migrations OWNER TO postgres;
+
+--
+-- Name: eth_funding_rounds; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_funding_rounds (
+    round_num integer NOT NULL,
+    blocknumber bigint NOT NULL,
+    creation_time timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.eth_funding_rounds OWNER TO postgres;
+
+--
+-- Name: eth_indexer_checkpoints; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_indexer_checkpoints (
+    name text NOT NULL,
+    last_block bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.eth_indexer_checkpoints OWNER TO postgres;
+
+--
+-- Name: TABLE eth_indexer_checkpoints; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.eth_indexer_checkpoints IS 'Resumable backfill checkpoints for the eth-indexer (last block whose Transfer events have been processed, keyed by subscription name).';
+
+
+--
+-- Name: eth_registered_endpoints; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_registered_endpoints (
+    id integer NOT NULL,
+    service_type text NOT NULL,
+    owner text NOT NULL,
+    delegate_wallet text NOT NULL,
+    endpoint text NOT NULL,
+    blocknumber bigint NOT NULL,
+    registered_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.eth_registered_endpoints OWNER TO postgres;
+
+--
+-- Name: eth_service_providers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_service_providers (
+    address text NOT NULL,
+    deployer_stake bigint NOT NULL,
+    deployer_cut bigint NOT NULL,
+    valid_bounds boolean NOT NULL,
+    number_of_endpoints integer NOT NULL,
+    min_account_stake bigint NOT NULL,
+    max_account_stake bigint NOT NULL
+);
+
+
+ALTER TABLE public.eth_service_providers OWNER TO postgres;
+
+--
+-- Name: eth_staked; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_staked (
+    address text NOT NULL,
+    total_staked bigint NOT NULL
+);
+
+
+ALTER TABLE public.eth_staked OWNER TO postgres;
+
+--
+-- Name: eth_user_balances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_user_balances (
+    user_id integer NOT NULL,
+    balance numeric DEFAULT 0 NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.eth_user_balances OWNER TO postgres;
+
+--
+-- Name: TABLE eth_user_balances; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.eth_user_balances IS 'Per-user AUDIO ERC-20 balance (wei), summed across users.wallet + chain=eth associated_wallets. Pre-aggregated mirror of eth_wallet_balances, maintained by triggers (handle_eth_wallet_balance_change / handle_associated_wallets) and recomputed by update_eth_user_balance(user_id). ETH-side analog of sol_user_balances.';
+
+
+--
+-- Name: eth_wallet_balances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.eth_wallet_balances (
+    wallet text NOT NULL,
+    balance numeric DEFAULT 0 NOT NULL,
+    blocknumber bigint,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.eth_wallet_balances OWNER TO postgres;
+
+--
+-- Name: TABLE eth_wallet_balances; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.eth_wallet_balances IS 'AUDIO ERC-20 balances (in wei) for tracked Ethereum wallets — primary users.wallet and chain=eth associated_wallets. Maintained event-driven by the eth-indexer (WebSocket subscription to the AUDIO Transfer topic, targeted balanceOf reads).';
+
+
+--
+-- Name: etl_addresses; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_addresses (
+    id integer NOT NULL,
+    address text NOT NULL,
+    pub_key bytea,
+    first_seen_block_height bigint,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_addresses OWNER TO postgres;
+
+--
+-- Name: etl_addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_addresses_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_addresses_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_addresses_id_seq OWNED BY public.etl_addresses.id;
+
+
+--
+-- Name: etl_blocks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_blocks (
+    id integer NOT NULL,
+    proposer_address text NOT NULL,
+    block_height bigint NOT NULL,
+    block_time timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_blocks OWNER TO postgres;
+
+--
+-- Name: etl_blocks_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_blocks_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_blocks_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_blocks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_blocks_id_seq OWNED BY public.etl_blocks.id;
+
+
+--
+-- Name: etl_db_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_db_migrations (
+    version bigint NOT NULL,
+    dirty boolean NOT NULL
+);
+
+
+ALTER TABLE public.etl_db_migrations OWNER TO postgres;
+
+--
+-- Name: etl_manage_entities; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_manage_entities (
+    id integer NOT NULL,
+    address text NOT NULL,
+    entity_type text NOT NULL,
+    entity_id bigint NOT NULL,
+    action text NOT NULL,
+    metadata text,
+    signature text NOT NULL,
+    signer text NOT NULL,
+    nonce text NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_manage_entities OWNER TO postgres;
+
+--
+-- Name: etl_manage_entities_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_manage_entities_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_manage_entities_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_manage_entities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_manage_entities_id_seq OWNED BY public.etl_manage_entities.id;
+
+
+--
+-- Name: etl_plays; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_plays (
+    id integer NOT NULL,
+    user_id text NOT NULL,
+    track_id text NOT NULL,
+    city text NOT NULL,
+    region text NOT NULL,
+    country text NOT NULL,
+    played_at timestamp without time zone NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    listened_at timestamp without time zone NOT NULL,
+    recorded_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_plays OWNER TO postgres;
+
+--
+-- Name: etl_plays_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_plays_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_plays_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_plays_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_plays_id_seq OWNED BY public.etl_plays.id;
+
+
+--
+-- Name: etl_sla_node_reports; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_sla_node_reports (
+    id integer NOT NULL,
+    sla_rollup_id integer NOT NULL,
+    address text NOT NULL,
+    num_blocks_proposed integer NOT NULL,
+    challenges_received integer NOT NULL,
+    challenges_failed integer NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_sla_node_reports OWNER TO postgres;
+
+--
+-- Name: etl_sla_node_reports_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_sla_node_reports_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_sla_node_reports_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_sla_node_reports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_sla_node_reports_id_seq OWNED BY public.etl_sla_node_reports.id;
+
+
+--
+-- Name: etl_sla_rollups; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_sla_rollups (
+    id integer NOT NULL,
+    block_start bigint NOT NULL,
+    block_end bigint NOT NULL,
+    block_height bigint NOT NULL,
+    validator_count integer NOT NULL,
+    block_quota integer NOT NULL,
+    bps double precision NOT NULL,
+    tps double precision NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_sla_rollups OWNER TO postgres;
+
+--
+-- Name: etl_sla_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_sla_rollups_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_sla_rollups_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_sla_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_sla_rollups_id_seq OWNED BY public.etl_sla_rollups.id;
+
+
+--
+-- Name: etl_storage_proof_verifications; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_storage_proof_verifications (
+    id integer NOT NULL,
+    height bigint NOT NULL,
+    proof bytea NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_storage_proof_verifications OWNER TO postgres;
+
+--
+-- Name: etl_storage_proof_verifications_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_storage_proof_verifications_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_storage_proof_verifications_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_storage_proof_verifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_storage_proof_verifications_id_seq OWNED BY public.etl_storage_proof_verifications.id;
+
+
+--
+-- Name: etl_storage_proofs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_storage_proofs (
+    id integer NOT NULL,
+    height bigint NOT NULL,
+    address text NOT NULL,
+    prover_addresses text[] NOT NULL,
+    cid text NOT NULL,
+    proof_signature bytea,
+    proof bytea,
+    status public.etl_proof_status DEFAULT 'unresolved'::public.etl_proof_status NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_storage_proofs OWNER TO postgres;
+
+--
+-- Name: etl_storage_proofs_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_storage_proofs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_storage_proofs_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_storage_proofs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_storage_proofs_id_seq OWNED BY public.etl_storage_proofs.id;
+
+
+--
+-- Name: etl_transactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_transactions (
+    id integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    tx_index integer NOT NULL,
+    tx_type text NOT NULL,
+    address text,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_transactions OWNER TO postgres;
+
+--
+-- Name: etl_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_transactions_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_transactions_id_seq OWNED BY public.etl_transactions.id;
+
+
+--
+-- Name: etl_validator_deregistrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_validator_deregistrations (
+    id integer NOT NULL,
+    comet_address text NOT NULL,
+    comet_pubkey bytea NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL
+);
+
+
+ALTER TABLE public.etl_validator_deregistrations OWNER TO postgres;
+
+--
+-- Name: etl_validator_deregistrations_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_validator_deregistrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_validator_deregistrations_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_validator_deregistrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_validator_deregistrations_id_seq OWNED BY public.etl_validator_deregistrations.id;
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_validator_misbehavior_deregistrations (
+    id integer NOT NULL,
+    comet_address text NOT NULL,
+    pub_key bytea NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_validator_misbehavior_deregistrations OWNER TO postgres;
+
+--
+-- Name: etl_validator_misbehavior_deregistrations_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_validator_misbehavior_deregistrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_validator_misbehavior_deregistrations_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_validator_misbehavior_deregistrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_validator_misbehavior_deregistrations_id_seq OWNED BY public.etl_validator_misbehavior_deregistrations.id;
+
+
+--
+-- Name: etl_validator_registrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_validator_registrations (
+    id integer NOT NULL,
+    address text NOT NULL,
+    endpoint text NOT NULL,
+    comet_address text NOT NULL,
+    eth_block text NOT NULL,
+    node_type text NOT NULL,
+    spid text NOT NULL,
+    comet_pubkey bytea NOT NULL,
+    voting_power bigint NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL
+);
+
+
+ALTER TABLE public.etl_validator_registrations OWNER TO postgres;
+
+--
+-- Name: etl_validator_registrations_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_validator_registrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_validator_registrations_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_validator_registrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_validator_registrations_id_seq OWNED BY public.etl_validator_registrations.id;
+
+
+--
+-- Name: etl_validators; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.etl_validators (
+    id integer NOT NULL,
+    address text NOT NULL,
+    endpoint text NOT NULL,
+    comet_address text NOT NULL,
+    node_type text NOT NULL,
+    spid text NOT NULL,
+    voting_power bigint NOT NULL,
+    status text NOT NULL,
+    registered_at bigint NOT NULL,
+    deregistered_at bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.etl_validators OWNER TO postgres;
+
+--
+-- Name: etl_validators_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.etl_validators_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.etl_validators_id_seq OWNER TO postgres;
+
+--
+-- Name: etl_validators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.etl_validators_id_seq OWNED BY public.etl_validators.id;
+
+
+--
+-- Name: event_routes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.event_routes (
+    slug character varying NOT NULL,
+    title_slug character varying NOT NULL,
+    collision_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    event_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    txhash character varying
+);
+
+
+ALTER TABLE public.event_routes OWNER TO postgres;
+
+--
+-- Name: events; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.events (
+    event_id integer NOT NULL,
+    event_type public.event_type NOT NULL,
+    user_id integer NOT NULL,
+    entity_type public.event_entity_type,
+    entity_id integer,
+    end_date timestamp without time zone,
+    is_deleted boolean DEFAULT false,
+    event_data jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.events OWNER TO postgres;
+
+--
+-- Name: follows; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.follows (
+    blockhash character varying,
+    blocknumber integer,
+    follower_user_id integer NOT NULL,
+    followee_user_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer
+);
+
+
+ALTER TABLE public.follows OWNER TO postgres;
+
+--
+-- Name: grants; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.grants (
+    blockhash character varying,
+    blocknumber integer,
+    grantee_address character varying NOT NULL,
+    user_id integer NOT NULL,
+    is_revoked boolean DEFAULT false NOT NULL,
+    is_current boolean NOT NULL,
+    is_approved boolean,
+    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying NOT NULL
+);
+
+
+ALTER TABLE public.grants OWNER TO postgres;
+
+--
+-- Name: hourly_play_counts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.hourly_play_counts (
+    hourly_timestamp timestamp without time zone NOT NULL,
+    play_count integer NOT NULL
+);
+
+
+ALTER TABLE public.hourly_play_counts OWNER TO postgres;
+
+--
+-- Name: indexing_checkpoints; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.indexing_checkpoints (
+    tablename character varying NOT NULL,
+    last_checkpoint integer NOT NULL,
+    signature character varying
+);
+
+
+ALTER TABLE public.indexing_checkpoints OWNER TO postgres;
+
+--
+-- Name: management_keys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.management_keys (
+    id integer NOT NULL,
+    track_id text NOT NULL,
+    address text NOT NULL
+);
+
+
+ALTER TABLE public.management_keys OWNER TO postgres;
+
+--
+-- Name: management_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.management_keys_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.management_keys_id_seq OWNER TO postgres;
+
+--
+-- Name: management_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.management_keys_id_seq OWNED BY public.management_keys.id;
+
+
+--
+-- Name: milestones; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.milestones (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    threshold integer NOT NULL,
+    blocknumber integer,
+    slot integer,
+    "timestamp" timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.milestones OWNER TO postgres;
+
+--
+-- Name: muted_users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.muted_users (
+    muted_user_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_delete boolean DEFAULT false,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.muted_users OWNER TO postgres;
+
+--
+-- Name: mv_dashboard_transaction_stats; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.mv_dashboard_transaction_stats AS
+ WITH latest_block_time AS (
+         SELECT etl_blocks.block_time
+           FROM public.etl_blocks
+          ORDER BY etl_blocks.block_height DESC
+         LIMIT 1
+        ), time_periods AS (
+         SELECT lbt.block_time AS now_time,
+            (lbt.block_time - '24:00:00'::interval) AS h24_ago,
+            (lbt.block_time - '48:00:00'::interval) AS h48_ago,
+            (lbt.block_time - '7 days'::interval) AS d7_ago,
+            (lbt.block_time - '30 days'::interval) AS d30_ago
+           FROM latest_block_time lbt
+        )
+ SELECT count(*) FILTER (WHERE (t.created_at >= tp.h24_ago)) AS transactions_24h,
+    count(*) FILTER (WHERE ((t.created_at >= tp.h48_ago) AND (t.created_at < tp.h24_ago))) AS transactions_previous_24h,
+    count(*) FILTER (WHERE (t.created_at >= tp.d7_ago)) AS transactions_7d,
+    count(*) FILTER (WHERE (t.created_at >= tp.d30_ago)) AS transactions_30d,
+    count(*) AS total_transactions
+   FROM (time_periods tp
+     CROSS JOIN public.etl_transactions t)
+  WHERE (t.created_at <= tp.now_time)
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.mv_dashboard_transaction_stats OWNER TO postgres;
+
+--
+-- Name: mv_dashboard_transaction_types; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.mv_dashboard_transaction_types AS
+ WITH latest_block_time AS (
+         SELECT etl_blocks.block_time
+           FROM public.etl_blocks
+          ORDER BY etl_blocks.block_height DESC
+         LIMIT 1
+        )
+ SELECT t.tx_type,
+    count(*) AS transaction_count
+   FROM (public.etl_transactions t
+     CROSS JOIN latest_block_time lbt)
+  WHERE (t.created_at <= lbt.block_time)
+  GROUP BY t.tx_type
+  ORDER BY (count(*)) DESC
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.mv_dashboard_transaction_types OWNER TO postgres;
+
+--
+-- Name: notification; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.notification (
+    id integer NOT NULL,
+    specifier character varying NOT NULL,
+    group_id character varying NOT NULL,
+    type character varying NOT NULL,
+    slot integer,
+    blocknumber integer,
+    "timestamp" timestamp without time zone NOT NULL,
+    data jsonb,
+    user_ids integer[],
+    type_v2 character varying
+);
+
+
+ALTER TABLE public.notification OWNER TO postgres;
+
+--
+-- Name: notification_campaign_push_open; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.notification_campaign_push_open (
+    campaign_id uuid NOT NULL,
+    user_id integer NOT NULL,
+    opened_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.notification_campaign_push_open OWNER TO postgres;
+
+--
+-- Name: notification_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.notification_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.notification_id_seq OWNER TO postgres;
+
+--
+-- Name: notification_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.notification_id_seq OWNED BY public.notification.id;
+
+
+--
+-- Name: notification_seen; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.notification_seen (
+    user_id integer NOT NULL,
+    seen_at timestamp without time zone NOT NULL,
+    blocknumber integer,
+    blockhash character varying,
+    txhash character varying
+);
+
+
+ALTER TABLE public.notification_seen OWNER TO postgres;
+
+--
+-- Name: oauth_authorization_codes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.oauth_authorization_codes (
+    code character varying(255) NOT NULL,
+    client_id character varying(255) NOT NULL,
+    user_id integer NOT NULL,
+    redirect_uri text NOT NULL,
+    code_challenge character varying(255) NOT NULL,
+    code_challenge_method character varying(10) DEFAULT 'S256'::character varying NOT NULL,
+    scope character varying(50) NOT NULL,
+    expires_at timestamp with time zone DEFAULT (now() + '00:10:00'::interval) NOT NULL,
+    used boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.oauth_authorization_codes OWNER TO postgres;
+
+--
+-- Name: oauth_redirect_uris; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.oauth_redirect_uris (
+    id integer NOT NULL,
+    client_id character varying(255) NOT NULL,
+    redirect_uri text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.oauth_redirect_uris OWNER TO postgres;
+
+--
+-- Name: oauth_redirect_uris_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.oauth_redirect_uris_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.oauth_redirect_uris_id_seq OWNER TO postgres;
+
+--
+-- Name: oauth_redirect_uris_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.oauth_redirect_uris_id_seq OWNED BY public.oauth_redirect_uris.id;
+
+
+--
+-- Name: oauth_tokens; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.oauth_tokens (
+    token character varying(255) NOT NULL,
+    token_type character varying(10) NOT NULL,
+    client_id character varying(255) NOT NULL,
+    user_id integer NOT NULL,
+    scope character varying(50) NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    is_revoked boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    refresh_token_id character varying(255),
+    family_id character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.oauth_tokens OWNER TO postgres;
+
+--
+-- Name: payment_router_txs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.payment_router_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.payment_router_txs OWNER TO postgres;
+
+--
+-- Name: playlist_routes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.playlist_routes (
+    slug character varying NOT NULL,
+    title_slug character varying NOT NULL,
+    collision_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    playlist_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    blockhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    txhash character varying NOT NULL
+);
+
+
+ALTER TABLE public.playlist_routes OWNER TO postgres;
+
+--
+-- Name: playlist_seen; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.playlist_seen (
+    user_id integer NOT NULL,
+    playlist_id integer NOT NULL,
+    seen_at timestamp without time zone NOT NULL,
+    is_current boolean NOT NULL,
+    blocknumber integer,
+    blockhash character varying,
+    txhash character varying
+);
+
+
+ALTER TABLE public.playlist_seen OWNER TO postgres;
+
+--
+-- Name: playlist_tracks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.playlist_tracks (
+    playlist_id integer NOT NULL,
+    track_id integer NOT NULL,
+    is_removed boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.playlist_tracks OWNER TO postgres;
+
+--
+-- Name: playlist_trending_scores; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.playlist_trending_scores (
+    playlist_id integer NOT NULL,
+    type character varying NOT NULL,
+    version character varying NOT NULL,
+    time_range character varying NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.playlist_trending_scores OWNER TO postgres;
+
+--
+-- Name: playlists; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.playlists (
+    blockhash character varying,
+    blocknumber integer,
+    playlist_id integer NOT NULL,
+    playlist_owner_id integer NOT NULL,
+    is_album boolean NOT NULL,
+    is_private boolean NOT NULL,
+    playlist_name character varying,
+    playlist_contents jsonb NOT NULL,
+    playlist_image_multihash character varying,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    description character varying,
+    created_at timestamp without time zone NOT NULL,
+    upc character varying,
+    updated_at timestamp without time zone NOT NULL,
+    playlist_image_sizes_multihash character varying,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    last_added_to timestamp without time zone,
+    slot integer,
+    metadata_multihash character varying,
+    is_image_autogenerated boolean DEFAULT false NOT NULL,
+    stream_conditions jsonb,
+    ddex_app character varying,
+    ddex_release_ids jsonb,
+    artists jsonb,
+    copyright_line jsonb,
+    producer_copyright_line jsonb,
+    parental_warning_type character varying,
+    is_scheduled_release boolean DEFAULT false NOT NULL,
+    release_date timestamp without time zone,
+    is_stream_gated boolean DEFAULT false
+);
+
+
+ALTER TABLE public.playlists OWNER TO postgres;
+
+--
+-- Name: plays_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.plays_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.plays_id_seq OWNER TO postgres;
+
+--
+-- Name: plays_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.plays_id_seq OWNED BY public.plays.id;
+
+
+--
+-- Name: prizes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.prizes (
+    id integer NOT NULL,
+    prize_id character varying NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    weight integer DEFAULT 1 NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    metadata jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.prizes OWNER TO postgres;
+
+--
+-- Name: TABLE prizes; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.prizes IS 'Defines prizes available for claiming. Prizes are selected randomly based on weight.';
+
+
+--
+-- Name: prizes_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.prizes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.prizes_id_seq OWNER TO postgres;
+
+--
+-- Name: prizes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.prizes_id_seq OWNED BY public.prizes.id;
+
+
+--
+-- Name: reactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.reactions (
+    id integer NOT NULL,
+    reaction_value integer NOT NULL,
+    sender_wallet character varying NOT NULL,
+    reaction_type character varying NOT NULL,
+    reacted_to character varying NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.reactions OWNER TO postgres;
+
+--
+-- Name: reactions_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.reactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.reactions_id_seq OWNER TO postgres;
+
+--
+-- Name: reactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.reactions_id_seq OWNED BY public.reactions.id;
+
+
+--
+-- Name: related_artists; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.related_artists (
+    user_id integer NOT NULL,
+    related_artist_user_id integer NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.related_artists OWNER TO postgres;
+
+--
+-- Name: remixes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.remixes (
+    parent_track_id integer NOT NULL,
+    child_track_id integer NOT NULL
+);
+
+
+ALTER TABLE public.remixes OWNER TO postgres;
+
+--
+-- Name: reported_comments; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.reported_comments (
+    reported_comment_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash text NOT NULL,
+    blockhash text NOT NULL,
+    blocknumber integer
+);
+
+
+ALTER TABLE public.reported_comments OWNER TO postgres;
+
+--
+-- Name: reposts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.reposts (
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer NOT NULL,
+    repost_item_id integer NOT NULL,
+    repost_type public.reposttype NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer,
+    is_repost_of_repost boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.reposts OWNER TO postgres;
+
+--
+-- Name: revert_blocks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.revert_blocks (
+    blocknumber integer NOT NULL,
+    prev_records jsonb NOT NULL
+);
+
+
+ALTER TABLE public.revert_blocks OWNER TO postgres;
+
+--
+-- Name: reward_codes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.reward_codes (
+    code text NOT NULL,
+    mint text NOT NULL,
+    reward_address text NOT NULL,
+    amount bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    remaining_uses integer DEFAULT 1 NOT NULL,
+    signature text
+);
+
+
+ALTER TABLE public.reward_codes OWNER TO postgres;
+
+--
+-- Name: TABLE reward_codes; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.reward_codes IS 'Stores reward codes for distributing coins';
+
+
+--
+-- Name: COLUMN reward_codes.code; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.reward_codes.code IS 'Unique code for redemption';
+
+
+--
+-- Name: COLUMN reward_codes.mint; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.reward_codes.mint IS 'Coin mint address';
+
+
+--
+-- Name: COLUMN reward_codes.reward_address; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.reward_codes.reward_address IS 'Address of the reward instance onchain';
+
+
+--
+-- Name: COLUMN reward_codes.amount; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.reward_codes.amount IS 'Amount of coins to reward';
+
+
+--
+-- Name: COLUMN reward_codes.remaining_uses; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.reward_codes.remaining_uses IS 'Number of times the code can still be redeemed';
+
+
+--
+-- Name: COLUMN reward_codes.signature; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.reward_codes.signature IS 'Signature used to generate the reward code';
+
+
+--
+-- Name: reward_manager_txs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.reward_manager_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.reward_manager_txs OWNER TO postgres;
+
+--
+-- Name: route_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.route_metrics (
+    route_path character varying NOT NULL,
+    version character varying NOT NULL,
+    query_string character varying DEFAULT ''::character varying NOT NULL,
+    count integer NOT NULL,
+    "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    id bigint NOT NULL,
+    ip character varying
+);
+
+
+ALTER TABLE public.route_metrics OWNER TO postgres;
+
+--
+-- Name: route_metrics_all_time; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_all_time AS
+ SELECT count(DISTINCT route_metrics.ip) AS unique_count,
+    sum(route_metrics.count) AS count
+   FROM public.route_metrics
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.route_metrics_all_time OWNER TO postgres;
+
+--
+-- Name: route_metrics_day_bucket; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_day_bucket AS
+ SELECT count(DISTINCT route_metrics.ip) AS unique_count,
+    sum(route_metrics.count) AS count,
+    date_trunc('day'::text, route_metrics."timestamp") AS "time"
+   FROM public.route_metrics
+  GROUP BY (date_trunc('day'::text, route_metrics."timestamp"))
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.route_metrics_day_bucket OWNER TO postgres;
+
+--
+-- Name: route_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.route_metrics ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.route_metrics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: route_metrics_month_bucket; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_month_bucket AS
+ SELECT count(DISTINCT route_metrics.ip) AS unique_count,
+    sum(route_metrics.count) AS count,
+    date_trunc('month'::text, route_metrics."timestamp") AS "time"
+   FROM public.route_metrics
+  GROUP BY (date_trunc('month'::text, route_metrics."timestamp"))
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.route_metrics_month_bucket OWNER TO postgres;
+
+--
+-- Name: route_metrics_trailing_month; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_trailing_month AS
+ SELECT count(DISTINCT route_metrics.ip) AS unique_count,
+    sum(route_metrics.count) AS count
+   FROM public.route_metrics
+  WHERE (route_metrics."timestamp" > (now() - '1 mon'::interval))
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.route_metrics_trailing_month OWNER TO postgres;
+
+--
+-- Name: route_metrics_trailing_week; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.route_metrics_trailing_week AS
+ SELECT count(DISTINCT route_metrics.ip) AS unique_count,
+    sum(route_metrics.count) AS count
+   FROM public.route_metrics
+  WHERE (route_metrics."timestamp" > (now() - '7 days'::interval))
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.route_metrics_trailing_week OWNER TO postgres;
+
+--
+-- Name: rpc_cursor; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.rpc_cursor (
+    relayed_by text NOT NULL,
+    relayed_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.rpc_cursor OWNER TO postgres;
+
+--
+-- Name: rpc_error; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.rpc_error (
+    sig text NOT NULL,
+    rpc_log_json jsonb NOT NULL,
+    error_text text NOT NULL,
+    error_count integer DEFAULT 0 NOT NULL,
+    last_attempt timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.rpc_error OWNER TO postgres;
+
+--
+-- Name: rpc_log; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.rpc_log (
+    relayed_at timestamp without time zone NOT NULL,
+    from_wallet text NOT NULL,
+    rpc json NOT NULL,
+    sig text NOT NULL,
+    relayed_by text NOT NULL,
+    applied_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.rpc_log OWNER TO postgres;
+
+--
+-- Name: saves; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.saves (
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer NOT NULL,
+    save_item_id integer NOT NULL,
+    save_type public.savetype NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer,
+    is_save_of_repost boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.saves OWNER TO postgres;
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migrations OWNER TO postgres;
+
+--
+-- Name: schema_version; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_version (
+    file_name text NOT NULL,
+    md5 text,
+    applied_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.schema_version OWNER TO postgres;
+
+--
+-- Name: shares; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.shares (
+    blockhash character varying,
+    blocknumber integer,
+    user_id integer NOT NULL,
+    share_item_id integer NOT NULL,
+    share_type public.sharetype NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    slot integer
+);
+
+
+ALTER TABLE public.shares OWNER TO postgres;
+
+--
+-- Name: skipped_transactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.skipped_transactions (
+    id integer NOT NULL,
+    blocknumber integer NOT NULL,
+    blockhash character varying NOT NULL,
+    txhash character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    level public.skippedtransactionlevel DEFAULT 'node'::public.skippedtransactionlevel NOT NULL
+);
+
+
+ALTER TABLE public.skipped_transactions OWNER TO postgres;
+
+--
+-- Name: skipped_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.skipped_transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.skipped_transactions_id_seq OWNER TO postgres;
+
+--
+-- Name: skipped_transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.skipped_transactions_id_seq OWNED BY public.skipped_transactions.id;
+
+
+--
+-- Name: sla_auditor_version_data; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sla_auditor_version_data (
+    id integer NOT NULL,
+    "nodeEndpoint" character varying(255) NOT NULL,
+    "nodeVersion" character varying(255) NOT NULL,
+    "minVersion" character varying(255) NOT NULL,
+    owner character varying(255) NOT NULL,
+    ok boolean NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.sla_auditor_version_data OWNER TO postgres;
+
+--
+-- Name: sla_auditor_version_data_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.sla_auditor_version_data_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.sla_auditor_version_data_id_seq OWNER TO postgres;
+
+--
+-- Name: sla_auditor_version_data_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.sla_auditor_version_data_id_seq OWNED BY public.sla_auditor_version_data.id;
+
+
+--
+-- Name: sla_node_reports; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sla_node_reports (
+    id integer NOT NULL,
+    address character varying NOT NULL,
+    blocks_proposed integer NOT NULL,
+    sla_rollup_id integer
+);
+
+
+ALTER TABLE public.sla_node_reports OWNER TO postgres;
+
+--
+-- Name: sla_node_reports_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.sla_node_reports_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.sla_node_reports_id_seq OWNER TO postgres;
+
+--
+-- Name: sla_node_reports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.sla_node_reports_id_seq OWNED BY public.sla_node_reports.id;
+
+
+--
+-- Name: sla_rollups; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sla_rollups (
+    id integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_start bigint NOT NULL,
+    block_end bigint NOT NULL,
+    "time" timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.sla_rollups OWNER TO postgres;
+
+--
+-- Name: sla_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.sla_rollups_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.sla_rollups_id_seq OWNER TO postgres;
+
+--
+-- Name: sla_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.sla_rollups_id_seq OWNED BY public.sla_rollups.id;
+
+
+--
+-- Name: sol_claimable_account_transfers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_claimable_account_transfers (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    from_account character varying NOT NULL,
+    to_account character varying NOT NULL,
+    sender_eth_address character varying NOT NULL
+);
+
+
+ALTER TABLE public.sol_claimable_account_transfers OWNER TO postgres;
+
+--
+-- Name: TABLE sol_claimable_account_transfers; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_claimable_account_transfers IS 'Stores claimable tokens program Transfer instructions for tracked mints.';
+
+
+--
+-- Name: sol_claimable_accounts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_claimable_accounts (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    mint character varying NOT NULL,
+    ethereum_address character varying NOT NULL,
+    account character varying NOT NULL
+);
+
+
+ALTER TABLE public.sol_claimable_accounts OWNER TO postgres;
+
+--
+-- Name: TABLE sol_claimable_accounts; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_claimable_accounts IS 'Stores claimable tokens program Create instructions for tracked mints.';
+
+
+--
+-- Name: sol_keypairs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_keypairs (
+    public_key character varying NOT NULL,
+    private_key bytea NOT NULL
+);
+
+
+ALTER TABLE public.sol_keypairs OWNER TO postgres;
+
+--
+-- Name: sol_locker_vesting_escrows; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_locker_vesting_escrows (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    recipient text NOT NULL,
+    token_mint text NOT NULL,
+    creator text NOT NULL,
+    base text NOT NULL,
+    escrow_bump smallint NOT NULL,
+    update_recipient_mode smallint NOT NULL,
+    cancel_mode smallint NOT NULL,
+    token_program_flag smallint NOT NULL,
+    cliff_time bigint NOT NULL,
+    frequency bigint NOT NULL,
+    cliff_unlock_amount bigint NOT NULL,
+    amount_per_period bigint NOT NULL,
+    number_of_period bigint NOT NULL,
+    total_claimed_amount bigint NOT NULL,
+    vesting_start_time bigint NOT NULL,
+    cancelled_at bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.sol_locker_vesting_escrows OWNER TO postgres;
+
+--
+-- Name: sol_meteora_damm_v2_initialize_custom_pool_instructions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_initialize_custom_pool_instructions (
+    signature text NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    creator text,
+    position_nft_mint text,
+    position_nft_account text,
+    payer text,
+    pool_authority text,
+    pool text,
+    "position" text,
+    token_a_mint text,
+    token_b_mint text,
+    token_a_vault text,
+    token_b_vault text,
+    payer_token_a text,
+    payer_token_b text,
+    token_a_program text,
+    token_b_program text,
+    token_2022_program text,
+    system_program text,
+    event_authority text,
+    program text,
+    remaining_accounts jsonb DEFAULT '[]'::jsonb,
+    base_fee_cliff_fee_numerator bigint,
+    base_fee_first_factor integer,
+    base_fee_second_factor_max_limiter_duration integer,
+    base_fee_second_factor_max_fee_bps integer,
+    base_fee_third_factor bigint,
+    base_fee_mode smallint,
+    dynamic_fee_bin_step smallint,
+    dynamic_fee_bin_step_u128 numeric,
+    dynamic_fee_filter_period smallint,
+    dynamic_fee_decay_period smallint,
+    dynamic_fee_reduction_factor smallint,
+    dynamic_fee_max_volatility_accumulator integer,
+    dynamic_fee_variable_fee_control integer,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_initialize_custom_pool_instructions OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_initialize_custom_pool_instructions; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_initialize_custom_pool_instructions IS 'Tracks InitializeCustomPool instructions for DAMM V2 pools.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_base_fees; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_base_fees (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    cliff_fee_numerator bigint NOT NULL,
+    fee_scheduler_mode smallint NOT NULL,
+    number_of_period smallint NOT NULL,
+    period_frequency bigint NOT NULL,
+    reduction_factor bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_pool_base_fees OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_base_fees; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_base_fees IS 'Tracks base fee configuration for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_dynamic_fees; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_dynamic_fees (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    initialized smallint NOT NULL,
+    max_volatility_accumulator integer NOT NULL,
+    variable_fee_control integer NOT NULL,
+    bin_step smallint NOT NULL,
+    filter_period smallint NOT NULL,
+    decay_period smallint NOT NULL,
+    reduction_factor smallint NOT NULL,
+    last_update_timestamp bigint NOT NULL,
+    bin_step_u128 numeric NOT NULL,
+    sqrt_price_reference numeric NOT NULL,
+    volatility_accumulator numeric NOT NULL,
+    volatility_reference numeric NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_pool_dynamic_fees OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_dynamic_fees; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_dynamic_fees IS 'Tracks dynamic fee configuration for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_fees; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_fees (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    protocol_fee_percent smallint NOT NULL,
+    partner_fee_percent smallint NOT NULL,
+    referral_fee_percent smallint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_pool_fees OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_fees; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_fees IS 'Tracks fee configuration for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_pool_metrics (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    total_lp_a_fee numeric NOT NULL,
+    total_lp_b_fee numeric NOT NULL,
+    total_protocol_a_fee numeric NOT NULL,
+    total_protocol_b_fee numeric NOT NULL,
+    total_partner_a_fee numeric NOT NULL,
+    total_partner_b_fee numeric NOT NULL,
+    total_position bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_pool_metrics OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_pool_metrics; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_pool_metrics IS 'Tracks aggregated metrics for DAMM V2 pools. A slice of the DAMM V2 pool state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_position_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_position_metrics (
+    "position" text NOT NULL,
+    slot bigint NOT NULL,
+    total_claimed_a_fee bigint NOT NULL,
+    total_claimed_b_fee bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_position_metrics OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_position_metrics; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_position_metrics IS 'Tracks aggregated metrics for DAMM V2 positions. A slice of the DAMM V2 position state.';
+
+
+--
+-- Name: sol_meteora_damm_v2_positions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_damm_v2_positions (
+    account text NOT NULL,
+    slot bigint NOT NULL,
+    pool text NOT NULL,
+    nft_mint text NOT NULL,
+    fee_a_per_token_checkpoint bigint NOT NULL,
+    fee_b_per_token_checkpoint bigint NOT NULL,
+    fee_a_pending bigint NOT NULL,
+    fee_b_pending bigint NOT NULL,
+    unlocked_liquidity numeric NOT NULL,
+    vested_liquidity numeric NOT NULL,
+    permanent_locked_liquidity numeric NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_damm_v2_positions OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_damm_v2_positions; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_damm_v2_positions IS 'Tracks DAMM V2 positions representing a claim to the liquidity and associated fees in a DAMM V2 pool. Join with sol_meteora_damm_v2_position_metrics for full position state.';
+
+
+--
+-- Name: sol_meteora_dbc_config_fees; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_config_fees (
+    config text NOT NULL,
+    slot bigint NOT NULL,
+    base_fee_cliff_fee_numerator bigint,
+    base_fee_period_frequency bigint,
+    base_fee_reduction_factor bigint,
+    base_fee_number_of_period smallint,
+    base_fee_fee_scheduler_mode smallint,
+    dynamic_fee_initialized smallint,
+    dynamic_fee_max_volatility_accumulator integer,
+    dynamic_fee_variable_fee_control integer,
+    dynamic_fee_bin_step smallint,
+    dynamic_fee_filter_period smallint,
+    dynamic_fee_decay_period smallint,
+    dynamic_fee_reduction_factor smallint,
+    dynamic_fee_bin_step_u128 numeric,
+    protocol_fee_percent smallint,
+    referral_fee_percent smallint
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_config_fees OWNER TO postgres;
+
+--
+-- Name: sol_meteora_dbc_config_vestings; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_config_vestings (
+    config text NOT NULL,
+    slot bigint NOT NULL,
+    amount_per_period bigint,
+    cliff_duration_from_migration_time bigint,
+    frequency bigint,
+    number_of_period bigint,
+    cliff_unlock_amount bigint
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_config_vestings OWNER TO postgres;
+
+--
+-- Name: sol_meteora_dbc_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_migrations (
+    signature text NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    dbc_pool text NOT NULL,
+    migration_metadata text NOT NULL,
+    config text NOT NULL,
+    dbc_pool_authority text NOT NULL,
+    damm_v2_pool text NOT NULL,
+    first_position_nft_mint text NOT NULL,
+    first_position_nft_account text NOT NULL,
+    first_position text NOT NULL,
+    second_position_nft_mint text NOT NULL,
+    second_position_nft_account text NOT NULL,
+    second_position text NOT NULL,
+    damm_pool_authority text NOT NULL,
+    base_mint text NOT NULL,
+    quote_mint text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_migrations OWNER TO postgres;
+
+--
+-- Name: TABLE sol_meteora_dbc_migrations; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_meteora_dbc_migrations IS 'Tracks migrations from DBC pools to DAMM V2 pools.';
+
+
+--
+-- Name: sol_meteora_dbc_pool_metrics; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_pool_metrics (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    total_protocol_base_fee bigint NOT NULL,
+    total_protocol_quote_fee bigint NOT NULL,
+    total_trading_base_fee bigint NOT NULL,
+    total_trading_quote_fee bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_pool_metrics OWNER TO postgres;
+
+--
+-- Name: sol_meteora_dbc_pool_volatility_trackers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_meteora_dbc_pool_volatility_trackers (
+    pool text NOT NULL,
+    slot bigint NOT NULL,
+    last_update_timestamp bigint NOT NULL,
+    volatility_accumulator numeric NOT NULL,
+    volatility_reference numeric NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_meteora_dbc_pool_volatility_trackers OWNER TO postgres;
+
+--
+-- Name: sol_payments; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_payments (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    route_index integer NOT NULL,
+    to_account character varying NOT NULL
+);
+
+
+ALTER TABLE public.sol_payments OWNER TO postgres;
+
+--
+-- Name: TABLE sol_payments; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_payments IS 'Stores payment router program Route instruction recipients and amounts for tracked mints.';
+
+
+--
+-- Name: sol_purchases; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_purchases (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    from_account character varying NOT NULL,
+    content_type character varying NOT NULL,
+    content_id integer NOT NULL,
+    buyer_user_id integer NOT NULL,
+    access_type character varying NOT NULL,
+    valid_after_blocknumber bigint NOT NULL,
+    is_valid boolean,
+    city character varying,
+    region character varying,
+    country character varying,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.sol_purchases OWNER TO postgres;
+
+--
+-- Name: TABLE sol_purchases; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_purchases IS 'Stores payment router program Route instructions that are paired with purchase information for tracked mints.';
+
+
+--
+-- Name: COLUMN sol_purchases.valid_after_blocknumber; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_purchases.valid_after_blocknumber IS 'Purchase transactions include the blocknumber that the content was most recently updated in order to ensure that the relevant pricing information has been indexed before evaluating whether the purchase is valid.';
+
+
+--
+-- Name: COLUMN sol_purchases.is_valid; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_purchases.is_valid IS 'A purchase is valid if it meets the pricing information set by the artist. If the pricing information is not available yet (as indicated by the valid_after_blocknumber), then is_valid will be NULL which indicates a "pending" state.';
+
+
+--
+-- Name: sol_retry_queue; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_retry_queue (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    indexer text NOT NULL,
+    update_message jsonb NOT NULL,
+    error text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_retry_queue OWNER TO postgres;
+
+--
+-- Name: TABLE sol_retry_queue; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_retry_queue IS 'Queue for retrying failed indexer updates.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.indexer; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.indexer IS 'The name of the indexer that failed (e.g., token_indexer, damm_v2_indexer).';
+
+
+--
+-- Name: COLUMN sol_retry_queue.update_message; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.update_message IS 'The JSONB update data that failed to process.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.error; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.error IS 'The error message from the failure.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.created_at; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.created_at IS 'The timestamp when the retry entry was created.';
+
+
+--
+-- Name: COLUMN sol_retry_queue.updated_at; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_retry_queue.updated_at IS 'The timestamp when the retry entry was last updated.';
+
+
+--
+-- Name: sol_reward_disbursements; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_reward_disbursements (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    user_bank character varying NOT NULL,
+    challenge_id character varying NOT NULL,
+    specifier character varying NOT NULL,
+    recipient_eth_address text,
+    created_at timestamp without time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.sol_reward_disbursements OWNER TO postgres;
+
+--
+-- Name: TABLE sol_reward_disbursements; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_reward_disbursements IS 'Stores reward manager program Evaluate instructions for tracked mints.';
+
+
+--
+-- Name: COLUMN sol_reward_disbursements.recipient_eth_address; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_disbursements.recipient_eth_address IS 'The Ethereum address of the recipient of the reward.';
+
+
+--
+-- Name: sol_reward_manager_inits; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_reward_manager_inits (
+    signature text NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    min_votes integer NOT NULL,
+    reward_manager_state text NOT NULL,
+    token_source text NOT NULL,
+    mint text NOT NULL,
+    manager text NOT NULL,
+    authority text NOT NULL
+);
+
+
+ALTER TABLE public.sol_reward_manager_inits OWNER TO postgres;
+
+--
+-- Name: TABLE sol_reward_manager_inits; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_reward_manager_inits IS 'Stores Init instructions for the Reward Manager program';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.min_votes; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.min_votes IS 'Minimum number of votes required for reward distribution';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.reward_manager_state; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.reward_manager_state IS 'Public key of the Reward Manager state account';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.token_source; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.token_source IS 'Public key of the token source account (Note: Any token account on the authority account is valid)';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.mint; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.mint IS 'Public key of the mint for the token source account';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.manager; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.manager IS 'Public key of the manager account that initially has authority to create and remove senders without quorum';
+
+
+--
+-- Name: COLUMN sol_reward_manager_inits.authority; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_reward_manager_inits.authority IS 'Public key of the authority account, which holds the token accounts that reward manager can disburse from';
+
+
+--
+-- Name: sol_slot_checkpoints; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_slot_checkpoints (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    from_slot bigint NOT NULL,
+    to_slot bigint NOT NULL,
+    subscription_hash text NOT NULL,
+    subscription jsonb NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    name text
+);
+
+
+ALTER TABLE public.sol_slot_checkpoints OWNER TO postgres;
+
+--
+-- Name: TABLE sol_slot_checkpoints; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_slot_checkpoints IS 'Stores checkpoints for Solana slots to track indexing progress.';
+
+
+--
+-- Name: COLUMN sol_slot_checkpoints.name; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_slot_checkpoints.name IS 'The name of the indexer this checkpoint is for (e.g., token_indexer, damm_v2_indexer).';
+
+
+--
+-- Name: sol_token_account_balance_changes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_token_account_balance_changes (
+    signature character varying NOT NULL,
+    mint character varying NOT NULL,
+    owner character varying NOT NULL,
+    account character varying NOT NULL,
+    change bigint NOT NULL,
+    balance bigint NOT NULL,
+    slot bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    fee_payer character varying
+);
+
+
+ALTER TABLE public.sol_token_account_balance_changes OWNER TO postgres;
+
+--
+-- Name: TABLE sol_token_account_balance_changes; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_token_account_balance_changes IS 'Stores token balance changes for all accounts of tracked mints.';
+
+
+--
+-- Name: COLUMN sol_token_account_balance_changes.fee_payer; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.sol_token_account_balance_changes.fee_payer IS 'The public key of the account that paid the fee for the transaction.';
+
+
+--
+-- Name: sol_token_account_balances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_token_account_balances (
+    account character varying NOT NULL,
+    mint character varying NOT NULL,
+    owner character varying NOT NULL,
+    balance bigint NOT NULL,
+    slot bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_token_account_balances OWNER TO postgres;
+
+--
+-- Name: TABLE sol_token_account_balances; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_token_account_balances IS 'Stores current token balances for all accounts of tracked mints.';
+
+
+--
+-- Name: sol_token_transfers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_token_transfers (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    amount bigint NOT NULL,
+    slot bigint NOT NULL,
+    from_account character varying NOT NULL,
+    to_account character varying NOT NULL
+);
+
+
+ALTER TABLE public.sol_token_transfers OWNER TO postgres;
+
+--
+-- Name: TABLE sol_token_transfers; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_token_transfers IS 'Stores SPL token transfers for tracked mints.';
+
+
+--
+-- Name: sol_transfer_memo_types; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_transfer_memo_types (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    memo_type character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.sol_transfer_memo_types OWNER TO postgres;
+
+--
+-- Name: TABLE sol_transfer_memo_types; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_transfer_memo_types IS 'Memo-tagged classifications for claimable_tokens transfers and payment_router routes. memo_type is one of: withdrawal, prepare_withdrawal, internal_transfer, recover_withdrawal.';
+
+
+--
+-- Name: sol_user_balances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sol_user_balances (
+    user_id integer NOT NULL,
+    mint text NOT NULL,
+    balance bigint NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.sol_user_balances OWNER TO postgres;
+
+--
+-- Name: TABLE sol_user_balances; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.sol_user_balances IS 'Stores the balances of Solana tokens for users.';
+
+
+--
+-- Name: sound_recordings; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sound_recordings (
+    id integer NOT NULL,
+    sound_recording_id text NOT NULL,
+    track_id text NOT NULL,
+    cid text NOT NULL,
+    encoding_details text
+);
+
+
+ALTER TABLE public.sound_recordings OWNER TO postgres;
+
+--
+-- Name: sound_recordings_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.sound_recordings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.sound_recordings_id_seq OWNER TO postgres;
+
+--
+-- Name: sound_recordings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.sound_recordings_id_seq OWNED BY public.sound_recordings.id;
+
+
+--
+-- Name: spl_token_tx; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.spl_token_tx (
+    last_scanned_slot integer NOT NULL,
+    signature character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.spl_token_tx OWNER TO postgres;
+
+--
+-- Name: stems; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.stems (
+    parent_track_id integer NOT NULL,
+    child_track_id integer NOT NULL
+);
+
+
+ALTER TABLE public.stems OWNER TO postgres;
+
+--
+-- Name: storage_proof_peers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.storage_proof_peers (
+    id integer NOT NULL,
+    block_height bigint NOT NULL,
+    prover_addresses text[] NOT NULL
+);
+
+
+ALTER TABLE public.storage_proof_peers OWNER TO postgres;
+
+--
+-- Name: storage_proof_peers_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.storage_proof_peers_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.storage_proof_peers_id_seq OWNER TO postgres;
+
+--
+-- Name: storage_proof_peers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.storage_proof_peers_id_seq OWNED BY public.storage_proof_peers.id;
+
+
+--
+-- Name: storage_proofs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.storage_proofs (
+    id integer NOT NULL,
+    block_height bigint NOT NULL,
+    address text NOT NULL,
+    cid text,
+    proof_signature text,
+    proof text,
+    prover_addresses text[] DEFAULT '{}'::text[] NOT NULL,
+    status public.proof_status DEFAULT 'unresolved'::public.proof_status NOT NULL
+);
+
+
+ALTER TABLE public.storage_proofs OWNER TO postgres;
+
+--
+-- Name: storage_proofs_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.storage_proofs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.storage_proofs_id_seq OWNER TO postgres;
+
+--
+-- Name: storage_proofs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.storage_proofs_id_seq OWNED BY public.storage_proofs.id;
+
+
+--
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.subscriptions (
+    blockhash character varying,
+    blocknumber integer,
+    subscriber_id integer NOT NULL,
+    user_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    is_delete boolean NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    entity_type text DEFAULT 'User'::text NOT NULL,
+    entity_id integer
+);
+
+
+ALTER TABLE public.subscriptions OWNER TO postgres;
+
+--
+-- Name: supporter_rank_ups; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.supporter_rank_ups (
+    slot integer NOT NULL,
+    sender_user_id integer NOT NULL,
+    receiver_user_id integer NOT NULL,
+    rank integer NOT NULL
+);
+
+
+ALTER TABLE public.supporter_rank_ups OWNER TO postgres;
+
+--
+-- Name: tag_track_user; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.tag_track_user AS
+ SELECT unnest(t.tags) AS tag,
+    t.track_id,
+    t.owner_id
+   FROM ( SELECT string_to_array(lower((tracks.tags)::text), ','::text) AS tags,
+            tracks.track_id,
+            tracks.owner_id
+           FROM public.tracks
+          WHERE (((tracks.tags)::text <> ''::text) AND (tracks.tags IS NOT NULL) AND (tracks.is_current IS TRUE) AND (tracks.is_unlisted IS FALSE) AND (tracks.stem_of IS NULL))
+          ORDER BY tracks.updated_at DESC) t
+  GROUP BY (unnest(t.tags)), t.track_id, t.owner_id
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.tag_track_user OWNER TO postgres;
+
+--
+-- Name: track_collaborators; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_collaborators (
+    track_id integer NOT NULL,
+    collaborator_user_id integer NOT NULL,
+    invited_by integer NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    txhash character varying NOT NULL,
+    blocknumber integer,
+    CONSTRAINT track_collaborators_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'accepted'::text, 'rejected'::text])))
+);
+
+
+ALTER TABLE public.track_collaborators OWNER TO postgres;
+
+--
+-- Name: TABLE track_collaborators; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.track_collaborators IS 'Collaborator credits on a track. Owner invites via track metadata (status=pending); the collaborator accepts/declines on-chain (accepted/rejected). Indexed by ETL (go-openaudio).';
+
+
+--
+-- Name: track_delist_statuses; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_delist_statuses (
+    created_at timestamp with time zone NOT NULL,
+    track_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    track_cid character varying NOT NULL,
+    delisted boolean NOT NULL,
+    reason public.delist_track_reason NOT NULL
+);
+
+
+ALTER TABLE public.track_delist_statuses OWNER TO postgres;
+
+--
+-- Name: track_downloads; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_downloads (
+    txhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    parent_track_id integer NOT NULL,
+    track_id integer NOT NULL,
+    user_id integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    city character varying,
+    region character varying,
+    country character varying
+);
+
+
+ALTER TABLE public.track_downloads OWNER TO postgres;
+
+--
+-- Name: track_price_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_price_history (
+    track_id integer NOT NULL,
+    splits jsonb NOT NULL,
+    total_price_cents bigint NOT NULL,
+    blocknumber integer NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    access public.usdc_purchase_access_type DEFAULT 'stream'::public.usdc_purchase_access_type NOT NULL
+);
+
+
+ALTER TABLE public.track_price_history OWNER TO postgres;
+
+--
+-- Name: track_releases; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_releases (
+    id integer NOT NULL,
+    track_id text NOT NULL
+);
+
+
+ALTER TABLE public.track_releases OWNER TO postgres;
+
+--
+-- Name: track_releases_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.track_releases_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.track_releases_id_seq OWNER TO postgres;
+
+--
+-- Name: track_releases_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.track_releases_id_seq OWNED BY public.track_releases.id;
+
+
+--
+-- Name: track_routes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_routes (
+    slug character varying NOT NULL,
+    title_slug character varying NOT NULL,
+    collision_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    track_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    blockhash character varying NOT NULL,
+    blocknumber integer NOT NULL,
+    txhash character varying NOT NULL
+);
+
+
+ALTER TABLE public.track_routes OWNER TO postgres;
+
+--
+-- Name: track_trending_scores; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.track_trending_scores (
+    track_id integer NOT NULL,
+    type character varying NOT NULL,
+    genre character varying,
+    version character varying NOT NULL,
+    time_range character varying NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.track_trending_scores OWNER TO postgres;
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.users (
+    blockhash character varying,
+    user_id integer NOT NULL,
+    is_current boolean NOT NULL,
+    handle character varying,
+    wallet character varying,
+    name text,
+    profile_picture character varying,
+    cover_photo character varying,
+    bio character varying,
+    location character varying,
+    metadata_multihash character varying,
+    creator_node_endpoint character varying,
+    blocknumber integer,
+    is_verified boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    handle_lc character varying,
+    cover_photo_sizes character varying,
+    profile_picture_sizes character varying,
+    primary_id integer,
+    secondary_ids integer[],
+    replica_set_update_signer character varying,
+    has_collectibles boolean DEFAULT false NOT NULL,
+    txhash character varying DEFAULT ''::character varying NOT NULL,
+    playlist_library jsonb,
+    is_deactivated boolean DEFAULT false NOT NULL,
+    slot integer,
+    user_storage_account character varying,
+    user_authority_account character varying,
+    artist_pick_track_id integer,
+    is_available boolean DEFAULT true NOT NULL,
+    is_storage_v2 boolean DEFAULT false NOT NULL,
+    allow_ai_attribution boolean DEFAULT false NOT NULL,
+    spl_usdc_payout_wallet character varying,
+    twitter_handle character varying,
+    instagram_handle character varying,
+    tiktok_handle character varying,
+    verified_with_twitter boolean DEFAULT false,
+    verified_with_instagram boolean DEFAULT false,
+    verified_with_tiktok boolean DEFAULT false,
+    website character varying,
+    donation character varying,
+    profile_type public.profile_type_enum,
+    coin_flair_mint text,
+    last_active_at timestamp with time zone
+);
+
+
+ALTER TABLE public.users OWNER TO postgres;
+
+--
+-- Name: COLUMN users.coin_flair_mint; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.users.coin_flair_mint IS 'The mint of the coin which the user has selected as their preferred flair. NULL for auto, empty string for none.';
+
+
+--
+-- Name: COLUMN users.last_active_at; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.users.last_active_at IS 'Timestamp of the user''s most recent app-open event, updated by POST /v1/users/me/ping.';
+
+
+--
+-- Name: trending_params; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW public.trending_params AS
+ SELECT t.track_id,
+    t.release_date,
+    t.genre,
+    t.owner_id,
+    ap.play_count,
+    au.follower_count AS owner_follower_count,
+    COALESCE(aggregate_track.repost_count, 0) AS repost_count,
+    COALESCE(aggregate_track.save_count, 0) AS save_count,
+    COALESCE(repost_week.repost_count, (0)::bigint) AS repost_week_count,
+    COALESCE(repost_month.repost_count, (0)::bigint) AS repost_month_count,
+    COALESCE(repost_year.repost_count, (0)::bigint) AS repost_year_count,
+    COALESCE(save_week.repost_count, (0)::bigint) AS save_week_count,
+    COALESCE(save_month.repost_count, (0)::bigint) AS save_month_count,
+    COALESCE(save_year.repost_count, (0)::bigint) AS save_year_count,
+    COALESCE(karma.karma, (0)::numeric) AS karma
+   FROM ((((((((((public.tracks t
+     LEFT JOIN ( SELECT ap_1.count AS play_count,
+            ap_1.play_item_id
+           FROM public.aggregate_plays ap_1) ap ON ((ap.play_item_id = t.track_id)))
+     LEFT JOIN ( SELECT au_1.user_id,
+            au_1.follower_count
+           FROM public.aggregate_user au_1) au ON ((au.user_id = t.owner_id)))
+     LEFT JOIN ( SELECT aggregate_track_1.track_id,
+            aggregate_track_1.repost_count,
+            aggregate_track_1.save_count
+           FROM public.aggregate_track aggregate_track_1) aggregate_track ON ((aggregate_track.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.repost_item_id AS track_id,
+            count(r.repost_item_id) AS repost_count
+           FROM public.reposts r
+          WHERE ((r.is_current IS TRUE) AND (r.repost_type = 'track'::public.reposttype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 year'::interval)))
+          GROUP BY r.repost_item_id) repost_year ON ((repost_year.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.repost_item_id AS track_id,
+            count(r.repost_item_id) AS repost_count
+           FROM public.reposts r
+          WHERE ((r.is_current IS TRUE) AND (r.repost_type = 'track'::public.reposttype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 mon'::interval)))
+          GROUP BY r.repost_item_id) repost_month ON ((repost_month.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.repost_item_id AS track_id,
+            count(r.repost_item_id) AS repost_count
+           FROM public.reposts r
+          WHERE ((r.is_current IS TRUE) AND (r.repost_type = 'track'::public.reposttype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '7 days'::interval)))
+          GROUP BY r.repost_item_id) repost_week ON ((repost_week.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.save_item_id AS track_id,
+            count(r.save_item_id) AS repost_count
+           FROM public.saves r
+          WHERE ((r.is_current IS TRUE) AND (r.save_type = 'track'::public.savetype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 year'::interval)))
+          GROUP BY r.save_item_id) save_year ON ((save_year.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.save_item_id AS track_id,
+            count(r.save_item_id) AS repost_count
+           FROM public.saves r
+          WHERE ((r.is_current IS TRUE) AND (r.save_type = 'track'::public.savetype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '1 mon'::interval)))
+          GROUP BY r.save_item_id) save_month ON ((save_month.track_id = t.track_id)))
+     LEFT JOIN ( SELECT r.save_item_id AS track_id,
+            count(r.save_item_id) AS repost_count
+           FROM public.saves r
+          WHERE ((r.is_current IS TRUE) AND (r.save_type = 'track'::public.savetype) AND (r.is_delete IS FALSE) AND (r.created_at > (now() - '7 days'::interval)))
+          GROUP BY r.save_item_id) save_week ON ((save_week.track_id = t.track_id)))
+     LEFT JOIN ( SELECT save_and_reposts.item_id AS track_id,
+            sum(au_1.follower_count) AS karma
+           FROM (( SELECT r_and_s.user_id,
+                    r_and_s.item_id
+                   FROM (( SELECT reposts.user_id,
+                            reposts.repost_item_id AS item_id
+                           FROM public.reposts
+                          WHERE ((reposts.is_delete IS FALSE) AND (reposts.is_current IS TRUE) AND (reposts.repost_type = 'track'::public.reposttype))
+                        UNION ALL
+                         SELECT saves.user_id,
+                            saves.save_item_id AS item_id
+                           FROM public.saves
+                          WHERE ((saves.is_delete IS FALSE) AND (saves.is_current IS TRUE) AND (saves.save_type = 'track'::public.savetype))) r_and_s
+                     JOIN public.users ON ((r_and_s.user_id = users.user_id)))
+                  WHERE (((users.cover_photo IS NOT NULL) OR (users.cover_photo_sizes IS NOT NULL)) AND ((users.profile_picture IS NOT NULL) OR (users.profile_picture_sizes IS NOT NULL)) AND (users.bio IS NOT NULL))) save_and_reposts
+             JOIN public.aggregate_user au_1 ON ((save_and_reposts.user_id = au_1.user_id)))
+          GROUP BY save_and_reposts.item_id) karma ON ((karma.track_id = t.track_id)))
+  WHERE ((t.is_current IS TRUE) AND (t.is_delete IS FALSE) AND (t.is_unlisted IS FALSE) AND (t.stem_of IS NULL))
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW public.trending_params OWNER TO postgres;
+
+--
+-- Name: trending_results; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.trending_results (
+    user_id integer NOT NULL,
+    id character varying,
+    rank integer NOT NULL,
+    type character varying NOT NULL,
+    version character varying NOT NULL,
+    week date NOT NULL
+);
+
+
+ALTER TABLE public.trending_results OWNER TO postgres;
+
+--
+-- Name: usdc_purchases; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.usdc_purchases (
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    buyer_user_id integer NOT NULL,
+    seller_user_id integer NOT NULL,
+    amount bigint NOT NULL,
+    content_type public.usdc_purchase_content_type NOT NULL,
+    content_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    extra_amount bigint DEFAULT 0 NOT NULL,
+    access public.usdc_purchase_access_type DEFAULT 'stream'::public.usdc_purchase_access_type NOT NULL,
+    city character varying,
+    region character varying,
+    country character varying,
+    vendor character varying,
+    splits jsonb NOT NULL
+);
+
+
+ALTER TABLE public.usdc_purchases OWNER TO postgres;
+
+--
+-- Name: usdc_transactions_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.usdc_transactions_history (
+    user_bank character varying NOT NULL,
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    transaction_type character varying NOT NULL,
+    method character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    transaction_created_at timestamp without time zone NOT NULL,
+    change numeric NOT NULL,
+    balance numeric NOT NULL,
+    tx_metadata character varying
+);
+
+
+ALTER TABLE public.usdc_transactions_history OWNER TO postgres;
+
+--
+-- Name: usdc_user_bank_accounts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.usdc_user_bank_accounts (
+    signature character varying NOT NULL,
+    ethereum_address character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    bank_account character varying NOT NULL
+);
+
+
+ALTER TABLE public.usdc_user_bank_accounts OWNER TO postgres;
+
+--
+-- Name: user_balance_changes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_balance_changes (
+    user_id integer NOT NULL,
+    blocknumber integer NOT NULL,
+    current_balance character varying NOT NULL,
+    previous_balance character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.user_balance_changes OWNER TO postgres;
+
+--
+-- Name: user_balance_changes_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_balance_changes_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.user_balance_changes_user_id_seq OWNER TO postgres;
+
+--
+-- Name: user_balance_changes_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_balance_changes_user_id_seq OWNED BY public.user_balance_changes.user_id;
+
+
+--
+-- Name: user_balance_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_balance_history (
+    user_id integer NOT NULL,
+    mint text NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    balance bigint NOT NULL,
+    balance_usd double precision NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.user_balance_history OWNER TO postgres;
+
+--
+-- Name: TABLE user_balance_history; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.user_balance_history IS 'Stores historical snapshots of user token balances per mint, binned hourly by timestamp';
+
+
+--
+-- Name: COLUMN user_balance_history.user_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_balance_history.user_id IS 'The user ID this balance snapshot belongs to';
+
+
+--
+-- Name: COLUMN user_balance_history.mint; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_balance_history.mint IS 'The token mint address';
+
+
+--
+-- Name: COLUMN user_balance_history."timestamp"; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_balance_history."timestamp" IS 'The binned timestamp (hourly) for this balance snapshot';
+
+
+--
+-- Name: COLUMN user_balance_history.balance; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_balance_history.balance IS 'The raw token balance (in token units, accounting for decimals)';
+
+
+--
+-- Name: COLUMN user_balance_history.balance_usd; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_balance_history.balance_usd IS 'The USD value of this token balance at this timestamp';
+
+
+--
+-- Name: COLUMN user_balance_history.created_at; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_balance_history.created_at IS 'When this record was created';
+
+
+--
+-- Name: user_balances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_balances (
+    user_id integer NOT NULL,
+    balance character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    associated_wallets_balance character varying DEFAULT '0'::character varying NOT NULL,
+    waudio character varying DEFAULT '0'::character varying,
+    associated_sol_wallets_balance character varying DEFAULT '0'::character varying NOT NULL
+);
+
+
+ALTER TABLE public.user_balances OWNER TO postgres;
+
+--
+-- Name: user_balances_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_balances_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.user_balances_user_id_seq OWNER TO postgres;
+
+--
+-- Name: user_balances_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_balances_user_id_seq OWNED BY public.user_balances.user_id;
+
+
+--
+-- Name: user_bank_accounts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_bank_accounts (
+    signature character varying NOT NULL,
+    ethereum_address character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    bank_account character varying NOT NULL
+);
+
+
+ALTER TABLE public.user_bank_accounts OWNER TO postgres;
+
+--
+-- Name: user_bank_txs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_bank_txs (
+    signature character varying NOT NULL,
+    slot integer NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.user_bank_txs OWNER TO postgres;
+
+--
+-- Name: user_challenges; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_challenges (
+    challenge_id character varying NOT NULL,
+    user_id integer NOT NULL,
+    specifier character varying NOT NULL,
+    is_complete boolean NOT NULL,
+    current_step_count integer,
+    completed_blocknumber integer,
+    amount integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp without time zone
+);
+
+
+ALTER TABLE public.user_challenges OWNER TO postgres;
+
+--
+-- Name: user_delist_statuses; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_delist_statuses (
+    created_at timestamp with time zone NOT NULL,
+    user_id integer NOT NULL,
+    delisted boolean NOT NULL,
+    reason public.delist_user_reason NOT NULL
+);
+
+
+ALTER TABLE public.user_delist_statuses OWNER TO postgres;
+
+--
+-- Name: user_distinct_play_hours; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_distinct_play_hours (
+    user_id integer NOT NULL,
+    hours_with_play integer DEFAULT 0 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.user_distinct_play_hours OWNER TO postgres;
+
+--
+-- Name: TABLE user_distinct_play_hours; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.user_distinct_play_hours IS 'Tracks the number of distinct hours in which a user has listened to a track';
+
+
+--
+-- Name: user_distinct_play_tracks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_distinct_play_tracks (
+    user_id integer NOT NULL,
+    track_count integer DEFAULT 0 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.user_distinct_play_tracks OWNER TO postgres;
+
+--
+-- Name: TABLE user_distinct_play_tracks; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.user_distinct_play_tracks IS 'Tracks the number of distinct tracks a user has listened to';
+
+
+--
+-- Name: user_events; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_events (
+    id integer NOT NULL,
+    blockhash character varying,
+    blocknumber integer,
+    is_current boolean NOT NULL,
+    user_id integer NOT NULL,
+    referrer integer,
+    is_mobile_user boolean DEFAULT false NOT NULL,
+    slot integer
+);
+
+
+ALTER TABLE public.user_events OWNER TO postgres;
+
+--
+-- Name: user_events_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_events_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.user_events_id_seq OWNER TO postgres;
+
+--
+-- Name: user_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_events_id_seq OWNED BY public.user_events.id;
+
+
+--
+-- Name: user_listening_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_listening_history (
+    user_id integer NOT NULL,
+    listening_history jsonb NOT NULL
+);
+
+
+ALTER TABLE public.user_listening_history OWNER TO postgres;
+
+--
+-- Name: user_listening_history_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_listening_history_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.user_listening_history_user_id_seq OWNER TO postgres;
+
+--
+-- Name: user_listening_history_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_listening_history_user_id_seq OWNED BY public.user_listening_history.user_id;
+
+
+--
+-- Name: user_payout_wallet_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_payout_wallet_history (
+    user_id integer NOT NULL,
+    spl_usdc_payout_wallet character varying,
+    blocknumber integer NOT NULL,
+    block_timestamp timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.user_payout_wallet_history OWNER TO postgres;
+
+--
+-- Name: user_pubkeys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_pubkeys (
+    user_id integer NOT NULL,
+    pubkey_base64 text NOT NULL
+);
+
+
+ALTER TABLE public.user_pubkeys OWNER TO postgres;
+
+--
+-- Name: user_score_features; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_score_features (
+    user_id integer NOT NULL,
+    challenge_count integer DEFAULT 0,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.user_score_features OWNER TO postgres;
+
+--
+-- Name: TABLE user_score_features; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.user_score_features IS 'Tracks some features used in user score calculation';
+
+
+--
+-- Name: COLUMN user_score_features.challenge_count; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.user_score_features.challenge_count IS 'Tracks the number of fast challenges auser has completed';
+
+
+--
+-- Name: user_tips; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_tips (
+    slot integer NOT NULL,
+    signature character varying NOT NULL,
+    sender_user_id integer NOT NULL,
+    receiver_user_id integer NOT NULL,
+    amount bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.user_tips OWNER TO postgres;
+
+--
+-- Name: v_token_transactions_history; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_token_transactions_history AS
+ SELECT bc.signature,
+    bc.mint,
+    bc.account AS user_bank,
+    users.user_id,
+    bc.block_timestamp AS transaction_date,
+    bc.created_at,
+    bc.slot,
+    (abs(bc.change))::text AS change,
+    (bc.balance)::text AS balance,
+        CASE
+            WHEN (bc.change < 0) THEN 'send'::text
+            ELSE 'receive'::text
+        END AS method,
+        CASE
+            WHEN (rd.signature IS NOT NULL) THEN
+            CASE
+                WHEN (c.type = 'trending'::public.challengetype) THEN 'trending_reward'::text
+                ELSE 'user_reward'::text
+            END
+            WHEN (p.signature IS NOT NULL) THEN 'purchase_content'::text
+            WHEN (tmt.memo_type IS NOT NULL) THEN (tmt.memo_type)::text
+            WHEN ((cat.signature IS NOT NULL) AND (from_owner.user_id IS NOT NULL) AND (to_owner.user_id IS NOT NULL) AND (from_owner.user_id <> to_owner.user_id)) THEN 'tip'::text
+            WHEN (cat.signature IS NOT NULL) THEN 'transfer'::text
+            ELSE 'transfer'::text
+        END AS transaction_type,
+        CASE
+            WHEN (rd.signature IS NOT NULL) THEN rd.challenge_id
+            WHEN (((tmt.memo_type)::text = 'withdrawal'::text) AND (cat.to_account IS NOT NULL)) THEN cat.to_account
+            WHEN ((cat.signature IS NOT NULL) AND (bc.change > 0) AND (from_owner.user_id IS NOT NULL)) THEN ((from_owner.user_id)::text)::character varying
+            WHEN ((cat.signature IS NOT NULL) AND (bc.change < 0) AND (to_owner.user_id IS NOT NULL)) THEN ((to_owner.user_id)::text)::character varying
+            ELSE NULL::character varying
+        END AS tx_metadata
+   FROM (((((((((((public.sol_token_account_balance_changes bc
+     JOIN public.sol_claimable_accounts sca ON ((((sca.account)::text = (bc.account)::text) AND ((sca.mint)::text = (bc.mint)::text))))
+     LEFT JOIN public.users ON ((((users.wallet)::text = (sca.ethereum_address)::text) AND (users.is_current = true))))
+     LEFT JOIN public.sol_claimable_account_transfers cat ON ((((cat.signature)::text = (bc.signature)::text) AND (((cat.from_account)::text = (bc.account)::text) OR ((cat.to_account)::text = (bc.account)::text)))))
+     LEFT JOIN public.sol_claimable_accounts from_sca ON ((((from_sca.account)::text = (cat.from_account)::text) AND ((from_sca.mint)::text = (bc.mint)::text))))
+     LEFT JOIN public.users from_owner ON ((((from_owner.wallet)::text = (from_sca.ethereum_address)::text) AND (from_owner.is_current = true))))
+     LEFT JOIN public.sol_claimable_accounts to_sca ON ((((to_sca.account)::text = (cat.to_account)::text) AND ((to_sca.mint)::text = (bc.mint)::text))))
+     LEFT JOIN public.users to_owner ON ((((to_owner.wallet)::text = (to_sca.ethereum_address)::text) AND (to_owner.is_current = true))))
+     LEFT JOIN public.sol_reward_disbursements rd ON ((((rd.signature)::text = (bc.signature)::text) AND ((rd.user_bank)::text = (bc.account)::text))))
+     LEFT JOIN public.challenges c ON (((c.id)::text = (rd.challenge_id)::text)))
+     LEFT JOIN public.sol_purchases p ON ((((p.signature)::text = (bc.signature)::text) AND ((p.from_account)::text = (bc.account)::text))))
+     LEFT JOIN public.sol_transfer_memo_types tmt ON (((tmt.signature)::text = (bc.signature)::text)));
+
+
+ALTER VIEW public.v_token_transactions_history OWNER TO postgres;
+
+--
+-- Name: VIEW v_token_transactions_history; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON VIEW public.v_token_transactions_history IS 'Mint-agnostic transactions history derived from sol_token_account_balance_changes (the hub: only table with both mint and block_timestamp). Per-row transaction_type derived by LEFT JOIN to typed tables (sol_claimable_account_transfers, sol_reward_disbursements, sol_purchases, sol_transfer_memo_types). Callers filter by mint at query time. Vendor purchase types (PURCHASE_STRIPE/COINBASE/UNKNOWN) on AUDIO still degrade to bare transfer until the AUDIO mint subscription + vendor-memo capture land.';
+
+
+--
+-- Name: v_usdc_purchases; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_usdc_purchases AS
+ SELECT sp.signature,
+    sp.slot,
+    sp.buyer_user_id,
+        CASE sp.content_type
+            WHEN 'track'::text THEN t.owner_id
+            WHEN 'album'::text THEN p.playlist_owner_id
+            WHEN 'playlist'::text THEN p.playlist_owner_id
+            ELSE NULL::integer
+        END AS seller_user_id,
+    sp.amount,
+    (sp.content_type)::public.usdc_purchase_content_type AS content_type,
+    sp.content_id,
+    sp.created_at,
+    sp.created_at AS updated_at,
+    GREATEST((sp.amount - COALESCE(
+        CASE sp.content_type
+            WHEN 'track'::text THEN ( SELECT (tph.total_price_cents * 10000)
+               FROM public.track_price_history tph
+              WHERE ((tph.track_id = sp.content_id) AND (tph.block_timestamp <= sp.created_at))
+              ORDER BY tph.block_timestamp DESC
+             LIMIT 1)
+            ELSE ( SELECT (aph.total_price_cents * 10000)
+               FROM public.album_price_history aph
+              WHERE ((aph.playlist_id = sp.content_id) AND (aph.block_timestamp <= sp.created_at))
+              ORDER BY aph.block_timestamp DESC
+             LIMIT 1)
+        END, sp.amount)), (0)::bigint) AS extra_amount,
+    (sp.access_type)::public.usdc_purchase_access_type AS access,
+    sp.city,
+    sp.region,
+    sp.country,
+    ( SELECT COALESCE(jsonb_agg(jsonb_build_object('user_id', COALESCE(u_payout.user_id, u_sca.user_id), 'payout_wallet', pay.to_account, 'amount', pay.amount, 'percentage', (((pay.amount)::numeric * 100.0) / (NULLIF(sp.amount, 0))::numeric)) ORDER BY pay.route_index), '[]'::jsonb) AS "coalesce"
+           FROM (((public.sol_payments pay
+             LEFT JOIN LATERAL ( SELECT upwh.user_id
+                   FROM public.user_payout_wallet_history upwh
+                  WHERE (((upwh.spl_usdc_payout_wallet)::text = (pay.to_account)::text) AND (upwh.block_timestamp <= sp.created_at))
+                  ORDER BY upwh.block_timestamp DESC
+                 LIMIT 1) u_payout ON (true))
+             LEFT JOIN public.sol_claimable_accounts sca ON ((((sca.account)::text = (pay.to_account)::text) AND ((sca.mint)::text = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'::text))))
+             LEFT JOIN public.users u_sca ON ((((u_sca.wallet)::text = (sca.ethereum_address)::text) AND (u_sca.is_current = true))))
+          WHERE (((pay.signature)::text = (sp.signature)::text) AND (pay.instruction_index = sp.instruction_index))) AS splits
+   FROM ((public.sol_purchases sp
+     LEFT JOIN public.tracks t ON ((((sp.content_type)::text = 'track'::text) AND (t.track_id = sp.content_id) AND (t.is_current = true))))
+     LEFT JOIN public.playlists p ON ((((sp.content_type)::text = ANY ((ARRAY['album'::character varying, 'playlist'::character varying])::text[])) AND (p.playlist_id = sp.content_id) AND (p.is_current = true))))
+  WHERE (sp.is_valid IS TRUE);
+
+
+ALTER VIEW public.v_usdc_purchases OWNER TO postgres;
+
+--
+-- Name: VIEW v_usdc_purchases; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON VIEW public.v_usdc_purchases IS 'Compatibility view exposing sol_purchases + sol_payments in the column shape API routes used to read from usdc_purchases. seller_user_id is the current content owner (not snapshotted at purchase time). extra_amount is amount paid minus base price from price history. vendor is intentionally dropped.';
+
+
+--
+-- Name: v_user_balances; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_user_balances AS
+ SELECT u.user_id,
+    (COALESCE(eub.balance, (0)::numeric))::character varying AS eth_balance,
+    (COALESCE(sub.balance, (0)::bigint))::character varying AS sol_balance,
+    GREATEST(COALESCE(eub.updated_at, '1970-01-01 00:00:00'::timestamp without time zone), COALESCE(sub.updated_at, '1970-01-01 00:00:00'::timestamp without time zone)) AS updated_at
+   FROM ((public.users u
+     LEFT JOIN public.sol_user_balances sub ON (((sub.user_id = u.user_id) AND (sub.mint = '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM'::text))))
+     LEFT JOIN public.eth_user_balances eub ON ((eub.user_id = u.user_id)))
+  WHERE (u.is_current = true);
+
+
+ALTER VIEW public.v_user_balances OWNER TO postgres;
+
+--
+-- Name: VIEW v_user_balances; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON VIEW public.v_user_balances IS 'Per-user AUDIO/wAUDIO balance totals. One row per current user with eth_balance (wei) and sol_balance (wAUDIO base units, 8 decimals — multiply by 10^10 to compare to wei). eth_balance is eth_user_balances (pre-aggregated across users.wallet + chain=eth associated_wallets, maintained by handle_eth_wallet_balance_change / handle_associated_wallets). sol_balance is sol_user_balances for the wAUDIO mint, pre-aggregated across user_bank PDAs + linked Solana wallets by handle_sol_claimable_accounts / update_sol_user_balance triggers.';
+
+
+--
+-- Name: validator_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.validator_history (
+    rowid integer NOT NULL,
+    endpoint text NOT NULL,
+    eth_address text NOT NULL,
+    comet_address text NOT NULL,
+    sp_id bigint NOT NULL,
+    service_type text NOT NULL,
+    event_type public.validator_event NOT NULL,
+    event_time timestamp without time zone NOT NULL,
+    event_block bigint NOT NULL
+);
+
+
+ALTER TABLE public.validator_history OWNER TO postgres;
+
+--
+-- Name: validator_history_rowid_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.validator_history_rowid_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.validator_history_rowid_seq OWNER TO postgres;
+
+--
+-- Name: validator_history_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.validator_history_rowid_seq OWNED BY public.validator_history.rowid;
+
+
+--
+-- Name: volume_leader_exclusions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.volume_leader_exclusions (
+    address text NOT NULL,
+    description text
+);
+
+
+ALTER TABLE public.volume_leader_exclusions OWNER TO postgres;
+
+--
+-- Name: access_keys id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.access_keys ALTER COLUMN id SET DEFAULT nextval('public.access_keys_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_daily_app_name_metrics id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_daily_app_name_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_daily_app_name_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_daily_total_users_metrics id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_daily_total_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_daily_total_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_daily_unique_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_daily_unique_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_app_name_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_monthly_app_name_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_total_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_monthly_total_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_unique_users_metrics ALTER COLUMN id SET DEFAULT nextval('public.aggregate_monthly_unique_users_metrics_id_seq'::regclass);
+
+
+--
+-- Name: associated_wallets id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.associated_wallets ALTER COLUMN id SET DEFAULT nextval('public.associated_wallets_id_seq'::regclass);
+
+
+--
+-- Name: challenge_listen_streak user_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.challenge_listen_streak ALTER COLUMN user_id SET DEFAULT nextval('public.challenge_listen_streak_user_id_seq'::regclass);
+
+
+--
+-- Name: challenge_profile_completion user_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.challenge_profile_completion ALTER COLUMN user_id SET DEFAULT nextval('public.challenge_profile_completion_user_id_seq'::regclass);
+
+
+--
+-- Name: claimed_prizes id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.claimed_prizes ALTER COLUMN id SET DEFAULT nextval('public.claimed_prizes_id_seq'::regclass);
+
+
+--
+-- Name: core_blocks rowid; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_blocks ALTER COLUMN rowid SET DEFAULT nextval('public.core_blocks_rowid_seq'::regclass);
+
+
+--
+-- Name: core_ern id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_ern ALTER COLUMN id SET DEFAULT nextval('public.core_ern_id_seq'::regclass);
+
+
+--
+-- Name: core_mead id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_mead ALTER COLUMN id SET DEFAULT nextval('public.core_mead_id_seq'::regclass);
+
+
+--
+-- Name: core_pie id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_pie ALTER COLUMN id SET DEFAULT nextval('public.core_pie_id_seq'::regclass);
+
+
+--
+-- Name: core_rewards id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_rewards ALTER COLUMN id SET DEFAULT nextval('public.core_rewards_id_seq'::regclass);
+
+
+--
+-- Name: core_transactions rowid; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_transactions ALTER COLUMN rowid SET DEFAULT nextval('public.core_transactions_rowid_seq'::regclass);
+
+
+--
+-- Name: core_tx_stats id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_tx_stats ALTER COLUMN id SET DEFAULT nextval('public.core_tx_stats_id_seq'::regclass);
+
+
+--
+-- Name: core_uploads id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_uploads ALTER COLUMN id SET DEFAULT nextval('public.core_uploads_id_seq'::regclass);
+
+
+--
+-- Name: core_validators rowid; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_validators ALTER COLUMN rowid SET DEFAULT nextval('public.core_validators_rowid_seq'::regclass);
+
+
+--
+-- Name: email_access id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.email_access ALTER COLUMN id SET DEFAULT nextval('public.email_access_id_seq'::regclass);
+
+
+--
+-- Name: encrypted_emails id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.encrypted_emails ALTER COLUMN id SET DEFAULT nextval('public.encrypted_emails_id_seq'::regclass);
+
+
+--
+-- Name: eth_blocks last_scanned_block; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_blocks ALTER COLUMN last_scanned_block SET DEFAULT nextval('public.eth_blocks_last_scanned_block_seq'::regclass);
+
+
+--
+-- Name: etl_addresses id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_addresses ALTER COLUMN id SET DEFAULT nextval('public.etl_addresses_id_seq'::regclass);
+
+
+--
+-- Name: etl_blocks id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_blocks ALTER COLUMN id SET DEFAULT nextval('public.etl_blocks_id_seq'::regclass);
+
+
+--
+-- Name: etl_manage_entities id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_manage_entities ALTER COLUMN id SET DEFAULT nextval('public.etl_manage_entities_id_seq'::regclass);
+
+
+--
+-- Name: etl_plays id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_plays ALTER COLUMN id SET DEFAULT nextval('public.etl_plays_id_seq'::regclass);
+
+
+--
+-- Name: etl_sla_node_reports id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_sla_node_reports ALTER COLUMN id SET DEFAULT nextval('public.etl_sla_node_reports_id_seq'::regclass);
+
+
+--
+-- Name: etl_sla_rollups id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_sla_rollups ALTER COLUMN id SET DEFAULT nextval('public.etl_sla_rollups_id_seq'::regclass);
+
+
+--
+-- Name: etl_storage_proof_verifications id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_storage_proof_verifications ALTER COLUMN id SET DEFAULT nextval('public.etl_storage_proof_verifications_id_seq'::regclass);
+
+
+--
+-- Name: etl_storage_proofs id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_storage_proofs ALTER COLUMN id SET DEFAULT nextval('public.etl_storage_proofs_id_seq'::regclass);
+
+
+--
+-- Name: etl_transactions id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_transactions ALTER COLUMN id SET DEFAULT nextval('public.etl_transactions_id_seq'::regclass);
+
+
+--
+-- Name: etl_validator_deregistrations id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validator_deregistrations ALTER COLUMN id SET DEFAULT nextval('public.etl_validator_deregistrations_id_seq'::regclass);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validator_misbehavior_deregistrations ALTER COLUMN id SET DEFAULT nextval('public.etl_validator_misbehavior_deregistrations_id_seq'::regclass);
+
+
+--
+-- Name: etl_validator_registrations id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validator_registrations ALTER COLUMN id SET DEFAULT nextval('public.etl_validator_registrations_id_seq'::regclass);
+
+
+--
+-- Name: etl_validators id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validators ALTER COLUMN id SET DEFAULT nextval('public.etl_validators_id_seq'::regclass);
+
+
+--
+-- Name: management_keys id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.management_keys ALTER COLUMN id SET DEFAULT nextval('public.management_keys_id_seq'::regclass);
+
+
+--
+-- Name: notification id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.notification ALTER COLUMN id SET DEFAULT nextval('public.notification_id_seq'::regclass);
+
+
+--
+-- Name: oauth_redirect_uris id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.oauth_redirect_uris ALTER COLUMN id SET DEFAULT nextval('public.oauth_redirect_uris_id_seq'::regclass);
+
+
+--
+-- Name: plays id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.plays ALTER COLUMN id SET DEFAULT nextval('public.plays_id_seq'::regclass);
+
+
+--
+-- Name: prizes id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.prizes ALTER COLUMN id SET DEFAULT nextval('public.prizes_id_seq'::regclass);
+
+
+--
+-- Name: reactions id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reactions ALTER COLUMN id SET DEFAULT nextval('public.reactions_id_seq'::regclass);
+
+
+--
+-- Name: skipped_transactions id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.skipped_transactions ALTER COLUMN id SET DEFAULT nextval('public.skipped_transactions_id_seq'::regclass);
+
+
+--
+-- Name: sla_auditor_version_data id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_auditor_version_data ALTER COLUMN id SET DEFAULT nextval('public.sla_auditor_version_data_id_seq'::regclass);
+
+
+--
+-- Name: sla_node_reports id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_node_reports ALTER COLUMN id SET DEFAULT nextval('public.sla_node_reports_id_seq'::regclass);
+
+
+--
+-- Name: sla_rollups id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_rollups ALTER COLUMN id SET DEFAULT nextval('public.sla_rollups_id_seq'::regclass);
+
+
+--
+-- Name: sound_recordings id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sound_recordings ALTER COLUMN id SET DEFAULT nextval('public.sound_recordings_id_seq'::regclass);
+
+
+--
+-- Name: storage_proof_peers id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.storage_proof_peers ALTER COLUMN id SET DEFAULT nextval('public.storage_proof_peers_id_seq'::regclass);
+
+
+--
+-- Name: storage_proofs id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.storage_proofs ALTER COLUMN id SET DEFAULT nextval('public.storage_proofs_id_seq'::regclass);
+
+
+--
+-- Name: track_releases id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_releases ALTER COLUMN id SET DEFAULT nextval('public.track_releases_id_seq'::regclass);
+
+
+--
+-- Name: user_balance_changes user_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_balance_changes ALTER COLUMN user_id SET DEFAULT nextval('public.user_balance_changes_user_id_seq'::regclass);
+
+
+--
+-- Name: user_balances user_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_balances ALTER COLUMN user_id SET DEFAULT nextval('public.user_balances_user_id_seq'::regclass);
+
+
+--
+-- Name: user_events id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_events ALTER COLUMN id SET DEFAULT nextval('public.user_events_id_seq'::regclass);
+
+
+--
+-- Name: user_listening_history user_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_listening_history ALTER COLUMN user_id SET DEFAULT nextval('public.user_listening_history_user_id_seq'::regclass);
+
+
+--
+-- Name: validator_history rowid; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.validator_history ALTER COLUMN rowid SET DEFAULT nextval('public.validator_history_rowid_seq'::regclass);
+
+
+--
+-- Name: access_keys access_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.access_keys
+    ADD CONSTRAINT access_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_daily_app_name_metrics aggregate_daily_app_name_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_daily_app_name_metrics
+    ADD CONSTRAINT aggregate_daily_app_name_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_daily_total_users_metrics aggregate_daily_total_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_daily_total_users_metrics
+    ADD CONSTRAINT aggregate_daily_total_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_daily_unique_users_metrics aggregate_daily_unique_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_daily_unique_users_metrics
+    ADD CONSTRAINT aggregate_daily_unique_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_monthly_app_name_metrics aggregate_monthly_app_name_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_app_name_metrics
+    ADD CONSTRAINT aggregate_monthly_app_name_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_monthly_plays aggregate_monthly_plays_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_plays
+    ADD CONSTRAINT aggregate_monthly_plays_pkey PRIMARY KEY (play_item_id, "timestamp", country);
+
+
+--
+-- Name: aggregate_monthly_total_users_metrics aggregate_monthly_total_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_total_users_metrics
+    ADD CONSTRAINT aggregate_monthly_total_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_monthly_unique_users_metrics aggregate_monthly_unique_users_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_monthly_unique_users_metrics
+    ADD CONSTRAINT aggregate_monthly_unique_users_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: aggregate_playlist aggregate_playlist_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_playlist
+    ADD CONSTRAINT aggregate_playlist_pkey PRIMARY KEY (playlist_id);
+
+
+--
+-- Name: aggregate_track aggregate_track_table_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_track
+    ADD CONSTRAINT aggregate_track_table_pkey PRIMARY KEY (track_id);
+
+
+--
+-- Name: aggregate_user aggregate_user_table_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_user
+    ADD CONSTRAINT aggregate_user_table_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: aggregate_user_tips aggregate_user_tips_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_user_tips
+    ADD CONSTRAINT aggregate_user_tips_pkey PRIMARY KEY (sender_user_id, receiver_user_id);
+
+
+--
+-- Name: album_price_history album_price_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.album_price_history
+    ADD CONSTRAINT album_price_history_pkey PRIMARY KEY (playlist_id, block_timestamp);
+
+
+--
+-- Name: alembic_version alembic_version_pkc; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.alembic_version
+    ADD CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num);
+
+
+--
+-- Name: anti_abuse_blocked_users anti_abuse_blocked_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.anti_abuse_blocked_users
+    ADD CONSTRAINT anti_abuse_blocked_users_pkey PRIMARY KEY (handle_lc);
+
+
+--
+-- Name: api_access_keys api_access_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_access_keys
+    ADD CONSTRAINT api_access_keys_pkey PRIMARY KEY (api_key, api_access_key);
+
+
+--
+-- Name: api_keys api_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_keys
+    ADD CONSTRAINT api_keys_pkey PRIMARY KEY (api_key);
+
+
+--
+-- Name: api_metrics_apps api_metrics_apps_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_metrics_apps
+    ADD CONSTRAINT api_metrics_apps_pkey PRIMARY KEY (date, api_key, app_name);
+
+
+--
+-- Name: api_metrics_apps_unique api_metrics_apps_unique_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_metrics_apps_unique
+    ADD CONSTRAINT api_metrics_apps_unique_pkey PRIMARY KEY (date, app_name);
+
+
+--
+-- Name: api_metrics_counts api_metrics_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_metrics_counts
+    ADD CONSTRAINT api_metrics_counts_pkey PRIMARY KEY (date);
+
+
+--
+-- Name: api_metrics_routes api_metrics_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.api_metrics_routes
+    ADD CONSTRAINT api_metrics_routes_pkey PRIMARY KEY (date, route_pattern, method);
+
+
+--
+-- Name: app_name_metrics app_name_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.app_name_metrics
+    ADD CONSTRAINT app_name_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: artist_coin_pools artist_coin_pools_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.artist_coin_pools
+    ADD CONSTRAINT artist_coin_pools_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: artist_coin_stats artist_coin_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.artist_coin_stats
+    ADD CONSTRAINT artist_coin_stats_pkey PRIMARY KEY (mint);
+
+
+--
+-- Name: artist_coins artist_coins_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.artist_coins
+    ADD CONSTRAINT artist_coins_pkey PRIMARY KEY (mint);
+
+
+--
+-- Name: artist_coins artist_coins_ticker_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.artist_coins
+    ADD CONSTRAINT artist_coins_ticker_unique UNIQUE (ticker);
+
+
+--
+-- Name: associated_wallets associated_wallets_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.associated_wallets
+    ADD CONSTRAINT associated_wallets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: audio_transactions_history audio_transactions_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.audio_transactions_history
+    ADD CONSTRAINT audio_transactions_history_pkey PRIMARY KEY (user_bank, signature);
+
+
+--
+-- Name: audius_data_txs audius_data_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.audius_data_txs
+    ADD CONSTRAINT audius_data_txs_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: blocks blocks_number_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.blocks
+    ADD CONSTRAINT blocks_number_key UNIQUE (number);
+
+
+--
+-- Name: blocks blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.blocks
+    ADD CONSTRAINT blocks_pkey PRIMARY KEY (blockhash);
+
+
+--
+-- Name: challenge_disbursements challenge_disbursements_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.challenge_disbursements
+    ADD CONSTRAINT challenge_disbursements_pkey PRIMARY KEY (challenge_id, specifier);
+
+
+--
+-- Name: challenge_listen_streak challenge_listen_streak_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.challenge_listen_streak
+    ADD CONSTRAINT challenge_listen_streak_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: challenge_profile_completion challenge_profile_completion_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.challenge_profile_completion
+    ADD CONSTRAINT challenge_profile_completion_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: challenges challenges_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.challenges
+    ADD CONSTRAINT challenges_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: chat_ban chat_ban_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_ban
+    ADD CONSTRAINT chat_ban_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: chat_blast chat_blast_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_blast
+    ADD CONSTRAINT chat_blast_pkey PRIMARY KEY (blast_id);
+
+
+--
+-- Name: chat_blocked_users chat_blocked_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_blocked_users
+    ADD CONSTRAINT chat_blocked_users_pkey PRIMARY KEY (blocker_user_id, blockee_user_id);
+
+
+--
+-- Name: chat_member chat_member_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_member
+    ADD CONSTRAINT chat_member_pkey PRIMARY KEY (chat_id, user_id);
+
+
+--
+-- Name: chat_message chat_message_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_message
+    ADD CONSTRAINT chat_message_pkey PRIMARY KEY (message_id);
+
+
+--
+-- Name: chat_message_reactions chat_message_reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_message_reactions
+    ADD CONSTRAINT chat_message_reactions_pkey PRIMARY KEY (user_id, message_id);
+
+
+--
+-- Name: chat_permissions chat_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_permissions
+    ADD CONSTRAINT chat_permissions_pkey PRIMARY KEY (user_id, permits);
+
+
+--
+-- Name: chat chat_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat
+    ADD CONSTRAINT chat_pkey PRIMARY KEY (chat_id);
+
+
+--
+-- Name: cid_data cid_data_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.cid_data
+    ADD CONSTRAINT cid_data_pkey PRIMARY KEY (cid);
+
+
+--
+-- Name: claimed_prizes claimed_prizes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.claimed_prizes
+    ADD CONSTRAINT claimed_prizes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: claimed_prizes claimed_prizes_signature_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.claimed_prizes
+    ADD CONSTRAINT claimed_prizes_signature_key UNIQUE (signature);
+
+
+--
+-- Name: comment_mentions comment_mentions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_mentions
+    ADD CONSTRAINT comment_mentions_pkey PRIMARY KEY (comment_id, user_id);
+
+
+--
+-- Name: comment_notification_settings comment_notification_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_notification_settings
+    ADD CONSTRAINT comment_notification_settings_pkey PRIMARY KEY (user_id, entity_id, entity_type);
+
+
+--
+-- Name: comment_reactions comment_reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_reactions
+    ADD CONSTRAINT comment_reactions_pkey PRIMARY KEY (comment_id, user_id);
+
+
+--
+-- Name: comment_reports comment_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_reports
+    ADD CONSTRAINT comment_reports_pkey PRIMARY KEY (comment_id, user_id);
+
+
+--
+-- Name: comment_threads comment_threads_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_threads
+    ADD CONSTRAINT comment_threads_pkey PRIMARY KEY (parent_comment_id, comment_id);
+
+
+--
+-- Name: comments comments_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comments
+    ADD CONSTRAINT comments_pkey PRIMARY KEY (comment_id);
+
+
+--
+-- Name: core_app_state core_app_state_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_app_state
+    ADD CONSTRAINT core_app_state_pkey PRIMARY KEY (block_height, app_hash);
+
+
+--
+-- Name: core_blocks core_blocks_height_chain_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_blocks
+    ADD CONSTRAINT core_blocks_height_chain_id_key UNIQUE (height, chain_id);
+
+
+--
+-- Name: core_blocks core_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_blocks
+    ADD CONSTRAINT core_blocks_pkey PRIMARY KEY (rowid);
+
+
+--
+-- Name: core_db_migrations core_db_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_db_migrations
+    ADD CONSTRAINT core_db_migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_deals core_deals_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_deals
+    ADD CONSTRAINT core_deals_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: core_ern core_ern_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_ern
+    ADD CONSTRAINT core_ern_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_mead core_mead_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_mead
+    ADD CONSTRAINT core_mead_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_parties core_parties_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_parties
+    ADD CONSTRAINT core_parties_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: core_pie core_pie_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_pie
+    ADD CONSTRAINT core_pie_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_releases core_releases_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_releases
+    ADD CONSTRAINT core_releases_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: core_resources core_resources_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_resources
+    ADD CONSTRAINT core_resources_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: core_rewards core_rewards_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_rewards
+    ADD CONSTRAINT core_rewards_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_transactions core_transactions_block_id_index_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_transactions
+    ADD CONSTRAINT core_transactions_block_id_index_key UNIQUE (block_id, index);
+
+
+--
+-- Name: core_transactions core_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_transactions
+    ADD CONSTRAINT core_transactions_pkey PRIMARY KEY (rowid);
+
+
+--
+-- Name: core_tx_stats core_tx_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_tx_stats
+    ADD CONSTRAINT core_tx_stats_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_tx_stats core_tx_stats_tx_hash_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_tx_stats
+    ADD CONSTRAINT core_tx_stats_tx_hash_key UNIQUE (tx_hash);
+
+
+--
+-- Name: core_uploads core_uploads_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_uploads
+    ADD CONSTRAINT core_uploads_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: core_validators core_validators_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_validators
+    ADD CONSTRAINT core_validators_pkey PRIMARY KEY (rowid);
+
+
+--
+-- Name: countries countries_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.countries
+    ADD CONSTRAINT countries_pkey PRIMARY KEY (iso);
+
+
+--
+-- Name: dashboard_wallet_users dashboard_wallet_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.dashboard_wallet_users
+    ADD CONSTRAINT dashboard_wallet_users_pkey PRIMARY KEY (wallet);
+
+
+--
+-- Name: delist_status_cursor delist_status_cursor_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.delist_status_cursor
+    ADD CONSTRAINT delist_status_cursor_pkey PRIMARY KEY (host, entity);
+
+
+--
+-- Name: developer_apps developer_apps_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.developer_apps
+    ADD CONSTRAINT developer_apps_pkey PRIMARY KEY (address, txhash);
+
+
+--
+-- Name: email_access email_access_email_owner_user_id_receiving_user_id_grantor__key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.email_access
+    ADD CONSTRAINT email_access_email_owner_user_id_receiving_user_id_grantor__key UNIQUE (email_owner_user_id, receiving_user_id, grantor_user_id);
+
+
+--
+-- Name: email_access email_access_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.email_access
+    ADD CONSTRAINT email_access_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: encrypted_emails encrypted_emails_email_owner_user_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.encrypted_emails
+    ADD CONSTRAINT encrypted_emails_email_owner_user_id_key UNIQUE (email_owner_user_id);
+
+
+--
+-- Name: encrypted_emails encrypted_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.encrypted_emails
+    ADD CONSTRAINT encrypted_emails_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: eth_active_proposals eth_active_proposals_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_active_proposals
+    ADD CONSTRAINT eth_active_proposals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: eth_blocks eth_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_blocks
+    ADD CONSTRAINT eth_blocks_pkey PRIMARY KEY (last_scanned_block);
+
+
+--
+-- Name: eth_db_migrations eth_db_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_db_migrations
+    ADD CONSTRAINT eth_db_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: eth_funding_rounds eth_funding_rounds_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_funding_rounds
+    ADD CONSTRAINT eth_funding_rounds_pkey PRIMARY KEY (round_num);
+
+
+--
+-- Name: eth_indexer_checkpoints eth_indexer_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_indexer_checkpoints
+    ADD CONSTRAINT eth_indexer_checkpoints_pkey PRIMARY KEY (name);
+
+
+--
+-- Name: eth_registered_endpoints eth_registered_endpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_registered_endpoints
+    ADD CONSTRAINT eth_registered_endpoints_pkey PRIMARY KEY (id, service_type);
+
+
+--
+-- Name: eth_service_providers eth_service_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_service_providers
+    ADD CONSTRAINT eth_service_providers_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: eth_staked eth_staked_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_staked
+    ADD CONSTRAINT eth_staked_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: eth_user_balances eth_user_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_user_balances
+    ADD CONSTRAINT eth_user_balances_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: eth_wallet_balances eth_wallet_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.eth_wallet_balances
+    ADD CONSTRAINT eth_wallet_balances_pkey PRIMARY KEY (wallet);
+
+
+--
+-- Name: etl_addresses etl_addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_addresses
+    ADD CONSTRAINT etl_addresses_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_blocks etl_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_blocks
+    ADD CONSTRAINT etl_blocks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_db_migrations etl_db_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_db_migrations
+    ADD CONSTRAINT etl_db_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: etl_manage_entities etl_manage_entities_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_manage_entities
+    ADD CONSTRAINT etl_manage_entities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_plays etl_plays_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_plays
+    ADD CONSTRAINT etl_plays_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_sla_node_reports etl_sla_node_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_sla_node_reports
+    ADD CONSTRAINT etl_sla_node_reports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_sla_rollups etl_sla_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_sla_rollups
+    ADD CONSTRAINT etl_sla_rollups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_storage_proof_verifications etl_storage_proof_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_storage_proof_verifications
+    ADD CONSTRAINT etl_storage_proof_verifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_storage_proofs etl_storage_proofs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_storage_proofs
+    ADD CONSTRAINT etl_storage_proofs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_transactions etl_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_transactions
+    ADD CONSTRAINT etl_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validator_deregistrations etl_validator_deregistrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validator_deregistrations
+    ADD CONSTRAINT etl_validator_deregistrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations etl_validator_misbehavior_deregistrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validator_misbehavior_deregistrations
+    ADD CONSTRAINT etl_validator_misbehavior_deregistrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validator_registrations etl_validator_registrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validator_registrations
+    ADD CONSTRAINT etl_validator_registrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validators etl_validators_endpoint_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validators
+    ADD CONSTRAINT etl_validators_endpoint_key UNIQUE (endpoint);
+
+
+--
+-- Name: etl_validators etl_validators_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_validators
+    ADD CONSTRAINT etl_validators_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: event_routes event_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.event_routes
+    ADD CONSTRAINT event_routes_pkey PRIMARY KEY (owner_id, slug);
+
+
+--
+-- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_pkey PRIMARY KEY (event_id);
+
+
+--
+-- Name: follows follows_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT follows_pkey PRIMARY KEY (follower_user_id, followee_user_id, txhash);
+
+
+--
+-- Name: grants grants_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.grants
+    ADD CONSTRAINT grants_pkey PRIMARY KEY (grantee_address, user_id, txhash);
+
+
+--
+-- Name: hourly_play_counts hourly_play_counts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.hourly_play_counts
+    ADD CONSTRAINT hourly_play_counts_pkey PRIMARY KEY (hourly_timestamp);
+
+
+--
+-- Name: indexing_checkpoints indexing_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.indexing_checkpoints
+    ADD CONSTRAINT indexing_checkpoints_pkey PRIMARY KEY (tablename);
+
+
+--
+-- Name: management_keys management_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.management_keys
+    ADD CONSTRAINT management_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: milestones milestones_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.milestones
+    ADD CONSTRAINT milestones_pkey PRIMARY KEY (id, name, threshold);
+
+
+--
+-- Name: muted_users muted_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.muted_users
+    ADD CONSTRAINT muted_users_pkey PRIMARY KEY (muted_user_id, user_id);
+
+
+--
+-- Name: notification_campaign_push_open notification_campaign_push_open_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.notification_campaign_push_open
+    ADD CONSTRAINT notification_campaign_push_open_pkey PRIMARY KEY (campaign_id, user_id);
+
+
+--
+-- Name: notification notification_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.notification
+    ADD CONSTRAINT notification_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notification_seen notification_seen_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.notification_seen
+    ADD CONSTRAINT notification_seen_pkey PRIMARY KEY (user_id, seen_at);
+
+
+--
+-- Name: oauth_authorization_codes oauth_authorization_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.oauth_authorization_codes
+    ADD CONSTRAINT oauth_authorization_codes_pkey PRIMARY KEY (code);
+
+
+--
+-- Name: oauth_redirect_uris oauth_redirect_uris_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.oauth_redirect_uris
+    ADD CONSTRAINT oauth_redirect_uris_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_tokens oauth_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_pkey PRIMARY KEY (token);
+
+
+--
+-- Name: core_indexed_blocks pk_chain_id_height; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.core_indexed_blocks
+    ADD CONSTRAINT pk_chain_id_height PRIMARY KEY (chain_id, height);
+
+
+--
+-- Name: collectibles pk_user_id; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.collectibles
+    ADD CONSTRAINT pk_user_id PRIMARY KEY (user_id);
+
+
+--
+-- Name: aggregate_plays play_item_id_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aggregate_plays
+    ADD CONSTRAINT play_item_id_pkey PRIMARY KEY (play_item_id);
+
+
+--
+-- Name: playlist_routes playlist_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlist_routes
+    ADD CONSTRAINT playlist_routes_pkey PRIMARY KEY (owner_id, slug);
+
+
+--
+-- Name: playlist_seen playlist_seen_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlist_seen
+    ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (user_id, playlist_id, seen_at);
+
+
+--
+-- Name: playlist_tracks playlist_tracks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlist_tracks
+    ADD CONSTRAINT playlist_tracks_pkey PRIMARY KEY (playlist_id, track_id);
+
+
+--
+-- Name: playlist_trending_scores playlist_trending_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlist_trending_scores
+    ADD CONSTRAINT playlist_trending_scores_pkey PRIMARY KEY (playlist_id, type, version, time_range);
+
+
+--
+-- Name: playlists playlists_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlists
+    ADD CONSTRAINT playlists_pkey PRIMARY KEY (playlist_id, txhash);
+
+
+--
+-- Name: plays plays_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.plays
+    ADD CONSTRAINT plays_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prizes prizes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.prizes
+    ADD CONSTRAINT prizes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prizes prizes_prize_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.prizes
+    ADD CONSTRAINT prizes_prize_id_key UNIQUE (prize_id);
+
+
+--
+-- Name: reactions reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reactions
+    ADD CONSTRAINT reactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: related_artists related_artists_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.related_artists
+    ADD CONSTRAINT related_artists_pkey PRIMARY KEY (user_id, related_artist_user_id);
+
+
+--
+-- Name: remixes remixes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.remixes
+    ADD CONSTRAINT remixes_pkey PRIMARY KEY (parent_track_id, child_track_id);
+
+
+--
+-- Name: reported_comments reported_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reported_comments
+    ADD CONSTRAINT reported_comments_pkey PRIMARY KEY (reported_comment_id, user_id);
+
+
+--
+-- Name: reposts reposts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reposts
+    ADD CONSTRAINT reposts_pkey PRIMARY KEY (user_id, repost_item_id, repost_type, txhash);
+
+
+--
+-- Name: revert_blocks revert_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.revert_blocks
+    ADD CONSTRAINT revert_blocks_pkey PRIMARY KEY (blocknumber);
+
+
+--
+-- Name: reward_codes reward_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reward_codes
+    ADD CONSTRAINT reward_codes_pkey PRIMARY KEY (code);
+
+
+--
+-- Name: reward_manager_txs reward_manager_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reward_manager_txs
+    ADD CONSTRAINT reward_manager_txs_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: route_metrics route_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.route_metrics
+    ADD CONSTRAINT route_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rpc_cursor rpc_cursor_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.rpc_cursor
+    ADD CONSTRAINT rpc_cursor_pkey PRIMARY KEY (relayed_by);
+
+
+--
+-- Name: rpc_error rpc_error_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.rpc_error
+    ADD CONSTRAINT rpc_error_pkey PRIMARY KEY (sig);
+
+
+--
+-- Name: rpc_log rpc_log_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.rpc_log
+    ADD CONSTRAINT rpc_log_pkey PRIMARY KEY (sig);
+
+
+--
+-- Name: saves saves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.saves
+    ADD CONSTRAINT saves_pkey PRIMARY KEY (user_id, save_item_id, save_type, txhash);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: schema_version schema_version_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.schema_version
+    ADD CONSTRAINT schema_version_pkey PRIMARY KEY (file_name);
+
+
+--
+-- Name: shares shares_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.shares
+    ADD CONSTRAINT shares_pkey PRIMARY KEY (user_id, share_item_id, share_type, txhash);
+
+
+--
+-- Name: skipped_transactions skipped_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.skipped_transactions
+    ADD CONSTRAINT skipped_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sla_auditor_version_data sla_auditor_version_data_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_auditor_version_data
+    ADD CONSTRAINT sla_auditor_version_data_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sla_node_reports sla_node_reports_address_sla_rollup_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_node_reports
+    ADD CONSTRAINT sla_node_reports_address_sla_rollup_id_key UNIQUE (address, sla_rollup_id);
+
+
+--
+-- Name: sla_node_reports sla_node_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_node_reports
+    ADD CONSTRAINT sla_node_reports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sla_rollups sla_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_rollups
+    ADD CONSTRAINT sla_rollups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sol_claimable_account_transfers sol_claimable_account_transfers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_claimable_account_transfers
+    ADD CONSTRAINT sol_claimable_account_transfers_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_claimable_accounts sol_claimable_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_claimable_accounts
+    ADD CONSTRAINT sol_claimable_accounts_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_keypairs sol_keypairs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_keypairs
+    ADD CONSTRAINT sol_keypairs_pkey PRIMARY KEY (public_key);
+
+
+--
+-- Name: sol_locker_vesting_escrows sol_locker_vesting_escrows_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_locker_vesting_escrows
+    ADD CONSTRAINT sol_locker_vesting_escrows_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_damm_v2_initialize_custom_pool_instructions sol_meteora_damm_v2_initialize_custom_pool_instructions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_initialize_custom_pool_instructions
+    ADD CONSTRAINT sol_meteora_damm_v2_initialize_custom_pool_instructions_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_base_fees sol_meteora_damm_v2_pool_base_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_base_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_base_fees_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_dynamic_fees sol_meteora_damm_v2_pool_dynamic_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_dynamic_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_dynamic_fees_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_fees sol_meteora_damm_v2_pool_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_fees_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_metrics sol_meteora_damm_v2_pool_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_metrics
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_metrics_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_damm_v2_pools sol_meteora_damm_v2_pools_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pools
+    ADD CONSTRAINT sol_meteora_damm_v2_pools_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_damm_v2_position_metrics sol_meteora_damm_v2_position_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_position_metrics
+    ADD CONSTRAINT sol_meteora_damm_v2_position_metrics_pkey PRIMARY KEY ("position");
+
+
+--
+-- Name: sol_meteora_damm_v2_positions sol_meteora_damm_v2_positions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_positions
+    ADD CONSTRAINT sol_meteora_damm_v2_positions_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_dbc_config_fees sol_meteora_dbc_config_fees_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_fees
+    ADD CONSTRAINT sol_meteora_dbc_config_fees_pkey PRIMARY KEY (config);
+
+
+--
+-- Name: sol_meteora_dbc_config_vestings sol_meteora_dbc_config_vestings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_vestings
+    ADD CONSTRAINT sol_meteora_dbc_config_vestings_pkey PRIMARY KEY (config);
+
+
+--
+-- Name: sol_meteora_dbc_configs sol_meteora_dbc_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_configs
+    ADD CONSTRAINT sol_meteora_dbc_configs_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_meteora_dbc_migrations sol_meteora_dbc_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_migrations
+    ADD CONSTRAINT sol_meteora_dbc_migrations_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_meteora_dbc_pool_metrics sol_meteora_dbc_pool_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_pool_metrics
+    ADD CONSTRAINT sol_meteora_dbc_pool_metrics_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_dbc_pool_volatility_trackers sol_meteora_dbc_pool_volatility_trackers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_pool_volatility_trackers
+    ADD CONSTRAINT sol_meteora_dbc_pool_volatility_trackers_pkey PRIMARY KEY (pool);
+
+
+--
+-- Name: sol_meteora_dbc_pools sol_meteora_dbc_pools_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_pools
+    ADD CONSTRAINT sol_meteora_dbc_pools_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_payments sol_payments_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_payments
+    ADD CONSTRAINT sol_payments_pkey PRIMARY KEY (signature, instruction_index, route_index);
+
+
+--
+-- Name: sol_purchases sol_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_purchases
+    ADD CONSTRAINT sol_purchases_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_retry_queue sol_retry_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_retry_queue
+    ADD CONSTRAINT sol_retry_queue_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sol_reward_disbursements sol_reward_disbursements_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_reward_disbursements
+    ADD CONSTRAINT sol_reward_disbursements_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_reward_manager_inits sol_reward_manager_inits_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_reward_manager_inits
+    ADD CONSTRAINT sol_reward_manager_inits_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_slot_checkpoints sol_slot_checkpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_slot_checkpoints
+    ADD CONSTRAINT sol_slot_checkpoints_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sol_token_account_balance_changes sol_token_account_balance_changes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_token_account_balance_changes
+    ADD CONSTRAINT sol_token_account_balance_changes_pkey PRIMARY KEY (signature, mint, account);
+
+
+--
+-- Name: sol_token_account_balances sol_token_account_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_token_account_balances
+    ADD CONSTRAINT sol_token_account_balances_pkey PRIMARY KEY (account);
+
+
+--
+-- Name: sol_token_transfers sol_token_transfers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_token_transfers
+    ADD CONSTRAINT sol_token_transfers_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_transfer_memo_types sol_transfer_memo_types_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_transfer_memo_types
+    ADD CONSTRAINT sol_transfer_memo_types_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_user_balances sol_user_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_user_balances
+    ADD CONSTRAINT sol_user_balances_pkey PRIMARY KEY (user_id, mint);
+
+
+--
+-- Name: sound_recordings sound_recordings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sound_recordings
+    ADD CONSTRAINT sound_recordings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: spl_token_tx spl_token_tx_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.spl_token_tx
+    ADD CONSTRAINT spl_token_tx_pkey PRIMARY KEY (last_scanned_slot);
+
+
+--
+-- Name: stems stems_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stems
+    ADD CONSTRAINT stems_pkey PRIMARY KEY (parent_track_id, child_track_id);
+
+
+--
+-- Name: storage_proof_peers storage_proof_peers_block_height_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.storage_proof_peers
+    ADD CONSTRAINT storage_proof_peers_block_height_key UNIQUE (block_height);
+
+
+--
+-- Name: storage_proof_peers storage_proof_peers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.storage_proof_peers
+    ADD CONSTRAINT storage_proof_peers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: storage_proofs storage_proofs_address_block_height_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.storage_proofs
+    ADD CONSTRAINT storage_proofs_address_block_height_key UNIQUE (address, block_height);
+
+
+--
+-- Name: storage_proofs storage_proofs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.storage_proofs
+    ADD CONSTRAINT storage_proofs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (subscriber_id, user_id, txhash);
+
+
+--
+-- Name: supporter_rank_ups supporter_rank_ups_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.supporter_rank_ups
+    ADD CONSTRAINT supporter_rank_ups_pkey PRIMARY KEY (slot, sender_user_id, receiver_user_id);
+
+
+--
+-- Name: track_collaborators track_collaborators_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_collaborators
+    ADD CONSTRAINT track_collaborators_pkey PRIMARY KEY (track_id, collaborator_user_id);
+
+
+--
+-- Name: track_delist_statuses track_delist_statuses_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_delist_statuses
+    ADD CONSTRAINT track_delist_statuses_pkey PRIMARY KEY (created_at, track_id, delisted);
+
+
+--
+-- Name: track_downloads track_downloads_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_downloads
+    ADD CONSTRAINT track_downloads_pkey PRIMARY KEY (parent_track_id, track_id, txhash);
+
+
+--
+-- Name: track_price_history track_price_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_price_history
+    ADD CONSTRAINT track_price_history_pkey PRIMARY KEY (track_id, block_timestamp);
+
+
+--
+-- Name: track_releases track_releases_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_releases
+    ADD CONSTRAINT track_releases_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: track_releases track_releases_track_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_releases
+    ADD CONSTRAINT track_releases_track_id_key UNIQUE (track_id);
+
+
+--
+-- Name: track_routes track_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_routes
+    ADD CONSTRAINT track_routes_pkey PRIMARY KEY (owner_id, slug);
+
+
+--
+-- Name: track_trending_scores track_trending_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_trending_scores
+    ADD CONSTRAINT track_trending_scores_pkey PRIMARY KEY (track_id, type, version, time_range);
+
+
+--
+-- Name: tracks tracks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.tracks
+    ADD CONSTRAINT tracks_pkey PRIMARY KEY (track_id, txhash);
+
+
+--
+-- Name: trending_results trending_results_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.trending_results
+    ADD CONSTRAINT trending_results_pkey PRIMARY KEY (rank, type, version, week);
+
+
+--
+-- Name: associated_wallets unique_user_wallet_chain; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.associated_wallets
+    ADD CONSTRAINT unique_user_wallet_chain UNIQUE (user_id, wallet, chain);
+
+
+--
+-- Name: notification uq_notification; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.notification
+    ADD CONSTRAINT uq_notification UNIQUE (group_id, specifier);
+
+
+--
+-- Name: usdc_purchases usdc_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.usdc_purchases
+    ADD CONSTRAINT usdc_purchases_pkey PRIMARY KEY (slot, signature);
+
+
+--
+-- Name: usdc_user_bank_accounts usdc_user_bank_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.usdc_user_bank_accounts
+    ADD CONSTRAINT usdc_user_bank_accounts_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: user_balance_changes user_balance_changes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_balance_changes
+    ADD CONSTRAINT user_balance_changes_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_balance_history user_balance_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_balance_history
+    ADD CONSTRAINT user_balance_history_pkey PRIMARY KEY (user_id, "timestamp", mint);
+
+
+--
+-- Name: user_balances user_balances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_balances
+    ADD CONSTRAINT user_balances_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_bank_accounts user_bank_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_bank_accounts
+    ADD CONSTRAINT user_bank_accounts_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: user_bank_txs user_bank_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_bank_txs
+    ADD CONSTRAINT user_bank_txs_pkey PRIMARY KEY (signature);
+
+
+--
+-- Name: user_challenges user_challenges_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_challenges
+    ADD CONSTRAINT user_challenges_pkey PRIMARY KEY (challenge_id, specifier);
+
+
+--
+-- Name: user_delist_statuses user_delist_statuses_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_delist_statuses
+    ADD CONSTRAINT user_delist_statuses_pkey PRIMARY KEY (created_at, user_id, delisted);
+
+
+--
+-- Name: user_distinct_play_hours user_distinct_play_hours_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_distinct_play_hours
+    ADD CONSTRAINT user_distinct_play_hours_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_distinct_play_tracks user_distinct_play_tracks_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_distinct_play_tracks
+    ADD CONSTRAINT user_distinct_play_tracks_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_events user_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_events
+    ADD CONSTRAINT user_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_listening_history user_listening_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_listening_history
+    ADD CONSTRAINT user_listening_history_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_payout_wallet_history user_payout_wallet_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_payout_wallet_history
+    ADD CONSTRAINT user_payout_wallet_history_pkey PRIMARY KEY (user_id, block_timestamp);
+
+
+--
+-- Name: user_pubkeys user_pubkeys_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_pubkeys
+    ADD CONSTRAINT user_pubkeys_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_score_features user_score_features_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_score_features
+    ADD CONSTRAINT user_score_features_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_tips user_tips_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_tips
+    ADD CONSTRAINT user_tips_pkey PRIMARY KEY (slot, signature);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (user_id, txhash);
+
+
+--
+-- Name: validator_history validator_history_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.validator_history
+    ADD CONSTRAINT validator_history_pkey PRIMARY KEY (rowid);
+
+
+--
+-- Name: volume_leader_exclusions volume_leader_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.volume_leader_exclusions
+    ADD CONSTRAINT volume_leader_exclusions_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: agg_user_has_tracks_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX agg_user_has_tracks_idx ON public.aggregate_user USING btree (user_id) WHERE (total_track_count > 0);
+
+
+--
+-- Name: artist_coins_ticker_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX artist_coins_ticker_idx ON public.artist_coins USING btree (ticker, user_id);
+
+
+--
+-- Name: INDEX artist_coins_ticker_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.artist_coins_ticker_idx IS 'Used for getting mint address by ticker.';
+
+
+--
+-- Name: artist_coins_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX artist_coins_user_id_idx ON public.artist_coins USING btree (user_id);
+
+
+--
+-- Name: INDEX artist_coins_user_id_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.artist_coins_user_id_idx IS 'Used for getting coins minted by a particular artist.';
+
+
+--
+-- Name: challenge_disbursements_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX challenge_disbursements_user_id ON public.challenge_disbursements USING btree (user_id);
+
+
+--
+-- Name: chat_member_user_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX chat_member_user_idx ON public.chat_member USING btree (user_id);
+
+
+--
+-- Name: chat_message_chat_created_non_blast_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX chat_message_chat_created_non_blast_idx ON public.chat_message USING btree (chat_id, created_at, user_id) WHERE (blast_id IS NULL);
+
+
+--
+-- Name: chat_message_reactions_updated_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX chat_message_reactions_updated_at_idx ON public.chat_message_reactions USING btree (updated_at, message_id, user_id);
+
+
+--
+-- Name: INDEX chat_message_reactions_updated_at_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.chat_message_reactions_updated_at_idx IS 'Supports DM reaction notification polling by updated_at cursor.';
+
+
+--
+-- Name: claimed_prizes_mint_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX claimed_prizes_mint_idx ON public.claimed_prizes USING btree (mint);
+
+
+--
+-- Name: INDEX claimed_prizes_mint_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.claimed_prizes_mint_idx IS 'Used for getting claimed prizes by coin mint.';
+
+
+--
+-- Name: claimed_prizes_signature_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX claimed_prizes_signature_idx ON public.claimed_prizes USING btree (signature);
+
+
+--
+-- Name: INDEX claimed_prizes_signature_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.claimed_prizes_signature_idx IS 'Used for checking if a signature has already been used.';
+
+
+--
+-- Name: claimed_prizes_wallet_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX claimed_prizes_wallet_idx ON public.claimed_prizes USING btree (wallet);
+
+
+--
+-- Name: INDEX claimed_prizes_wallet_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.claimed_prizes_wallet_idx IS 'Used for getting claimed prizes by wallet.';
+
+
+--
+-- Name: comments_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX comments_blocknumber_idx ON public.comments USING btree (blocknumber);
+
+
+--
+-- Name: INDEX comments_blocknumber_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.comments_blocknumber_idx IS 'Range scans by blocknumber for the incremental FirstWeeklyComment challenge processor (c).';
+
+
+--
+-- Name: comments_user_track_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX comments_user_track_created_at_idx ON public.comments USING btree (user_id, created_at DESC) INCLUDE (comment_id) WHERE ((entity_type = 'Track'::text) AND (is_delete = false));
+
+
+--
+-- Name: eth_registered_endpoints_wallet_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX eth_registered_endpoints_wallet_idx ON public.eth_registered_endpoints USING btree (delegate_wallet);
+
+
+--
+-- Name: eth_wallet_balances_updated_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX eth_wallet_balances_updated_at_idx ON public.eth_wallet_balances USING btree (updated_at);
+
+
+--
+-- Name: INDEX eth_wallet_balances_updated_at_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.eth_wallet_balances_updated_at_idx IS 'Supports staleness queries / catch-up sweeps.';
+
+
+--
+-- Name: etl_blocks_block_height_desc_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_blocks_block_height_desc_idx ON public.etl_blocks USING btree (block_height DESC);
+
+
+--
+-- Name: etl_blocks_block_height_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_blocks_block_height_idx ON public.etl_blocks USING btree (block_height);
+
+
+--
+-- Name: etl_blocks_block_time_height_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_blocks_block_time_height_idx ON public.etl_blocks USING btree (block_time DESC, block_height DESC);
+
+
+--
+-- Name: etl_blocks_block_time_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_blocks_block_time_idx ON public.etl_blocks USING btree (block_time);
+
+
+--
+-- Name: etl_blocks_block_time_range_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_blocks_block_time_range_idx ON public.etl_blocks USING btree (block_time, block_height);
+
+
+--
+-- Name: etl_blocks_id_desc_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_blocks_id_desc_idx ON public.etl_blocks USING btree (id DESC);
+
+
+--
+-- Name: etl_manage_entities_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_manage_entities_cursor_idx ON public.etl_manage_entities USING btree (block_height, id);
+
+
+--
+-- Name: etl_manage_entities_tx_hash_action_entity_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_manage_entities_tx_hash_action_entity_idx ON public.etl_manage_entities USING btree (tx_hash, action, entity_type);
+
+
+--
+-- Name: etl_manage_entities_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_manage_entities_tx_hash_idx ON public.etl_manage_entities USING btree (tx_hash);
+
+
+--
+-- Name: etl_plays_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_plays_cursor_idx ON public.etl_plays USING btree (block_height, id);
+
+
+--
+-- Name: etl_plays_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_plays_tx_hash_idx ON public.etl_plays USING btree (tx_hash);
+
+
+--
+-- Name: etl_sla_node_reports_address_lower_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_node_reports_address_lower_idx ON public.etl_sla_node_reports USING btree (lower(address));
+
+
+--
+-- Name: etl_sla_node_reports_address_sla_rollup_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_node_reports_address_sla_rollup_idx ON public.etl_sla_node_reports USING btree (address, sla_rollup_id);
+
+
+--
+-- Name: etl_sla_node_reports_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_node_reports_cursor_idx ON public.etl_sla_node_reports USING btree (block_height, id);
+
+
+--
+-- Name: etl_sla_node_reports_sla_rollup_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_node_reports_sla_rollup_id_idx ON public.etl_sla_node_reports USING btree (sla_rollup_id);
+
+
+--
+-- Name: etl_sla_rollups_block_height_desc_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_rollups_block_height_desc_idx ON public.etl_sla_rollups USING btree (block_height DESC, id DESC);
+
+
+--
+-- Name: etl_sla_rollups_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_rollups_cursor_idx ON public.etl_sla_rollups USING btree (block_height, id);
+
+
+--
+-- Name: etl_sla_rollups_latest_covering_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_rollups_latest_covering_idx ON public.etl_sla_rollups USING btree (block_height DESC, id DESC, block_start, block_end, validator_count, block_quota, bps, tps);
+
+
+--
+-- Name: etl_sla_rollups_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_sla_rollups_tx_hash_idx ON public.etl_sla_rollups USING btree (tx_hash);
+
+
+--
+-- Name: etl_storage_proof_verifications_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proof_verifications_cursor_idx ON public.etl_storage_proof_verifications USING btree (block_height, id);
+
+
+--
+-- Name: etl_storage_proof_verifications_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proof_verifications_tx_hash_idx ON public.etl_storage_proof_verifications USING btree (tx_hash);
+
+
+--
+-- Name: etl_storage_proofs_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_cursor_idx ON public.etl_storage_proofs USING btree (block_height, id);
+
+
+--
+-- Name: etl_storage_proofs_height_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_height_address_idx ON public.etl_storage_proofs USING btree (height, address);
+
+
+--
+-- Name: etl_storage_proofs_height_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_height_idx ON public.etl_storage_proofs USING btree (height);
+
+
+--
+-- Name: etl_storage_proofs_height_range_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_height_range_idx ON public.etl_storage_proofs USING btree (height, address) WHERE (height >= 0);
+
+
+--
+-- Name: etl_storage_proofs_status_fail_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_status_fail_idx ON public.etl_storage_proofs USING btree (height, address) WHERE (status = 'fail'::public.etl_proof_status);
+
+
+--
+-- Name: etl_storage_proofs_status_unresolved_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_status_unresolved_idx ON public.etl_storage_proofs USING btree (height, address) WHERE (status = 'unresolved'::public.etl_proof_status);
+
+
+--
+-- Name: etl_storage_proofs_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_storage_proofs_tx_hash_idx ON public.etl_storage_proofs USING btree (tx_hash);
+
+
+--
+-- Name: etl_transactions_address_filter_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_address_filter_idx ON public.etl_transactions USING btree (lower(address), tx_type, created_at, block_height DESC, tx_index DESC);
+
+
+--
+-- Name: etl_transactions_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_address_idx ON public.etl_transactions USING btree (address);
+
+
+--
+-- Name: etl_transactions_address_lower_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_address_lower_idx ON public.etl_transactions USING btree (lower(address));
+
+
+--
+-- Name: etl_transactions_block_height_desc_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_block_height_desc_idx ON public.etl_transactions USING btree (block_height DESC, tx_index DESC);
+
+
+--
+-- Name: etl_transactions_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_created_at_idx ON public.etl_transactions USING btree (created_at);
+
+
+--
+-- Name: etl_transactions_created_at_type_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_created_at_type_idx ON public.etl_transactions USING btree (created_at, tx_type);
+
+
+--
+-- Name: etl_transactions_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_cursor_idx ON public.etl_transactions USING btree (block_height, id);
+
+
+--
+-- Name: etl_transactions_id_desc_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_id_desc_idx ON public.etl_transactions USING btree (id DESC);
+
+
+--
+-- Name: etl_transactions_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX etl_transactions_tx_hash_idx ON public.etl_transactions USING btree (tx_hash);
+
+
+--
+-- Name: etl_transactions_tx_type_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_transactions_tx_type_idx ON public.etl_transactions USING btree (tx_type);
+
+
+--
+-- Name: etl_validator_deregistrations_comet_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_deregistrations_comet_address_idx ON public.etl_validator_deregistrations USING btree (comet_address);
+
+
+--
+-- Name: etl_validator_deregistrations_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_deregistrations_cursor_idx ON public.etl_validator_deregistrations USING btree (block_height, id);
+
+
+--
+-- Name: etl_validator_deregistrations_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_deregistrations_tx_hash_idx ON public.etl_validator_deregistrations USING btree (tx_hash);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_misbehavior_deregistrations_cursor_idx ON public.etl_validator_misbehavior_deregistrations USING btree (block_height, id);
+
+
+--
+-- Name: etl_validator_registrations_comet_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_registrations_comet_address_idx ON public.etl_validator_registrations USING btree (comet_address);
+
+
+--
+-- Name: etl_validator_registrations_cursor_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_registrations_cursor_idx ON public.etl_validator_registrations USING btree (block_height, id);
+
+
+--
+-- Name: etl_validator_registrations_tx_hash_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validator_registrations_tx_hash_idx ON public.etl_validator_registrations USING btree (tx_hash);
+
+
+--
+-- Name: etl_validators_active_reports_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validators_active_reports_idx ON public.etl_validators USING btree (status, comet_address) WHERE (status = 'active'::text);
+
+
+--
+-- Name: etl_validators_address_lower_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validators_address_lower_idx ON public.etl_validators USING btree (lower(address));
+
+
+--
+-- Name: etl_validators_comet_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validators_comet_address_idx ON public.etl_validators USING btree (comet_address);
+
+
+--
+-- Name: etl_validators_comet_address_lower_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validators_comet_address_lower_idx ON public.etl_validators USING btree (lower(comet_address));
+
+
+--
+-- Name: etl_validators_status_covering_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validators_status_covering_idx ON public.etl_validators USING btree (status, comet_address, endpoint, node_type, spid, voting_power) WHERE (status = 'active'::text);
+
+
+--
+-- Name: etl_validators_status_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX etl_validators_status_idx ON public.etl_validators USING btree (status);
+
+
+--
+-- Name: event_routes_event_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX event_routes_event_id_idx ON public.event_routes USING btree (event_id);
+
+
+--
+-- Name: event_routes_is_current_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX event_routes_is_current_idx ON public.event_routes USING btree (event_id, is_current);
+
+
+--
+-- Name: fix_tracks_top_genre_users_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX fix_tracks_top_genre_users_idx ON public.tracks USING btree (track_id, owner_id, genre, is_unlisted, is_delete) WHERE (stem_of IS NULL);
+
+
+--
+-- Name: follows_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX follows_blocknumber_idx ON public.follows USING btree (blocknumber);
+
+
+--
+-- Name: follows_current_uniq_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX follows_current_uniq_idx ON public.follows USING btree (follower_user_id, followee_user_id) WHERE (is_current = true);
+
+
+--
+-- Name: follows_inbound_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX follows_inbound_idx ON public.follows USING btree (followee_user_id, follower_user_id, is_delete);
+
+
+--
+-- Name: idx_access_keys_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_access_keys_track_id ON public.access_keys USING btree (track_id);
+
+
+--
+-- Name: idx_aggregate_user_follower_count; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_aggregate_user_follower_count ON public.aggregate_user USING btree (user_id, follower_count);
+
+
+--
+-- Name: idx_api_access_keys_api_access_key; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_access_keys_api_access_key ON public.api_access_keys USING btree (api_access_key);
+
+
+--
+-- Name: idx_api_access_keys_is_active; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_access_keys_is_active ON public.api_access_keys USING btree (api_key, is_active) WHERE (is_active = true);
+
+
+--
+-- Name: idx_api_metrics_apps_api_key; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_apps_api_key ON public.api_metrics_apps USING btree (api_key) WHERE (api_key IS NOT NULL);
+
+
+--
+-- Name: idx_api_metrics_apps_app_name; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_apps_app_name ON public.api_metrics_apps USING btree (app_name) WHERE (app_name IS NOT NULL);
+
+
+--
+-- Name: idx_api_metrics_apps_date; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_apps_date ON public.api_metrics_apps USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_apps_unique_app_name; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_apps_unique_app_name ON public.api_metrics_apps_unique USING btree (app_name);
+
+
+--
+-- Name: idx_api_metrics_apps_unique_date; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_apps_unique_date ON public.api_metrics_apps_unique USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_counts_date; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_counts_date ON public.api_metrics_counts USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_routes_date; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_routes_date ON public.api_metrics_routes USING btree (date);
+
+
+--
+-- Name: idx_api_metrics_routes_method; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_routes_method ON public.api_metrics_routes USING btree (method);
+
+
+--
+-- Name: idx_api_metrics_routes_route_pattern; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_api_metrics_routes_route_pattern ON public.api_metrics_routes USING btree (route_pattern);
+
+
+--
+-- Name: idx_chain_blockhash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_chain_blockhash ON public.core_indexed_blocks USING btree (blockhash);
+
+
+--
+-- Name: idx_challenge_disbursements_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_challenge_disbursements_created_at ON public.challenge_disbursements USING btree (created_at);
+
+
+--
+-- Name: idx_challenge_disbursements_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_challenge_disbursements_slot ON public.challenge_disbursements USING btree (slot);
+
+
+--
+-- Name: idx_chat_message_chat_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_chat_message_chat_id ON public.chat_message USING btree (chat_id);
+
+
+--
+-- Name: idx_chat_message_reactions_message_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_chat_message_reactions_message_id ON public.chat_message_reactions USING btree (message_id);
+
+
+--
+-- Name: idx_chat_message_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_chat_message_user_id ON public.chat_message USING btree (user_id, created_at);
+
+
+--
+-- Name: idx_core_blocks_chain_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_blocks_chain_id ON public.core_blocks USING btree (chain_id);
+
+
+--
+-- Name: idx_core_blocks_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_blocks_created_at ON public.core_blocks USING btree (created_at);
+
+
+--
+-- Name: idx_core_blocks_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_blocks_hash ON public.core_blocks USING btree (hash);
+
+
+--
+-- Name: idx_core_blocks_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_blocks_height ON public.core_blocks USING btree (height);
+
+
+--
+-- Name: idx_core_blocks_proposer; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_blocks_proposer ON public.core_blocks USING btree (proposer);
+
+
+--
+-- Name: idx_core_deals_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_deals_block_height ON public.core_deals USING btree (block_height);
+
+
+--
+-- Name: idx_core_deals_ern_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_deals_ern_address ON public.core_deals USING btree (ern_address);
+
+
+--
+-- Name: idx_core_deals_tx_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_deals_tx_hash ON public.core_deals USING btree (tx_hash);
+
+
+--
+-- Name: idx_core_ern_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_ern_address ON public.core_ern USING btree (address);
+
+
+--
+-- Name: idx_core_ern_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_ern_block_height ON public.core_ern USING btree (block_height);
+
+
+--
+-- Name: idx_core_ern_message_control_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_ern_message_control_type ON public.core_ern USING btree (message_control_type);
+
+
+--
+-- Name: idx_core_ern_sender; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_ern_sender ON public.core_ern USING btree (sender);
+
+
+--
+-- Name: idx_core_mead_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_mead_address ON public.core_mead USING btree (address);
+
+
+--
+-- Name: idx_core_mead_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_mead_block_height ON public.core_mead USING btree (block_height);
+
+
+--
+-- Name: idx_core_mead_sender; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_mead_sender ON public.core_mead USING btree (sender);
+
+
+--
+-- Name: idx_core_parties_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_parties_block_height ON public.core_parties USING btree (block_height);
+
+
+--
+-- Name: idx_core_parties_ern_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_parties_ern_address ON public.core_parties USING btree (ern_address);
+
+
+--
+-- Name: idx_core_parties_tx_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_parties_tx_hash ON public.core_parties USING btree (tx_hash);
+
+
+--
+-- Name: idx_core_pie_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_pie_address ON public.core_pie USING btree (address);
+
+
+--
+-- Name: idx_core_pie_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_pie_block_height ON public.core_pie USING btree (block_height);
+
+
+--
+-- Name: idx_core_pie_sender; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_pie_sender ON public.core_pie USING btree (sender);
+
+
+--
+-- Name: idx_core_releases_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_releases_block_height ON public.core_releases USING btree (block_height);
+
+
+--
+-- Name: idx_core_releases_ern_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_releases_ern_address ON public.core_releases USING btree (ern_address);
+
+
+--
+-- Name: idx_core_releases_tx_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_releases_tx_hash ON public.core_releases USING btree (tx_hash);
+
+
+--
+-- Name: idx_core_resources_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_resources_block_height ON public.core_resources USING btree (block_height);
+
+
+--
+-- Name: idx_core_resources_ern_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_resources_ern_address ON public.core_resources USING btree (ern_address);
+
+
+--
+-- Name: idx_core_resources_tx_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_resources_tx_hash ON public.core_resources USING btree (tx_hash);
+
+
+--
+-- Name: idx_core_rewards_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_rewards_address ON public.core_rewards USING btree (address);
+
+
+--
+-- Name: idx_core_rewards_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_rewards_block_height ON public.core_rewards USING btree (block_height);
+
+
+--
+-- Name: idx_core_rewards_claim_authorities; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_rewards_claim_authorities ON public.core_rewards USING gin (claim_authorities);
+
+
+--
+-- Name: idx_core_rewards_reward_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_rewards_reward_id ON public.core_rewards USING btree (reward_id);
+
+
+--
+-- Name: idx_core_rewards_sender; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_rewards_sender ON public.core_rewards USING btree (sender);
+
+
+--
+-- Name: idx_core_stats_tx_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_stats_tx_type ON public.core_tx_stats USING btree (tx_type);
+
+
+--
+-- Name: idx_core_transactions_block_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_transactions_block_id ON public.core_transactions USING btree (block_id);
+
+
+--
+-- Name: idx_core_transactions_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_transactions_created_at ON public.core_transactions USING btree (created_at);
+
+
+--
+-- Name: idx_core_transactions_tx_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_transactions_tx_hash ON public.core_transactions USING btree (tx_hash);
+
+
+--
+-- Name: idx_core_transactions_tx_hash_lower; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_transactions_tx_hash_lower ON public.core_transactions USING btree (lower(tx_hash));
+
+
+--
+-- Name: idx_core_tx_hash; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_tx_hash ON public.core_tx_stats USING btree (tx_hash);
+
+
+--
+-- Name: idx_core_tx_stats_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_tx_stats_created_at ON public.core_tx_stats USING btree (created_at);
+
+
+--
+-- Name: idx_core_tx_stats_time_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_tx_stats_time_type ON public.core_tx_stats USING btree (created_at, tx_type);
+
+
+--
+-- Name: idx_core_uploads_cid; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_uploads_cid ON public.core_uploads USING btree (cid);
+
+
+--
+-- Name: idx_core_uploads_transcoded_cid; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_uploads_transcoded_cid ON public.core_uploads USING btree (transcoded_cid);
+
+
+--
+-- Name: idx_core_validators_comet_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_validators_comet_address ON public.core_validators USING btree (comet_address);
+
+
+--
+-- Name: idx_core_validators_endpoint; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_validators_endpoint ON public.core_validators USING btree (endpoint);
+
+
+--
+-- Name: idx_core_validators_eth_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_core_validators_eth_address ON public.core_validators USING btree (eth_address);
+
+
+--
+-- Name: idx_dashboard_wallet_users_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_dashboard_wallet_users_user_id ON public.dashboard_wallet_users USING btree (user_id);
+
+
+--
+-- Name: idx_ddex_release_ids; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_ddex_release_ids ON public.tracks USING gin (ddex_release_ids);
+
+
+--
+-- Name: idx_email_access_grantor; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_email_access_grantor ON public.email_access USING btree (grantor_user_id);
+
+
+--
+-- Name: idx_email_access_receiver; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_email_access_receiver ON public.email_access USING btree (receiving_user_id);
+
+
+--
+-- Name: idx_encrypted_emails_email_address_owner_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_encrypted_emails_email_address_owner_user_id ON public.encrypted_emails USING btree (email_owner_user_id);
+
+
+--
+-- Name: idx_events_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_events_created_at ON public.events USING btree (created_at);
+
+
+--
+-- Name: idx_events_end_date; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_events_end_date ON public.events USING btree (end_date);
+
+
+--
+-- Name: idx_events_entity_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_events_entity_id ON public.events USING btree (entity_id);
+
+
+--
+-- Name: idx_events_entity_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_events_entity_type ON public.events USING btree (entity_type);
+
+
+--
+-- Name: idx_events_event_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_events_event_type ON public.events USING btree (event_type);
+
+
+--
+-- Name: idx_fanout; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_fanout ON public.follows USING btree (follower_user_id, followee_user_id);
+
+
+--
+-- Name: idx_fanout_not_deleted; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_fanout_not_deleted ON public.follows USING btree (follower_user_id, followee_user_id) WHERE (is_delete = false);
+
+
+--
+-- Name: idx_genre_related_artists; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_genre_related_artists ON public.aggregate_user USING btree (dominant_genre, follower_count, user_id);
+
+
+--
+-- Name: idx_grants_grantee_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_grants_grantee_address ON public.grants USING btree (grantee_address, is_revoked, created_at DESC) WHERE (is_current = true);
+
+
+--
+-- Name: idx_grants_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_grants_user_id ON public.grants USING btree (user_id);
+
+
+--
+-- Name: idx_lower_wallet; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_lower_wallet ON public.users USING btree (lower((wallet)::text));
+
+
+--
+-- Name: idx_management_keys_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_management_keys_track_id ON public.management_keys USING btree (track_id);
+
+
+--
+-- Name: idx_oauth_authorization_codes_client_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_authorization_codes_client_id ON public.oauth_authorization_codes USING btree (client_id);
+
+
+--
+-- Name: idx_oauth_authorization_codes_expires_used; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_authorization_codes_expires_used ON public.oauth_authorization_codes USING btree (expires_at, used);
+
+
+--
+-- Name: idx_oauth_redirect_uris_client_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_redirect_uris_client_id ON public.oauth_redirect_uris USING btree (client_id);
+
+
+--
+-- Name: idx_oauth_tokens_client_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_tokens_client_id ON public.oauth_tokens USING btree (client_id);
+
+
+--
+-- Name: idx_oauth_tokens_family_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_tokens_family_id ON public.oauth_tokens USING btree (family_id);
+
+
+--
+-- Name: idx_oauth_tokens_lookup; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_tokens_lookup ON public.oauth_tokens USING btree (token, token_type, is_revoked, expires_at);
+
+
+--
+-- Name: idx_oauth_tokens_refresh_token_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_tokens_refresh_token_id ON public.oauth_tokens USING btree (refresh_token_id);
+
+
+--
+-- Name: idx_oauth_tokens_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_oauth_tokens_user_id ON public.oauth_tokens USING btree (user_id);
+
+
+--
+-- Name: idx_payment_router_txs_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_payment_router_txs_slot ON public.payment_router_txs USING btree (slot);
+
+
+--
+-- Name: idx_playlist_status; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_playlist_status ON public.playlists USING btree (playlist_id, is_album, is_private, is_delete, is_current);
+
+
+--
+-- Name: idx_playlist_tracks_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_playlist_tracks_track_id ON public.playlist_tracks USING btree (track_id, created_at);
+
+
+--
+-- Name: idx_playlist_trending_scores_ordered; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_playlist_trending_scores_ordered ON public.playlist_trending_scores USING btree (type, version, time_range, score DESC, playlist_id DESC);
+
+
+--
+-- Name: INDEX idx_playlist_trending_scores_ordered; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.idx_playlist_trending_scores_ordered IS 'Covers playlist trending endpoints ordered by score desc, playlist_id desc.';
+
+
+--
+-- Name: idx_playlists_albums_published; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_playlists_albums_published ON public.playlists USING btree (playlist_id) WHERE ((is_album = true) AND (is_delete = false) AND (is_current = true));
+
+
+--
+-- Name: INDEX idx_playlists_albums_published; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.idx_playlists_albums_published IS 'Partial index for GetTracks album_backlink subquery; lets non-album lookups skip the heap entirely.';
+
+
+--
+-- Name: idx_reward_manager_txs_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_reward_manager_txs_slot ON public.reward_manager_txs USING btree (slot);
+
+
+--
+-- Name: idx_rpc_relayed_by; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_rpc_relayed_by ON public.rpc_log USING btree (relayed_by, relayed_at);
+
+
+--
+-- Name: idx_sla_node_reports_rollup_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_sla_node_reports_rollup_address ON public.sla_node_reports USING btree (sla_rollup_id, address);
+
+
+--
+-- Name: idx_sla_rollups_block_end; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_sla_rollups_block_end ON public.sla_rollups USING btree (block_end DESC);
+
+
+--
+-- Name: idx_sol_reward_manager_inits_mint; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_sol_reward_manager_inits_mint ON public.sol_reward_manager_inits USING btree (mint);
+
+
+--
+-- Name: INDEX idx_sol_reward_manager_inits_mint; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.idx_sol_reward_manager_inits_mint IS 'Index to quickly find reward manager init instructions by mint of its token rewards';
+
+
+--
+-- Name: idx_sound_recordings_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_sound_recordings_track_id ON public.sound_recordings USING btree (track_id);
+
+
+--
+-- Name: idx_storage_proof_peers_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_storage_proof_peers_block_height ON public.storage_proof_peers USING btree (block_height DESC);
+
+
+--
+-- Name: idx_storage_proofs_block_height; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_storage_proofs_block_height ON public.storage_proofs USING btree (block_height DESC);
+
+
+--
+-- Name: idx_time; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_time ON public.sla_rollups USING btree ("time" DESC);
+
+
+--
+-- Name: idx_track_collaborators_collaborator; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_track_collaborators_collaborator ON public.track_collaborators USING btree (collaborator_user_id, status, track_id);
+
+
+--
+-- Name: idx_track_downloads_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_track_downloads_track_id ON public.track_downloads USING btree (track_id);
+
+
+--
+-- Name: idx_track_downloads_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_track_downloads_user_id ON public.track_downloads USING btree (user_id);
+
+
+--
+-- Name: idx_track_releases_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_track_releases_track_id ON public.track_releases USING btree (track_id);
+
+
+--
+-- Name: idx_track_status; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_track_status ON public.tracks USING btree (track_id, is_unlisted, is_available, is_delete, is_current);
+
+
+--
+-- Name: idx_track_trending_scores_for_you_desc_tiebreak; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_track_trending_scores_for_you_desc_tiebreak ON public.track_trending_scores USING btree (score DESC, track_id DESC) WHERE (((type)::text = 'TRACKS'::text) AND ((version)::text = 'pnagD'::text) AND ((time_range)::text = 'week'::text) AND ((genre IS NULL) OR ((genre)::text = ''::text)));
+
+
+--
+-- Name: INDEX idx_track_trending_scores_for_you_desc_tiebreak; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.idx_track_trending_scores_for_you_desc_tiebreak IS 'Partial index matching For You feed weekly track candidate ordering by score desc, track_id desc.';
+
+
+--
+-- Name: idx_tracks_stream_conditions_gin; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_tracks_stream_conditions_gin ON public.tracks USING gin (stream_conditions);
+
+
+--
+-- Name: idx_tts_genre_time_score; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_tts_genre_time_score ON public.track_trending_scores USING btree (genre, time_range, score DESC, track_id);
+
+
+--
+-- Name: idx_usdc_purchases_buyer; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_usdc_purchases_buyer ON public.usdc_purchases USING btree (buyer_user_id);
+
+
+--
+-- Name: idx_usdc_purchases_seller; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_usdc_purchases_seller ON public.usdc_purchases USING btree (seller_user_id);
+
+
+--
+-- Name: idx_usdc_purchases_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_usdc_purchases_type ON public.usdc_purchases USING btree (content_type);
+
+
+--
+-- Name: idx_usdc_transactions_history_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_usdc_transactions_history_slot ON public.usdc_transactions_history USING btree (slot);
+
+
+--
+-- Name: idx_usdc_transactions_history_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_usdc_transactions_history_type ON public.usdc_transactions_history USING btree (transaction_type);
+
+
+--
+-- Name: idx_usdc_user_bank_accounts_eth_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_usdc_user_bank_accounts_eth_address ON public.usdc_user_bank_accounts USING btree (ethereum_address);
+
+
+--
+-- Name: idx_user_bank_eth_address; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_user_bank_eth_address ON public.user_bank_accounts USING btree (ethereum_address);
+
+
+--
+-- Name: idx_user_bank_txs_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_user_bank_txs_slot ON public.user_bank_txs USING btree (slot);
+
+
+--
+-- Name: idx_user_status; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_user_status ON public.users USING btree (user_id, is_deactivated, is_available, is_current);
+
+
+--
+-- Name: idx_validator_history_event_time; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX idx_validator_history_event_time ON public.validator_history USING btree (event_time);
+
+
+--
+-- Name: interval_play_track_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX interval_play_track_id_idx ON public.aggregate_interval_plays USING btree (track_id);
+
+
+--
+-- Name: ix_aggregate_user_tips_receiver_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_aggregate_user_tips_receiver_user_id ON public.aggregate_user_tips USING btree (receiver_user_id);
+
+
+--
+-- Name: ix_announcement; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_announcement ON public.notification USING btree (type, "timestamp") WHERE ((type)::text = 'announcement'::text);
+
+
+--
+-- Name: ix_associated_wallets_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_associated_wallets_user_id ON public.associated_wallets USING btree (user_id);
+
+
+--
+-- Name: ix_associated_wallets_wallet; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_associated_wallets_wallet ON public.associated_wallets USING btree (wallet);
+
+
+--
+-- Name: ix_au_user_follows; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_au_user_follows ON public.aggregate_user USING btree (user_id) INCLUDE (follower_count, following_count);
+
+
+--
+-- Name: INDEX ix_au_user_follows; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.ix_au_user_follows IS 'Fast lookup for fields use in karma calculation';
+
+
+--
+-- Name: ix_audio_transactions_history_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_audio_transactions_history_slot ON public.audio_transactions_history USING btree (slot);
+
+
+--
+-- Name: ix_audio_transactions_history_transaction_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_audio_transactions_history_transaction_type ON public.audio_transactions_history USING btree (transaction_type);
+
+
+--
+-- Name: ix_follows_followee_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_follows_followee_user_id ON public.follows USING btree (followee_user_id);
+
+
+--
+-- Name: ix_follows_follower_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_follows_follower_user_id ON public.follows USING btree (follower_user_id);
+
+
+--
+-- Name: ix_notification; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_notification ON public.notification USING gin (user_ids);
+
+
+--
+-- Name: ix_notification_cooldown_user_ids; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_notification_cooldown_user_ids ON public.notification USING gin (user_ids) WHERE ((type)::text = 'reward_in_cooldown'::text);
+
+
+--
+-- Name: INDEX ix_notification_cooldown_user_ids; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.ix_notification_cooldown_user_ids IS 'Partial GIN for the on_user_challenge trigger''s cooldown-window check; replaces a multi-second IO-bound scan against the full 8GB notification table with a tiny in-subset lookup.';
+
+
+--
+-- Name: ix_oauth_redirect_uris_client_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_oauth_redirect_uris_client_id ON public.oauth_redirect_uris USING btree (client_id);
+
+
+--
+-- Name: ix_playlist_trending_scores_playlist_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_playlist_trending_scores_playlist_id ON public.playlist_trending_scores USING btree (playlist_id);
+
+
+--
+-- Name: ix_plays_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_plays_created_at ON public.plays USING btree (created_at);
+
+
+--
+-- Name: ix_plays_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_plays_slot ON public.plays USING btree (slot);
+
+
+--
+-- Name: ix_plays_sol_signature; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_plays_sol_signature ON public.plays USING btree (signature);
+
+
+--
+-- Name: ix_plays_user_hour; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_plays_user_hour ON public.plays USING btree (user_id, date_trunc('hour'::text, created_at)) WHERE (user_id IS NOT NULL);
+
+
+--
+-- Name: INDEX ix_plays_user_hour; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.ix_plays_user_hour IS 'Helps compute distinct hourly plays by user id';
+
+
+--
+-- Name: ix_plays_user_track_date; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_plays_user_track_date ON public.plays USING btree (user_id, play_item_id, created_at) WHERE (user_id IS NOT NULL);
+
+
+--
+-- Name: ix_reactions_reacted_to_reaction_type; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_reactions_reacted_to_reaction_type ON public.reactions USING btree (reacted_to, reaction_type);
+
+
+--
+-- Name: ix_subscriptions_blocknumber; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_subscriptions_blocknumber ON public.subscriptions USING btree (blocknumber);
+
+
+--
+-- Name: ix_subscriptions_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_subscriptions_user_id ON public.subscriptions USING btree (user_id);
+
+
+--
+-- Name: ix_supporter_rank_ups_receiver_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_supporter_rank_ups_receiver_user_id ON public.supporter_rank_ups USING btree (receiver_user_id);
+
+
+--
+-- Name: ix_supporter_rank_ups_sender_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_supporter_rank_ups_sender_user_id ON public.supporter_rank_ups USING btree (sender_user_id);
+
+
+--
+-- Name: ix_supporter_rank_ups_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_supporter_rank_ups_slot ON public.supporter_rank_ups USING btree (slot);
+
+
+--
+-- Name: ix_track_trending_scores_genre; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_track_trending_scores_genre ON public.track_trending_scores USING btree (genre);
+
+
+--
+-- Name: ix_track_trending_scores_track_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_track_trending_scores_track_id ON public.track_trending_scores USING btree (track_id);
+
+
+--
+-- Name: ix_trending_scores_desc_tiebreak; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_trending_scores_desc_tiebreak ON public.track_trending_scores USING btree (type, version, time_range, score DESC, track_id DESC);
+
+
+--
+-- Name: ix_user_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_user_created_at ON public.users USING btree (created_at, user_id, is_current);
+
+
+--
+-- Name: ix_user_events_blocknumber; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_user_events_blocknumber ON public.user_events USING btree (blocknumber);
+
+
+--
+-- Name: INDEX ix_user_events_blocknumber; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.ix_user_events_blocknumber IS 'Range scans by blocknumber for the incremental Phase 3 challenge processors (m/r/rv/rd).';
+
+
+--
+-- Name: ix_user_tips_receiver_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_user_tips_receiver_user_id ON public.user_tips USING btree (receiver_user_id);
+
+
+--
+-- Name: ix_user_tips_sender_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_user_tips_sender_user_id ON public.user_tips USING btree (sender_user_id);
+
+
+--
+-- Name: ix_user_tips_slot; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_user_tips_slot ON public.user_tips USING btree (slot);
+
+
+--
+-- Name: ix_users_active_count; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_users_active_count ON public.users USING btree (is_deactivated, is_current, handle_lc, is_available) WHERE ((is_deactivated = false) AND (is_current = true) AND (handle_lc IS NOT NULL) AND (is_available = true));
+
+
+--
+-- Name: milestones_name_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX milestones_name_idx ON public.milestones USING btree (name, id);
+
+
+--
+-- Name: mv_dashboard_transaction_stats_24h_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX mv_dashboard_transaction_stats_24h_idx ON public.mv_dashboard_transaction_stats USING btree (transactions_24h);
+
+
+--
+-- Name: mv_dashboard_transaction_types_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX mv_dashboard_transaction_types_idx ON public.mv_dashboard_transaction_types USING btree (tx_type, transaction_count);
+
+
+--
+-- Name: notification_seen_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX notification_seen_blocknumber_idx ON public.notification_seen USING btree (blocknumber);
+
+
+--
+-- Name: playlist_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX playlist_created_at_idx ON public.playlists USING btree (created_at);
+
+
+--
+-- Name: playlist_owner_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX playlist_owner_idx ON public.playlists USING btree (playlist_owner_id, created_at);
+
+
+--
+-- Name: playlist_routes_owner_title_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX playlist_routes_owner_title_slug_idx ON public.playlist_routes USING btree (owner_id, title_slug, collision_id);
+
+
+--
+-- Name: playlist_routes_playlist_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX playlist_routes_playlist_id_idx ON public.playlist_routes USING btree (playlist_id);
+
+
+--
+-- Name: playlists_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX playlists_blocknumber_idx ON public.playlists USING btree (blocknumber);
+
+
+--
+-- Name: playlists_scheduled_release_due_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX playlists_scheduled_release_due_idx ON public.playlists USING btree (release_date) WHERE ((is_private = true) AND (is_album = true) AND (is_scheduled_release = true) AND (release_date IS NOT NULL) AND (is_current = true) AND (is_delete = false));
+
+
+--
+-- Name: INDEX playlists_scheduled_release_due_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.playlists_scheduled_release_due_idx IS 'Covers the scheduled-release publisher album update by release_date for due private scheduled albums.';
+
+
+--
+-- Name: prizes_active_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX prizes_active_idx ON public.prizes USING btree (is_active);
+
+
+--
+-- Name: INDEX prizes_active_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.prizes_active_idx IS 'Used for filtering active prizes.';
+
+
+--
+-- Name: related_artists_related_artist_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX related_artists_related_artist_id_idx ON public.related_artists USING btree (related_artist_user_id, user_id);
+
+
+--
+-- Name: remixes_child_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX remixes_child_idx ON public.remixes USING btree (child_track_id, parent_track_id);
+
+
+--
+-- Name: reposts_current_uniq_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX reposts_current_uniq_idx ON public.reposts USING btree (user_id, repost_item_id, repost_type) WHERE (is_current = true);
+
+
+--
+-- Name: reposts_item_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reposts_item_idx ON public.reposts USING btree (repost_item_id, repost_type, user_id, is_delete);
+
+
+--
+-- Name: reposts_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reposts_new_blocknumber_idx ON public.reposts USING btree (blocknumber);
+
+
+--
+-- Name: reposts_new_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reposts_new_created_at_idx ON public.reposts USING btree (created_at);
+
+
+--
+-- Name: reposts_user_created_at_active_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reposts_user_created_at_active_idx ON public.reposts USING btree (user_id, created_at DESC) INCLUDE (repost_type, repost_item_id) WHERE (is_delete = false);
+
+
+--
+-- Name: reposts_user_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reposts_user_idx ON public.reposts USING btree (user_id, repost_type, repost_item_id, created_at, is_delete);
+
+
+--
+-- Name: reward_codes_mint_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reward_codes_mint_idx ON public.reward_codes USING btree (mint);
+
+
+--
+-- Name: reward_codes_reward_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX reward_codes_reward_address_idx ON public.reward_codes USING btree (reward_address);
+
+
+--
+-- Name: rpc_log_applied_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX rpc_log_applied_at_idx ON public.rpc_log USING brin (applied_at);
+
+
+--
+-- Name: saves_current_uniq_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX saves_current_uniq_idx ON public.saves USING btree (user_id, save_item_id, save_type) WHERE (is_current = true);
+
+
+--
+-- Name: saves_item_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX saves_item_idx ON public.saves USING btree (save_item_id, save_type, user_id, is_delete);
+
+
+--
+-- Name: saves_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX saves_new_blocknumber_idx ON public.saves USING btree (blocknumber);
+
+
+--
+-- Name: saves_user_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX saves_user_idx ON public.saves USING btree (user_id, save_type, save_item_id, is_delete);
+
+
+--
+-- Name: saves_user_track_current_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX saves_user_track_current_blocknumber_idx ON public.saves USING btree (user_id, blocknumber, save_item_id DESC) INCLUDE (created_at) WHERE ((save_type = 'track'::public.savetype) AND (is_current = true) AND (is_delete = false));
+
+
+--
+-- Name: shares_item_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX shares_item_idx ON public.shares USING btree (share_item_id, share_type, user_id);
+
+
+--
+-- Name: shares_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX shares_new_blocknumber_idx ON public.shares USING btree (blocknumber);
+
+
+--
+-- Name: shares_new_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX shares_new_created_at_idx ON public.shares USING btree (created_at);
+
+
+--
+-- Name: shares_slot_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX shares_slot_idx ON public.shares USING btree (slot);
+
+
+--
+-- Name: shares_user_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX shares_user_idx ON public.shares USING btree (user_id, share_type, share_item_id, created_at);
+
+
+--
+-- Name: sla_auditor_version_data_nodeendpoint_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sla_auditor_version_data_nodeendpoint_index ON public.sla_auditor_version_data USING btree ("nodeEndpoint");
+
+
+--
+-- Name: sol_claimable_account_transfers_from_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_claimable_account_transfers_from_idx ON public.sol_claimable_account_transfers USING btree (from_account);
+
+
+--
+-- Name: INDEX sol_claimable_account_transfers_from_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_claimable_account_transfers_from_idx IS 'Used for getting transfers by recipient.';
+
+
+--
+-- Name: sol_claimable_account_transfers_sender_eth_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_claimable_account_transfers_sender_eth_address_idx ON public.sol_claimable_account_transfers USING btree (sender_eth_address);
+
+
+--
+-- Name: INDEX sol_claimable_account_transfers_sender_eth_address_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_claimable_account_transfers_sender_eth_address_idx IS 'Used for getting transfers by sender user wallet.';
+
+
+--
+-- Name: sol_claimable_account_transfers_to_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_claimable_account_transfers_to_idx ON public.sol_claimable_account_transfers USING btree (to_account);
+
+
+--
+-- Name: INDEX sol_claimable_account_transfers_to_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_claimable_account_transfers_to_idx IS 'Used for getting transfers by sender.';
+
+
+--
+-- Name: sol_claimable_accounts_account_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_claimable_accounts_account_idx ON public.sol_claimable_accounts USING btree (account);
+
+
+--
+-- Name: INDEX sol_claimable_accounts_account_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_claimable_accounts_account_idx IS 'Used for getting user wallet by account.';
+
+
+--
+-- Name: sol_claimable_accounts_eth_mint_slot_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_claimable_accounts_eth_mint_slot_idx ON public.sol_claimable_accounts USING btree (ethereum_address, mint, slot DESC);
+
+
+--
+-- Name: sol_claimable_accounts_ethereum_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_claimable_accounts_ethereum_address_idx ON public.sol_claimable_accounts USING btree (ethereum_address, mint);
+
+
+--
+-- Name: INDEX sol_claimable_accounts_ethereum_address_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_claimable_accounts_ethereum_address_idx IS 'Used for getting account by user wallet and mint.';
+
+
+--
+-- Name: sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a ON public.sol_meteora_damm_v2_initialize_custom_pool_instructions USING btree (token_a_mint);
+
+
+--
+-- Name: INDEX sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_meteora_damm_v2_initialize_custom_pool_instructions_token_a IS 'Used for finding artist positions by token_a_mint.';
+
+
+--
+-- Name: sol_meteora_dbc_migrations_base_mint_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_meteora_dbc_migrations_base_mint_idx ON public.sol_meteora_dbc_migrations USING btree (base_mint);
+
+
+--
+-- Name: INDEX sol_meteora_dbc_migrations_base_mint_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_meteora_dbc_migrations_base_mint_idx IS 'Used for finding artist positions by base_mint.';
+
+
+--
+-- Name: sol_payments_to_account; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_payments_to_account ON public.sol_payments USING btree (to_account);
+
+
+--
+-- Name: INDEX sol_payments_to_account; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_payments_to_account IS 'Used for getting payments to a particular user.';
+
+
+--
+-- Name: sol_purchases_buyer_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_purchases_buyer_user_id_idx ON public.sol_purchases USING btree (buyer_user_id, is_valid);
+
+
+--
+-- Name: INDEX sol_purchases_buyer_user_id_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_purchases_buyer_user_id_idx IS 'Used for getting purchases by a user.';
+
+
+--
+-- Name: sol_purchases_content_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_purchases_content_idx ON public.sol_purchases USING btree (content_id, content_type, access_type, is_valid);
+
+
+--
+-- Name: INDEX sol_purchases_content_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_purchases_content_idx IS 'Used for getting sales of particular content.';
+
+
+--
+-- Name: sol_purchases_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_purchases_created_at_idx ON public.sol_purchases USING btree (created_at);
+
+
+--
+-- Name: sol_purchases_from_account_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_purchases_from_account_idx ON public.sol_purchases USING btree (from_account, is_valid);
+
+
+--
+-- Name: INDEX sol_purchases_from_account_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_purchases_from_account_idx IS 'Used for getting purchases by a user via their account.';
+
+
+--
+-- Name: sol_purchases_valid_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_purchases_valid_idx ON public.sol_purchases USING btree (is_valid, valid_after_blocknumber);
+
+
+--
+-- Name: INDEX sol_purchases_valid_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_purchases_valid_idx IS 'Used for updating purchases to be valid after the specified blocknumber is reached.';
+
+
+--
+-- Name: sol_reward_disbursements_challenge_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_reward_disbursements_challenge_idx ON public.sol_reward_disbursements USING btree (challenge_id, specifier);
+
+
+--
+-- Name: INDEX sol_reward_disbursements_challenge_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_reward_disbursements_challenge_idx IS 'Used for getting reward disbursements for a specific challenge type or claim.';
+
+
+--
+-- Name: sol_reward_disbursements_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_reward_disbursements_created_at_idx ON public.sol_reward_disbursements USING btree (created_at);
+
+
+--
+-- Name: sol_reward_disbursements_recipient_eth_address_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_reward_disbursements_recipient_eth_address_idx ON public.sol_reward_disbursements USING btree (recipient_eth_address);
+
+
+--
+-- Name: sol_reward_disbursements_user_bank_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_reward_disbursements_user_bank_idx ON public.sol_reward_disbursements USING btree (user_bank);
+
+
+--
+-- Name: INDEX sol_reward_disbursements_user_bank_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_reward_disbursements_user_bank_idx IS 'Used for getting reward disbursements for a user.';
+
+
+--
+-- Name: sol_slot_checkpoints_from_slot_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_slot_checkpoints_from_slot_idx ON public.sol_slot_checkpoints USING btree (subscription_hash, from_slot);
+
+
+--
+-- Name: sol_slot_checkpoints_to_slot_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_slot_checkpoints_to_slot_idx ON public.sol_slot_checkpoints USING btree (subscription_hash, to_slot);
+
+
+--
+-- Name: sol_token_account_balance_changes_account_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_account_balance_changes_account_idx ON public.sol_token_account_balance_changes USING btree (account, slot);
+
+
+--
+-- Name: INDEX sol_token_account_balance_changes_account_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_token_account_balance_changes_account_idx IS 'Used for getting recent transactions by account.';
+
+
+--
+-- Name: sol_token_account_balance_changes_mint_block_timestamp; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_account_balance_changes_mint_block_timestamp ON public.sol_token_account_balance_changes USING btree (mint, block_timestamp DESC);
+
+
+--
+-- Name: sol_token_account_balance_changes_mint_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_account_balance_changes_mint_idx ON public.sol_token_account_balance_changes USING btree (mint, slot);
+
+
+--
+-- Name: INDEX sol_token_account_balance_changes_mint_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_token_account_balance_changes_mint_idx IS 'Used for getting recent transactions by mint.';
+
+
+--
+-- Name: sol_token_account_balance_changes_owner_slot_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_account_balance_changes_owner_slot_idx ON public.sol_token_account_balance_changes USING btree (owner, slot DESC);
+
+
+--
+-- Name: INDEX sol_token_account_balance_changes_owner_slot_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_token_account_balance_changes_owner_slot_idx IS 'Used for associating connected wallets with the transaction.';
+
+
+--
+-- Name: sol_token_account_balances_mint_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_account_balances_mint_idx ON public.sol_token_account_balances USING btree (mint);
+
+
+--
+-- Name: INDEX sol_token_account_balances_mint_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_token_account_balances_mint_idx IS 'Used for getting current balances by mint.';
+
+
+--
+-- Name: sol_token_account_balances_owner_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_account_balances_owner_idx ON public.sol_token_account_balances USING btree (owner);
+
+
+--
+-- Name: sol_token_transfers_from_account_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_transfers_from_account_idx ON public.sol_token_transfers USING btree (from_account);
+
+
+--
+-- Name: sol_token_transfers_to_account_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_token_transfers_to_account_idx ON public.sol_token_transfers USING btree (to_account);
+
+
+--
+-- Name: sol_transfer_memo_types_slot_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_transfer_memo_types_slot_idx ON public.sol_transfer_memo_types USING btree (slot);
+
+
+--
+-- Name: sol_transfer_memo_types_type_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_transfer_memo_types_type_idx ON public.sol_transfer_memo_types USING btree (memo_type);
+
+
+--
+-- Name: sol_user_balances_mint_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sol_user_balances_mint_user_id_idx ON public.sol_user_balances USING btree (mint, user_id);
+
+
+--
+-- Name: INDEX sol_user_balances_mint_user_id_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.sol_user_balances_mint_user_id_idx IS 'Index for quick access to user balances by mint and user ID.';
+
+
+--
+-- Name: subscriptions_current_uniq_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX subscriptions_current_uniq_idx ON public.subscriptions USING btree (subscriber_id, user_id) WHERE (is_current = true);
+
+
+--
+-- Name: subscriptions_entity_type_entity_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX subscriptions_entity_type_entity_id_idx ON public.subscriptions USING btree (entity_type, entity_id) WHERE ((is_current = true) AND (is_delete = false));
+
+
+--
+-- Name: tag_track_user_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX tag_track_user_idx ON public.tag_track_user USING btree (tag, track_id, owner_id);
+
+
+--
+-- Name: tag_track_user_tag_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX tag_track_user_tag_idx ON public.tag_track_user USING btree (tag);
+
+
+--
+-- Name: track_created_at_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_created_at_idx ON public.tracks USING btree (created_at);
+
+
+--
+-- Name: track_delist_statuses_owner_id_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_delist_statuses_owner_id_created_at ON public.track_delist_statuses USING btree (owner_id, created_at);
+
+
+--
+-- Name: track_delist_statuses_track_cid_created_at; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_delist_statuses_track_cid_created_at ON public.track_delist_statuses USING btree (track_cid, created_at);
+
+
+--
+-- Name: track_owner_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_owner_id_idx ON public.tracks USING btree (owner_id);
+
+
+--
+-- Name: track_owner_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_owner_idx ON public.tracks USING btree (owner_id, created_at);
+
+
+--
+-- Name: track_routes_owner_title_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_routes_owner_title_slug_idx ON public.track_routes USING btree (owner_id, title_slug, collision_id);
+
+
+--
+-- Name: track_routes_track_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX track_routes_track_id_idx ON public.track_routes USING btree (track_id);
+
+
+--
+-- Name: tracks_ai_attribution_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX tracks_ai_attribution_user_id ON public.tracks USING btree (ai_attribution_user_id) WHERE (ai_attribution_user_id IS NOT NULL);
+
+
+--
+-- Name: tracks_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX tracks_blocknumber_idx ON public.tracks USING btree (blocknumber);
+
+
+--
+-- Name: tracks_isrc_normalized_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX tracks_isrc_normalized_idx ON public.tracks USING btree (regexp_replace(upper((isrc)::text), '[^A-Z0-9]'::text, ''::text, 'g'::text)) WHERE (isrc IS NOT NULL);
+
+
+--
+-- Name: INDEX tracks_isrc_normalized_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.tracks_isrc_normalized_idx IS 'Functional index supporting GetTrackIdsByISRC; matches regexp_replace(upper(isrc), ''[^A-Z0-9]'', '''', ''g'') so dash/case-insensitive ?isrc= lookups hit the index.';
+
+
+--
+-- Name: tracks_scheduled_release_due_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX tracks_scheduled_release_due_idx ON public.tracks USING btree (release_date) WHERE ((is_unlisted = true) AND (is_scheduled_release = true) AND (release_date IS NOT NULL) AND (is_current = true) AND (is_delete = false));
+
+
+--
+-- Name: INDEX tracks_scheduled_release_due_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.tracks_scheduled_release_due_idx IS 'Covers the scheduled-release publisher tracks update by release_date for due unlisted scheduled tracks.';
+
+
+--
+-- Name: tracks_track_cid_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX tracks_track_cid_idx ON public.tracks USING btree (track_cid, is_delete);
+
+
+--
+-- Name: trending_params_track_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX trending_params_track_id_idx ON public.trending_params USING btree (track_id);
+
+
+--
+-- Name: user_balance_history_timestamp_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_balance_history_timestamp_idx ON public.user_balance_history USING btree ("timestamp" DESC);
+
+
+--
+-- Name: INDEX user_balance_history_timestamp_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.user_balance_history_timestamp_idx IS 'Optimizes queries finding recent balances across all users';
+
+
+--
+-- Name: user_balance_history_user_timestamp_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_balance_history_user_timestamp_idx ON public.user_balance_history USING btree (user_id, "timestamp");
+
+
+--
+-- Name: INDEX user_balance_history_user_timestamp_idx; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON INDEX public.user_balance_history_user_timestamp_idx IS 'Optimizes time-range queries for a user, ordered by timestamp ASC';
+
+
+--
+-- Name: user_challenges_challenge_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_challenges_challenge_idx ON public.user_challenges USING btree (challenge_id);
+
+
+--
+-- Name: user_challenges_fast; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_challenges_fast ON public.user_challenges USING btree (user_id, completed_at) WHERE (is_complete AND ((challenge_id)::text <> ALL ((ARRAY['m'::character varying, 'b'::character varying])::text[])));
+
+
+--
+-- Name: user_challenges_user_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_challenges_user_id ON public.user_challenges USING btree (user_id);
+
+
+--
+-- Name: user_events_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_events_user_id_idx ON public.user_events USING btree (user_id);
+
+
+--
+-- Name: user_payout_wallet_history_wallet_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_payout_wallet_history_wallet_idx ON public.user_payout_wallet_history USING btree (spl_usdc_payout_wallet, block_timestamp);
+
+
+--
+-- Name: users_new_blocknumber_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX users_new_blocknumber_idx ON public.users USING btree (blocknumber);
+
+
+--
+-- Name: users_new_handle_lc_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX users_new_handle_lc_idx ON public.users USING btree (handle_lc);
+
+
+--
+-- Name: users_new_wallet_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX users_new_wallet_idx ON public.users USING btree (wallet);
+
+
+--
+-- Name: users_spl_usdc_payout_wallet_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX users_spl_usdc_payout_wallet_idx ON public.users USING btree (spl_usdc_payout_wallet) WHERE (spl_usdc_payout_wallet IS NOT NULL);
+
+
+--
+-- Name: associated_wallets before_associated_wallets_canonicalize; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER before_associated_wallets_canonicalize BEFORE INSERT OR UPDATE ON public.associated_wallets FOR EACH ROW EXECUTE FUNCTION public.canonicalize_associated_wallet();
+
+
+--
+-- Name: TRIGGER before_associated_wallets_canonicalize ON associated_wallets; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER before_associated_wallets_canonicalize ON public.associated_wallets IS 'Lowercases chain=eth wallets on insert/update so eth_wallet_balances joins (PK on lowercase) hit without case mismatches. Solana wallets are left alone — base58 is case-sensitive.';
+
+
+--
+-- Name: artist_coins on_artist_coins_change; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_artist_coins_change AFTER INSERT OR DELETE OR UPDATE ON public.artist_coins FOR EACH ROW EXECUTE FUNCTION public.handle_artist_coins_change();
+
+
+--
+-- Name: TRIGGER on_artist_coins_change ON artist_coins; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER on_artist_coins_change ON public.artist_coins IS 'Notifies when artist coins are added, removed, or updated.';
+
+
+--
+-- Name: associated_wallets on_associated_wallets; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_associated_wallets AFTER INSERT OR DELETE OR UPDATE ON public.associated_wallets FOR EACH ROW EXECUTE FUNCTION public.handle_associated_wallets();
+
+
+--
+-- Name: TRIGGER on_associated_wallets ON associated_wallets; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER on_associated_wallets ON public.associated_wallets IS 'Updates sol_user_balances and eth_user_balances when associated_wallets are added and removed';
+
+
+--
+-- Name: challenge_disbursements on_challenge_disbursement; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_challenge_disbursement AFTER INSERT ON public.challenge_disbursements FOR EACH ROW EXECUTE FUNCTION public.handle_challenge_disbursement();
+
+
+--
+-- Name: chat_blast on_chat_blast; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_chat_blast AFTER INSERT ON public.chat_blast FOR EACH ROW EXECUTE FUNCTION public.handle_chat_blast();
+
+
+--
+-- Name: chat_message on_chat_message; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_chat_message AFTER INSERT ON public.chat_message FOR EACH ROW EXECUTE FUNCTION public.handle_chat_message();
+
+
+--
+-- Name: chat_message_reactions on_chat_message_reaction_changed; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_chat_message_reaction_changed AFTER INSERT OR DELETE OR UPDATE ON public.chat_message_reactions FOR EACH ROW EXECUTE FUNCTION public.handle_chat_message_reaction_changed();
+
+
+--
+-- Name: comments on_comment; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_comment AFTER INSERT ON public.comments FOR EACH ROW EXECUTE FUNCTION public.handle_comment();
+
+
+--
+-- Name: comment_mentions on_comment_mention; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_comment_mention AFTER INSERT ON public.comment_mentions FOR EACH ROW EXECUTE FUNCTION public.handle_comment_mention();
+
+
+--
+-- Name: comments on_comment_notification; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE CONSTRAINT TRIGGER on_comment_notification AFTER INSERT ON public.comments DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.handle_comment_notification();
+
+
+--
+-- Name: comment_reactions on_comment_reaction; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_comment_reaction AFTER INSERT ON public.comment_reactions FOR EACH ROW EXECUTE FUNCTION public.handle_comment_reaction();
+
+
+--
+-- Name: comments on_comment_remix_contest_update; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE CONSTRAINT TRIGGER on_comment_remix_contest_update AFTER INSERT ON public.comments DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.handle_comment_remix_contest_update();
+
+
+--
+-- Name: comment_threads on_comment_thread; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_comment_thread AFTER INSERT ON public.comment_threads FOR EACH ROW EXECUTE FUNCTION public.handle_comment_thread();
+
+
+--
+-- Name: sol_meteora_dbc_pools on_dbc_pool_change; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_dbc_pool_change AFTER INSERT ON public.sol_meteora_dbc_pools FOR EACH ROW EXECUTE FUNCTION public.handle_dbc_pool();
+
+
+--
+-- Name: TRIGGER on_dbc_pool_change ON sol_meteora_dbc_pools; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER on_dbc_pool_change ON public.sol_meteora_dbc_pools IS 'Notifies when DBC pools are added, removed, or updated.';
+
+
+--
+-- Name: eth_wallet_balances on_eth_wallet_balance_changes; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_eth_wallet_balance_changes AFTER INSERT OR UPDATE ON public.eth_wallet_balances FOR EACH ROW EXECUTE FUNCTION public.handle_eth_wallet_balance_change();
+
+
+--
+-- Name: TRIGGER on_eth_wallet_balance_changes ON eth_wallet_balances; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER on_eth_wallet_balance_changes ON public.eth_wallet_balances IS 'Recomputes eth_user_balances for affected users whenever an eth wallet balance changes.';
+
+
+--
+-- Name: events on_event; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_event AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.handle_event();
+
+
+--
+-- Name: comments on_fan_club_text_post; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE CONSTRAINT TRIGGER on_fan_club_text_post AFTER INSERT ON public.comments DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.handle_fan_club_text_post();
+
+
+--
+-- Name: follows on_follow; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_follow AFTER INSERT OR UPDATE ON public.follows FOR EACH ROW EXECUTE FUNCTION public.handle_follow();
+
+
+--
+-- Name: plays on_play; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_play AFTER INSERT ON public.plays FOR EACH ROW EXECUTE FUNCTION public.handle_play();
+
+
+--
+-- Name: playlists on_playlist; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_playlist AFTER INSERT ON public.playlists FOR EACH ROW EXECUTE FUNCTION public.handle_playlist();
+
+
+--
+-- Name: playlists on_playlist_notify_pending_purchase_revalidation; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_playlist_notify_pending_purchase_revalidation AFTER INSERT OR UPDATE OF blocknumber ON public.playlists FOR EACH ROW EXECUTE FUNCTION public.notify_pending_purchase_revalidation();
+
+
+--
+-- Name: playlist_tracks on_playlist_track; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_playlist_track AFTER INSERT ON public.playlist_tracks FOR EACH ROW EXECUTE FUNCTION public.handle_playlist_track();
+
+
+--
+-- Name: reactions on_reaction; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_reaction AFTER INSERT ON public.reactions FOR EACH ROW EXECUTE FUNCTION public.handle_reaction();
+
+
+--
+-- Name: reposts on_repost; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_repost AFTER INSERT OR UPDATE ON public.reposts FOR EACH ROW EXECUTE FUNCTION public.handle_repost();
+
+
+--
+-- Name: rpc_log on_rpc_log; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_rpc_log AFTER INSERT ON public.rpc_log FOR EACH ROW EXECUTE FUNCTION public.handle_comms_rpc_log();
+
+
+--
+-- Name: saves on_save; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_save AFTER INSERT OR UPDATE ON public.saves FOR EACH ROW EXECUTE FUNCTION public.handle_save();
+
+
+--
+-- Name: shares on_share; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_share AFTER INSERT ON public.shares FOR EACH ROW EXECUTE FUNCTION public.handle_share();
+
+
+--
+-- Name: sol_claimable_accounts on_sol_claimable_accounts; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_sol_claimable_accounts AFTER INSERT ON public.sol_claimable_accounts FOR EACH ROW EXECUTE FUNCTION public.handle_sol_claimable_accounts();
+
+
+--
+-- Name: TRIGGER on_sol_claimable_accounts ON sol_claimable_accounts; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER on_sol_claimable_accounts ON public.sol_claimable_accounts IS 'Updates sol_user_balances whenever a sol_claimable_account is inserted.';
+
+
+--
+-- Name: sol_purchases on_sol_purchase; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_sol_purchase AFTER INSERT ON public.sol_purchases FOR EACH ROW EXECUTE FUNCTION public.handle_sol_purchase();
+
+
+--
+-- Name: sol_reward_disbursements on_sol_reward_disbursement; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_sol_reward_disbursement AFTER INSERT ON public.sol_reward_disbursements FOR EACH ROW EXECUTE FUNCTION public.handle_sol_reward_disbursement();
+
+
+--
+-- Name: sol_token_account_balance_changes on_sol_token_account_balance_changes; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_sol_token_account_balance_changes AFTER INSERT ON public.sol_token_account_balance_changes FOR EACH ROW EXECUTE FUNCTION public.handle_sol_token_balance_change();
+
+
+--
+-- Name: TRIGGER on_sol_token_account_balance_changes ON sol_token_account_balance_changes; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TRIGGER on_sol_token_account_balance_changes ON public.sol_token_account_balance_changes IS 'Updates sol_token_account_balances whenever a sol_token_balance_change is inserted with a higher slot.';
+
+
+--
+-- Name: sol_claimable_account_transfers on_sol_usdc_withdrawal; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_sol_usdc_withdrawal AFTER INSERT ON public.sol_claimable_account_transfers FOR EACH ROW EXECUTE FUNCTION public.handle_sol_usdc_withdrawal();
+
+
+--
+-- Name: supporter_rank_ups on_supporter_rank_up; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_supporter_rank_up AFTER INSERT ON public.supporter_rank_ups FOR EACH ROW EXECUTE FUNCTION public.handle_supporter_rank_up();
+
+
+--
+-- Name: user_challenges on_tastemaker_user_challenge; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_tastemaker_user_challenge AFTER INSERT ON public.user_challenges FOR EACH ROW WHEN (((new.challenge_id)::text = 't'::text)) EXECUTE FUNCTION public.handle_tastemaker();
+
+
+--
+-- Name: tracks on_track; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_track AFTER INSERT OR UPDATE ON public.tracks FOR EACH ROW EXECUTE FUNCTION public.handle_track();
+
+
+--
+-- Name: tracks on_track_notify_pending_purchase_revalidation; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_track_notify_pending_purchase_revalidation AFTER INSERT OR UPDATE OF blocknumber ON public.tracks FOR EACH ROW EXECUTE FUNCTION public.notify_pending_purchase_revalidation();
+
+
+--
+-- Name: user_challenges on_trending_user_challenge; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_trending_user_challenge AFTER INSERT ON public.user_challenges FOR EACH ROW WHEN (((new.challenge_id)::text = ANY ((ARRAY['tt'::character varying, 'tut'::character varying])::text[]))) EXECUTE FUNCTION public.handle_trending();
+
+
+--
+-- Name: usdc_purchases on_usdc_purchase; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_usdc_purchase AFTER INSERT ON public.usdc_purchases FOR EACH ROW EXECUTE FUNCTION public.handle_usdc_purchase();
+
+
+--
+-- Name: usdc_transactions_history on_usdc_withdrawal; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_usdc_withdrawal AFTER INSERT ON public.usdc_transactions_history FOR EACH ROW EXECUTE FUNCTION public.handle_usdc_withdrawal();
+
+
+--
+-- Name: users on_user; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_user AFTER INSERT ON public.users FOR EACH ROW EXECUTE FUNCTION public.handle_user();
+
+
+--
+-- Name: user_balance_changes on_user_balance_changes; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_user_balance_changes AFTER INSERT OR UPDATE ON public.user_balance_changes FOR EACH ROW EXECUTE FUNCTION public.handle_user_balance_change();
+
+
+--
+-- Name: user_challenges on_user_challenge; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_user_challenge AFTER INSERT OR UPDATE ON public.user_challenges FOR EACH ROW EXECUTE FUNCTION public.handle_on_user_challenge();
+
+
+--
+-- Name: user_tips on_user_tip; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER on_user_tip AFTER INSERT ON public.user_tips FOR EACH ROW EXECUTE FUNCTION public.handle_user_tip();
+
+
+--
+-- Name: aggregate_plays trg_aggregate_plays; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_aggregate_plays AFTER INSERT OR UPDATE ON public.aggregate_plays FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: aggregate_user trg_aggregate_user; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_aggregate_user AFTER INSERT OR UPDATE ON public.aggregate_user FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: artist_coins trg_artist_coins; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_artist_coins AFTER INSERT OR UPDATE ON public.artist_coins FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: follows trg_follows; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_follows AFTER INSERT OR UPDATE ON public.follows FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: notification trg_notification; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_notification AFTER INSERT ON public.notification FOR EACH ROW EXECUTE FUNCTION public.on_new_notification_row();
+
+
+--
+-- Name: notification_seen trg_notification_seen; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_notification_seen AFTER INSERT ON public.notification_seen FOR EACH ROW EXECUTE FUNCTION public.on_new_notification_seen_row();
+
+
+--
+-- Name: playlists trg_playlists; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_playlists AFTER INSERT OR UPDATE ON public.playlists FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: reposts trg_reposts; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_reposts AFTER INSERT OR UPDATE ON public.reposts FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: saves trg_saves; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_saves AFTER INSERT OR UPDATE ON public.saves FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: shares trg_shares; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_shares AFTER INSERT OR UPDATE ON public.shares FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: tracks trg_tracks; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_tracks AFTER INSERT OR UPDATE ON public.tracks FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: usdc_purchases trg_usdc_purchases; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_usdc_purchases AFTER INSERT OR UPDATE ON public.usdc_purchases FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: users trg_users; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trg_users AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION public.on_new_row();
+
+
+--
+-- Name: grants trigger_grant_change; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trigger_grant_change AFTER INSERT OR UPDATE ON public.grants FOR EACH ROW EXECUTE FUNCTION public.process_grant_change();
+
+
+--
+-- Name: etl_blocks trigger_notify_new_block; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trigger_notify_new_block AFTER INSERT ON public.etl_blocks FOR EACH ROW EXECUTE FUNCTION public.notify_new_block();
+
+
+--
+-- Name: etl_plays trigger_notify_new_plays; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trigger_notify_new_plays AFTER INSERT ON public.etl_plays FOR EACH ROW EXECUTE FUNCTION public.notify_new_plays();
+
+
+--
+-- Name: track_collaborators trigger_track_collaborator_change; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER trigger_track_collaborator_change AFTER INSERT OR UPDATE ON public.track_collaborators FOR EACH ROW EXECUTE FUNCTION public.process_track_collaborator_change();
+
+
+--
+-- Name: album_price_history album_price_history_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.album_price_history
+    ADD CONSTRAINT album_price_history_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: associated_wallets associated_wallets_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.associated_wallets
+    ADD CONSTRAINT associated_wallets_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: chat_member chat_member_chat_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_member
+    ADD CONSTRAINT chat_member_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES public.chat(chat_id) ON DELETE CASCADE;
+
+
+--
+-- Name: chat_message chat_message_blast_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_message
+    ADD CONSTRAINT chat_message_blast_id_fkey FOREIGN KEY (blast_id) REFERENCES public.chat_blast(blast_id);
+
+
+--
+-- Name: chat_message chat_message_chat_member_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_message
+    ADD CONSTRAINT chat_message_chat_member_fkey FOREIGN KEY (chat_id, user_id) REFERENCES public.chat_member(chat_id, user_id) ON DELETE CASCADE;
+
+
+--
+-- Name: chat_message_reactions chat_message_reactions_message_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.chat_message_reactions
+    ADD CONSTRAINT chat_message_reactions_message_id_fkey FOREIGN KEY (message_id) REFERENCES public.chat_message(message_id) ON DELETE CASCADE;
+
+
+--
+-- Name: collectibles collectibles_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.collectibles
+    ADD CONSTRAINT collectibles_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comment_mentions comment_mentions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_mentions
+    ADD CONSTRAINT comment_mentions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comment_reactions comment_reactions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_reactions
+    ADD CONSTRAINT comment_reactions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comment_reports comment_reports_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comment_reports
+    ADD CONSTRAINT comment_reports_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: comments comments_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.comments
+    ADD CONSTRAINT comments_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: dashboard_wallet_users dashboard_wallet_users_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.dashboard_wallet_users
+    ADD CONSTRAINT dashboard_wallet_users_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: developer_apps developer_apps_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.developer_apps
+    ADD CONSTRAINT developer_apps_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: etl_sla_node_reports etl_sla_node_reports_sla_rollup_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.etl_sla_node_reports
+    ADD CONSTRAINT etl_sla_node_reports_sla_rollup_id_fkey FOREIGN KEY (sla_rollup_id) REFERENCES public.etl_sla_rollups(id);
+
+
+--
+-- Name: events events_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number);
+
+
+--
+-- Name: follows follows_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT follows_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: grants grants_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.grants
+    ADD CONSTRAINT grants_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: muted_users muted_users_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.muted_users
+    ADD CONSTRAINT muted_users_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: notification_seen notification_seen_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.notification_seen
+    ADD CONSTRAINT notification_seen_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: playlist_seen playlist_seen_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlist_seen
+    ADD CONSTRAINT playlist_seen_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: playlists playlists_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.playlists
+    ADD CONSTRAINT playlists_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: reactions reactions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reactions
+    ADD CONSTRAINT reactions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: reported_comments reported_comments_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reported_comments
+    ADD CONSTRAINT reported_comments_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: reposts reposts_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.reposts
+    ADD CONSTRAINT reposts_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: revert_blocks revert_blocks_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.revert_blocks
+    ADD CONSTRAINT revert_blocks_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: saves saves_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.saves
+    ADD CONSTRAINT saves_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: sla_node_reports sla_node_reports_sla_rollup_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sla_node_reports
+    ADD CONSTRAINT sla_node_reports_sla_rollup_id_fkey FOREIGN KEY (sla_rollup_id) REFERENCES public.sla_rollups(id);
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_base_fees sol_meteora_damm_v2_pool_base_fees_pool_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_base_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_base_fees_pool_fkey FOREIGN KEY (pool) REFERENCES public.sol_meteora_damm_v2_pools(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_dynamic_fees sol_meteora_damm_v2_pool_dynamic_fees_pool_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_dynamic_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_dynamic_fees_pool_fkey FOREIGN KEY (pool) REFERENCES public.sol_meteora_damm_v2_pools(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_fees sol_meteora_damm_v2_pool_fees_pool_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_fees
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_fees_pool_fkey FOREIGN KEY (pool) REFERENCES public.sol_meteora_damm_v2_pools(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_damm_v2_pool_metrics sol_meteora_damm_v2_pool_metrics_pool_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_pool_metrics
+    ADD CONSTRAINT sol_meteora_damm_v2_pool_metrics_pool_fkey FOREIGN KEY (pool) REFERENCES public.sol_meteora_damm_v2_pools(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_damm_v2_position_metrics sol_meteora_damm_v2_position_metrics_position_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_damm_v2_position_metrics
+    ADD CONSTRAINT sol_meteora_damm_v2_position_metrics_position_fkey FOREIGN KEY ("position") REFERENCES public.sol_meteora_damm_v2_positions(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_dbc_config_fees sol_meteora_dbc_config_fees_config_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_fees
+    ADD CONSTRAINT sol_meteora_dbc_config_fees_config_fkey FOREIGN KEY (config) REFERENCES public.sol_meteora_dbc_configs(account) ON DELETE CASCADE;
+
+
+--
+-- Name: sol_meteora_dbc_config_vestings sol_meteora_dbc_config_vestings_config_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sol_meteora_dbc_config_vestings
+    ADD CONSTRAINT sol_meteora_dbc_config_vestings_config_fkey FOREIGN KEY (config) REFERENCES public.sol_meteora_dbc_configs(account) ON DELETE CASCADE;
+
+
+--
+-- Name: subscriptions subscriptions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: track_downloads track_downloads_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_downloads
+    ADD CONSTRAINT track_downloads_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: track_price_history track_price_history_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.track_price_history
+    ADD CONSTRAINT track_price_history_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: tracks tracks_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.tracks
+    ADD CONSTRAINT tracks_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: user_challenges user_challenges_challenge_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_challenges
+    ADD CONSTRAINT user_challenges_challenge_id_fkey FOREIGN KEY (challenge_id) REFERENCES public.challenges(id);
+
+
+--
+-- Name: user_events user_events_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_events
+    ADD CONSTRAINT user_events_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: user_payout_wallet_history user_payout_wallet_history_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_payout_wallet_history
+    ADD CONSTRAINT user_payout_wallet_history_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: users users_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: cloudsqlsuperuser
+--
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_advance(text, pg_lsn); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_advance(text, pg_lsn) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_create(text); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_create(text) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_drop(text); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_drop(text) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_oid(text); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_oid(text) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_progress(text, boolean); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_progress(text, boolean) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_session_is_setup(); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_session_is_setup() TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_session_progress(boolean); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_session_progress(boolean) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_session_reset(); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_session_reset() TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_session_setup(text); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_session_setup(text) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_xact_reset(); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_xact_reset() TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_replication_origin_xact_setup(pg_lsn, timestamp with time zone); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_replication_origin_xact_setup(pg_lsn, timestamp with time zone) TO cloudsqlsuperuser;
+
+
+--
+-- Name: FUNCTION pg_show_replication_origin_status(OUT local_id oid, OUT external_id text, OUT remote_lsn pg_lsn, OUT local_lsn pg_lsn); Type: ACL; Schema: pg_catalog; Owner: cloudsqladmin
+--
+
+GRANT ALL ON FUNCTION pg_catalog.pg_show_replication_origin_status(OUT local_id oid, OUT external_id text, OUT remote_lsn pg_lsn, OUT local_lsn pg_lsn) TO cloudsqlsuperuser;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict m2R0Xrr2M70d8hLjwblvFqPiH7hL2wRm5AnbsIsPeL7ouQYXYoxsnkDeEoKyYER
+

--- a/cmd/genesis-writer/testdata/seed.sql
+++ b/cmd/genesis-writer/testdata/seed.sql
@@ -524,6 +524,68 @@ INSERT INTO saves (
    '0xfff0000000000000000000000000000000000000000000000000000000000005', '2021-10-09 01:00:00');
 
 -- ============================================================
+-- EVENTS
+-- 1 – remix contest with entity reference
+-- 2 – live event with end_date, no entity
+-- 3 – new release, deleted (should be skipped)
+-- ============================================================
+
+INSERT INTO events (
+  event_id, event_type, user_id, entity_type, entity_id,
+  end_date, is_deleted, event_data, created_at, updated_at,
+  txhash, blockhash, blocknumber
+) VALUES
+  (
+    1, 'remix_contest', 3000001, 'track', 2000001,
+    NULL, false, '{"prize": "featured placement"}',
+    '2022-01-15 00:00:00', '2022-01-15 00:00:00',
+    '0xeee1000000000000000000000000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1
+  ),
+  (
+    2, 'live_event', 3000002, NULL, NULL,
+    '2022-06-01 23:00:00', false, NULL,
+    '2022-03-01 00:00:00', '2022-03-01 00:00:00',
+    '0xeee1000000000000000000000000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1
+  ),
+  -- deleted event — should NOT be migrated
+  (
+    3, 'new_release', 3000001, 'track', 2000008,
+    NULL, true, '{"message": "surprise drop"}',
+    '2022-04-01 00:00:00', '2022-04-01 00:00:00',
+    '0xeee1000000000000000000000000000000000000000000000000000000000003',
+    '0x0000000000000000000000000000000000000000000000000000000000000001', 1
+  );
+
+-- ============================================================
+-- TRACK COLLABORATORS
+-- Track 2000001 has two collaborators: one accepted, one pending
+-- Track 2000008 has one accepted collaborator
+-- ============================================================
+
+INSERT INTO track_collaborators (
+  track_id, collaborator_user_id, invited_by, status,
+  created_at, updated_at, txhash, blocknumber
+) VALUES
+  -- accepted collaborator on track 2000001
+  (2000001, 3000002, 3000001, 'accepted',
+   '2021-06-02 00:00:00', '2021-06-02 01:00:00',
+   '0xeee2000000000000000000000000000000000000000000000000000000000001', 1),
+  -- pending collaborator on track 2000001
+  (2000001, 3000003, 3000001, 'pending',
+   '2021-06-02 00:00:00', '2021-06-02 00:00:00',
+   '0xeee2000000000000000000000000000000000000000000000000000000000002', 1),
+  -- accepted collaborator on track 2000008
+  (2000008, 3000006, 3000001, 'accepted',
+   '2021-10-02 00:00:00', '2021-10-02 01:00:00',
+   '0xeee2000000000000000000000000000000000000000000000000000000000003', 1),
+  -- rejected collaborator (should NOT produce an approval)
+  (2000001, 3000004, 3000001, 'rejected',
+   '2021-06-03 00:00:00', '2021-06-03 01:00:00',
+   '0xeee2000000000000000000000000000000000000000000000000000000000004', 1);
+
+-- ============================================================
 -- PLAYS
 -- Mix of identified (user_id set) and anonymous (user_id=NULL)
 -- Mix of full geo, partial geo, no geo


### PR DESCRIPTION
## Summary
- Move `dp_schema.sql` into `cmd/genesis-writer/testdata/` (was in deleted `genesis-replay` dir) and update docker-compose volume mount
- Regenerate `dp_schema.sql` from current DP to include `events` and `track_collaborators` tables
- Add seed data for events (2 active, 1 deleted) and track collaborators (2 accepted, 1 pending, 1 rejected)
- Extend integration test snapshot and indexer to verify event and collaborator round-trip

## Test plan
- [ ] Run `go test -v -tags integration -run TestGenesisWriter -timeout 30m ./cmd/genesis-writer/...`
- [ ] Verify event count matches (2 active, deleted event excluded)
- [ ] Verify collaborator states: 2 accepted, 1 pending (rejected excluded from snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)