### PR TITLE
fix: reject duplicate ERN entity refs

### DIFF
--- a/pkg/core/server/abci.go
+++ b/pkg/core/server/abci.go
@@ -1029,6 +1029,9 @@ func (s *Server) isValidV2Transaction(tx []byte) (*v1beta1.Transaction, error) {
 	}
 
 	// check tx header info
+	if msg.Envelope == nil || msg.Envelope.Header == nil {
+		return nil, fmt.Errorf("transaction envelope header is nil")
+	}
 	header := msg.Envelope.Header
 	if header.ChainId != s.config.GenesisFile.ChainID {
 		return nil, fmt.Errorf("invalid chain id: %s", header.ChainId)
@@ -1057,9 +1060,13 @@ func (s *Server) validateBlockTx(ctx context.Context, blockTime time.Time, block
 	signedTx, err := s.isValidSignedTransaction(tx)
 	if err != nil {
 		// check if the tx is a v2 transaction
-		_, err := s.isValidV2Transaction(tx)
+		v2Tx, err := s.isValidV2Transaction(tx)
 		if err != nil {
 			s.logger.Error("Invalid block: unrecognized transaction type")
+			return false, nil
+		}
+		if err := s.validateV2Transaction(ctx, blockHeight, v2Tx); err != nil {
+			s.logger.Error("Invalid block: invalid v2 tx", zap.Error(err))
 			return false, nil
 		}
 		return true, nil

--- a/pkg/core/server/ddex_consensus_test.go
+++ b/pkg/core/server/ddex_consensus_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1beta1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1beta1"
+	ddexv1beta1 "github.com/OpenAudio/go-openaudio/pkg/api/ddex/v1beta1"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestProcessProposalRejectsDuplicateERNPartyReferences(t *testing.T) {
+	f := newDDEXConsensusFixture(t)
+	txBytes := f.makeERNTx(t, []string{"party-1", "party-1"})
+
+	resp, err := f.server.ProcessProposal(f.ctx, &abcitypes.ProcessProposalRequest{
+		Height: f.blockHeight,
+		Time:   time.Unix(1, 0).UTC(),
+		Txs:    [][]byte{txBytes},
+	})
+	require.NoError(t, err)
+	require.Equal(t, abcitypes.PROCESS_PROPOSAL_STATUS_REJECT, resp.Status)
+}
+
+func TestFinalizeBlockRejectsDuplicateERNPartyReferencesWithoutPoisoningCommit(t *testing.T) {
+	f := newDDEXConsensusFixture(t)
+	txBytes := f.makeERNTx(t, []string{"party-1", "party-1"})
+
+	resp, err := f.server.FinalizeBlock(f.ctx, &abcitypes.FinalizeBlockRequest{
+		Height: f.blockHeight,
+		Hash:   []byte{0x01},
+		Time:   time.Unix(1, 0).UTC(),
+		Txs:    [][]byte{txBytes},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TxResults, 1)
+	require.Equal(t, uint32(2), resp.TxResults[0].Code)
+	require.NoError(t, f.server.commitInProgressTx(f.ctx))
+}
+
+type ddexConsensusFixture struct {
+	ctx         context.Context
+	server      *Server
+	blockHeight int64
+}
+
+func newDDEXConsensusFixture(t *testing.T) *ddexConsensusFixture {
+	t.Helper()
+
+	f := newRegistrationConsensusFixture(t)
+	f.server.config.ProgrammableDistributionEnabled = true
+	setupDDEXConsensusTestDB(t, f.server.pool)
+
+	return &ddexConsensusFixture{
+		ctx:         f.ctx,
+		server:      f.server,
+		blockHeight: f.blockHeight,
+	}
+}
+
+func (f *ddexConsensusFixture) makeERNTx(t *testing.T, partyRefs []string) []byte {
+	t.Helper()
+
+	partyList := make([]*ddexv1beta1.Party, 0, len(partyRefs))
+	for _, ref := range partyRefs {
+		partyList = append(partyList, &ddexv1beta1.Party{PartyReference: ref})
+	}
+
+	controlType := ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_NEW_MESSAGE
+	tx := &corev1beta1.Transaction{
+		Signature: &corev1beta1.Signature{Signature: []byte{0xff}},
+		Envelope: &corev1beta1.Envelope{
+			Header: &corev1beta1.EnvelopeHeader{
+				ChainId:    f.server.config.GenesisFile.ChainID,
+				Expiration: f.blockHeight + 10,
+				From:       "0x0000000000000000000000000000000000000001",
+				To:         "0x0000000000000000000000000000000000000002",
+			},
+			Messages: []*corev1beta1.Message{
+				{
+					Message: &corev1beta1.Message_Ern{
+						Ern: &ddexv1beta1.NewReleaseMessage{
+							MessageHeader: &ddexv1beta1.MessageHeader{
+								MessageId:          "message-1",
+								MessageControlType: &controlType,
+							},
+							PartyList: partyList,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	txBytes, err := proto.Marshal(tx)
+	require.NoError(t, err)
+	return txBytes
+}
+
+func setupDDEXConsensusTestDB(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `
+			DROP TABLE IF EXISTS core_deals;
+			DROP TABLE IF EXISTS core_parties;
+			DROP TABLE IF EXISTS core_releases;
+			DROP TABLE IF EXISTS core_resources;
+			DROP TABLE IF EXISTS core_ern;
+		`)
+	})
+
+	_, err := pool.Exec(context.Background(), `
+		CREATE TABLE IF NOT EXISTS core_ern (
+			id bigserial primary key,
+			address text not null,
+			index bigint not null,
+			tx_hash text not null,
+			sender text not null,
+			message_control_type smallint not null,
+			raw_message bytea not null,
+			raw_acknowledgment bytea not null,
+			block_height bigint not null
+		);
+		CREATE TABLE IF NOT EXISTS core_resources (
+			address text primary key,
+			ern_address text not null,
+			entity_type text not null,
+			entity_index integer not null,
+			tx_hash text not null,
+			block_height bigint not null,
+			created_at timestamp default now()
+		);
+		CREATE TABLE IF NOT EXISTS core_releases (
+			address text primary key,
+			ern_address text not null,
+			entity_type text not null,
+			entity_index integer not null,
+			tx_hash text not null,
+			block_height bigint not null,
+			created_at timestamp default now()
+		);
+		CREATE TABLE IF NOT EXISTS core_parties (
+			address text primary key,
+			ern_address text not null,
+			entity_type text not null,
+			entity_index integer not null,
+			tx_hash text not null,
+			block_height bigint not null,
+			created_at timestamp default now()
+		);
+		CREATE TABLE IF NOT EXISTS core_deals (
+			address text primary key,
+			ern_address text not null,
+			entity_type text not null,
+			entity_index integer not null,
+			tx_hash text not null,
+			block_height bigint not null,
+			created_at timestamp default now()
+		);
+	`)
+	require.NoError(t, err)
+}

--- a/pkg/core/server/ern.go
+++ b/pkg/core/server/ern.go
@@ -118,11 +118,82 @@ func getERNOAPMessageSender(msg *ddexv1beta1.NewReleaseMessage) string {
 	return oapAddress
 }
 
+func validateUniqueERNEntityReferences(msg *ddexv1beta1.NewReleaseMessage) error {
+	if msg == nil {
+		return nil
+	}
+
+	if err := validateUniqueERNReferences("party", len(msg.GetPartyList()), func(i int) string {
+		return msg.GetPartyList()[i].GetPartyReference()
+	}); err != nil {
+		return err
+	}
+
+	if err := validateUniqueERNReferences("resource", len(msg.GetResourceList()), func(i int) string {
+		return getERNResourceReference(msg.GetResourceList()[i])
+	}); err != nil {
+		return err
+	}
+
+	if err := validateUniqueERNReferences("release", len(msg.GetReleaseList()), func(i int) string {
+		return getERNReleaseReference(msg.GetReleaseList()[i])
+	}); err != nil {
+		return err
+	}
+
+	return validateUniqueERNReferences("deal", len(msg.GetDealList()), func(i int) string {
+		return getERNDealReference(msg.GetDealList()[i])
+	})
+}
+
+func validateUniqueERNReferences(entityType string, count int, refAt func(int) string) error {
+	seen := make(map[string]int, count)
+	for i := 0; i < count; i++ {
+		ref := refAt(i)
+		if firstIndex, ok := seen[ref]; ok {
+			return fmt.Errorf("duplicate ERN %s reference %q at positions %d and %d", entityType, ref, firstIndex+1, i+1)
+		}
+		seen[ref] = i
+	}
+	return nil
+}
+
+func getERNResourceReference(resource *ddexv1beta1.Resource) string {
+	if sr := resource.GetSoundRecording(); sr != nil {
+		return sr.GetResourceReference()
+	}
+	if img := resource.GetImage(); img != nil {
+		return img.GetResourceReference()
+	}
+	return ""
+}
+
+func getERNReleaseReference(release *ddexv1beta1.Release) string {
+	if mr := release.GetMainRelease(); mr != nil {
+		return mr.GetReleaseReference()
+	}
+	if tr := release.GetTrackRelease(); tr != nil {
+		return tr.GetReleaseReference()
+	}
+	return ""
+}
+
+func getERNDealReference(deal *ddexv1beta1.Deal) string {
+	if deal == nil {
+		return ""
+	}
+	return deal.String()
+}
+
 // Validate an ERN message that's expected to be a NEW_MESSAGE, expects that the transaction header is valid
 func (s *Server) validateERNNewMessage(ctx context.Context, msg *ddexv1beta1.NewReleaseMessage) error {
 	// Check feature flag
 	if !s.config.ProgrammableDistributionEnabled {
 		return errors.New("programmable distribution is not enabled in this environment")
+	}
+
+	if err := validateUniqueERNEntityReferences(msg); err != nil {
+		return err
 	}
 
 	resourceList := msg.GetResourceList()

--- a/pkg/core/server/transaction_v2.go
+++ b/pkg/core/server/transaction_v2.go
@@ -18,7 +18,15 @@ var (
 )
 
 func (s *Server) validateV2Transaction(ctx context.Context, currentHeight int64, tx *v1beta1.Transaction) error {
+	if tx == nil || tx.Envelope == nil {
+		return errors.New("transaction envelope is nil")
+	}
+
 	header := tx.Envelope.Header
+	if header == nil {
+		return errors.New("transaction envelope header is nil")
+	}
+
 	if header.ChainId != s.config.GenesisFile.ChainID {
 		return ErrV2TransactionInvalidChainID
 	}
@@ -35,16 +43,28 @@ func (s *Server) validateV2Transaction(ctx context.Context, currentHeight int64,
 	// use errgroup to validate all messages
 	eg := errgroup.Group{}
 	for _, msg := range tx.Envelope.Messages {
+		msg := msg
 		eg.Go(func() error {
+			if msg == nil {
+				return errors.New("transaction message is nil")
+			}
+
 			switch msg.Message.(type) {
 			case *v1beta1.Message_Ern:
-				switch msg.GetErn().MessageHeader.MessageControlType {
-				case ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_NEW_MESSAGE.Enum():
-					return s.validateERNNewMessage(ctx, msg.GetErn())
-				case ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_UPDATED_MESSAGE.Enum():
-					return s.validateERNUpdateMessage(ctx, to, from, msg.GetErn())
-				case ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_TAKEDOWN_MESSAGE.Enum():
-					return s.validateERNTakedownMessage(ctx, msg.GetErn())
+				ern := msg.GetErn()
+				if ern == nil || ern.MessageHeader == nil || ern.MessageHeader.MessageControlType == nil {
+					return errors.New("ERN message control type is nil")
+				}
+
+				switch *ern.MessageHeader.MessageControlType {
+				case ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_NEW_MESSAGE, ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_TEST_MESSAGE:
+					return s.validateERNNewMessage(ctx, ern)
+				case ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_UPDATED_MESSAGE:
+					return s.validateERNUpdateMessage(ctx, to, from, ern)
+				case ddexv1beta1.MessageControlType_MESSAGE_CONTROL_TYPE_TAKEDOWN_MESSAGE:
+					return s.validateERNTakedownMessage(ctx, ern)
+				default:
+					return fmt.Errorf("unsupported ERN message control type: %s", ern.MessageHeader.GetMessageControlType())
 				}
 			case *v1beta1.Message_Mead:
 				return s.validateMEADNewMessage(ctx, msg.GetMead())


### PR DESCRIPTION
## Summary
- add a regression for duplicate ERN party references being accepted by `ProcessProposal` and poisoning commit in `FinalizeBlock`
- run v2 message validation during block proposal validation instead of only checking the v2 envelope shape
- reject duplicate ERN party/resource/release/deal references before normalized entity inserts can hit primary-key conflicts
- fix v2 ERN control-type dispatch to compare enum values, preserving `TEST_MESSAGE` as a new-message path

## TDD
- Red: `TestProcessProposalRejectsDuplicateERNPartyReferences` accepted the duplicate-reference proposal
- Red: `TestFinalizeBlockRejectsDuplicateERNPartyReferencesWithoutPoisoningCommit` failed with `commit unexpectedly resulted in rollback`
- Green: both tests pass after the validation fix

## Test Plan
- `TEST_DB_URL=postgres://localhost:55437/openaudio_test?host=/tmp/openaudio-ddex-pr-pg.UWFaMS go test ./pkg/core/server -run 'Test(ProcessProposalRejectsDuplicateERNPartyReferences|FinalizeBlockRejectsDuplicateERNPartyReferencesWithoutPoisoningCommit)' -count=1 -v`\n- `TEST_DB_URL=postgres://localhost:55437/openaudio_test?host=/tmp/openaudio-ddex-pr-pg.UWFaMS go test ./pkg/core/server -count=1`\n- `TEST_DB_URL=postgres://localhost:55437/openaudio_test?host=/tmp/openaudio-ddex-pr-pg.UWFaMS go test ./pkg/core/... -count=1`