### PR TITLE
fix: isolate manage entity metadata side writes

### DIFF
--- a/pkg/core/server/manage_entity.go
+++ b/pkg/core/server/manage_entity.go
@@ -55,7 +55,7 @@ func (s *Server) finalizeManageEntity(ctx context.Context, stx *v1.SignedTransac
 	// Populate sound_recordings and management_keys for Track Create/Update
 	if strings.EqualFold(manageEntity.EntityType, "Track") &&
 		(strings.EqualFold(manageEntity.Action, "Create") || strings.EqualFold(manageEntity.Action, "Update")) {
-		if err := s.processTrackManageEntity(ctx, manageEntity); err != nil {
+		if err := s.processTrackManageEntityBestEffort(ctx, manageEntity); err != nil {
 			s.logger.Error("failed to process track manage entity", zap.Error(err),
 				zap.String("entity_type", manageEntity.EntityType),
 				zap.Int64("entity_id", manageEntity.EntityId))
@@ -66,7 +66,32 @@ func (s *Server) finalizeManageEntity(ctx context.Context, stx *v1.SignedTransac
 	return manageEntity, nil
 }
 
+func (s *Server) processTrackManageEntityBestEffort(ctx context.Context, me *v1.ManageEntityLegacy) error {
+	if s.abciState != nil && s.abciState.onGoingBlock != nil {
+		savepoint, err := s.abciState.onGoingBlock.Begin(ctx)
+		if err != nil {
+			return fmt.Errorf("begin track metadata savepoint: %w", err)
+		}
+		if err := s.processTrackManageEntityWithQueries(ctx, s.db.WithTx(savepoint), me); err != nil {
+			if rollbackErr := savepoint.Rollback(ctx); rollbackErr != nil {
+				return fmt.Errorf("%w; rollback track metadata savepoint: %v", err, rollbackErr)
+			}
+			return err
+		}
+		if err := savepoint.Commit(ctx); err != nil {
+			return fmt.Errorf("commit track metadata savepoint: %w", err)
+		}
+		return nil
+	}
+
+	return s.processTrackManageEntity(ctx, me)
+}
+
 func (s *Server) processTrackManageEntity(ctx context.Context, me *v1.ManageEntityLegacy) error {
+	return s.processTrackManageEntityWithQueries(ctx, s.getDb(), me)
+}
+
+func (s *Server) processTrackManageEntityWithQueries(ctx context.Context, q *db.Queries, me *v1.ManageEntityLegacy) error {
 	var meta trackMetadata
 	if err := json.Unmarshal([]byte(me.Metadata), &meta); err != nil {
 		return fmt.Errorf("parse track metadata: %w", err)
@@ -74,7 +99,6 @@ func (s *Server) processTrackManageEntity(ctx context.Context, me *v1.ManageEnti
 
 	signers := meta.AccessAuthorities
 	trackID := strconv.FormatInt(me.EntityId, 10)
-	q := s.getDb()
 
 	if len(signers) == 0 {
 		// access_authorities null/empty: ungate the track by removing management keys

--- a/pkg/core/server/manage_entity_consensus_test.go
+++ b/pkg/core/server/manage_entity_consensus_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFinalizeBlockManageEntityMetadataErrorDoesNotPoisonCommit(t *testing.T) {
+	f := newManageEntityConsensusFixture(t)
+	txBytes := marshalManageEntitySignedTransactions(t,
+		makeTrackManageEntityTx(1, "QmSharedCID"),
+		makeTrackManageEntityTx(2, "QmSharedCID"),
+	)
+
+	height := f.blockHeight + 1
+	blockTime := time.Unix(height, 0).UTC()
+	processResp, err := f.server.ProcessProposal(f.ctx, &abcitypes.ProcessProposalRequest{
+		Height: height,
+		Time:   blockTime,
+		Txs:    txBytes,
+	})
+	require.NoError(t, err)
+	require.Equal(t, abcitypes.PROCESS_PROPOSAL_STATUS_ACCEPT, processResp.Status)
+
+	finalizeResp, err := f.server.FinalizeBlock(f.ctx, &abcitypes.FinalizeBlockRequest{
+		Height: height,
+		Hash:   []byte{1, 2, 3, 4},
+		Time:   blockTime,
+		Txs:    txBytes,
+	})
+	require.NoError(t, err)
+	require.Len(t, finalizeResp.TxResults, 2)
+	require.Equal(t, uint32(0), finalizeResp.TxResults[0].Code)
+	require.Equal(t, uint32(0), finalizeResp.TxResults[1].Code)
+	require.NoError(t, f.server.commitInProgressTx(f.ctx))
+}
+
+type manageEntityConsensusFixture struct {
+	ctx         context.Context
+	server      *Server
+	blockHeight int64
+}
+
+func newManageEntityConsensusFixture(t *testing.T) *manageEntityConsensusFixture {
+	t.Helper()
+
+	f := newRegistrationConsensusFixture(t)
+	setupManageEntityConsensusTestDB(t, f.server.pool)
+	return &manageEntityConsensusFixture{
+		ctx:         f.ctx,
+		server:      f.server,
+		blockHeight: f.blockHeight,
+	}
+}
+
+func makeTrackManageEntityTx(trackID int64, cid string) *v1.SignedTransaction {
+	metadata := fmt.Sprintf(`{"access_authorities":["0x0000000000000000000000000000000000000001"],"data":{"track_cid":%q}}`, cid)
+	return &v1.SignedTransaction{
+		Transaction: &v1.SignedTransaction_ManageEntity{
+			ManageEntity: &v1.ManageEntityLegacy{
+				EntityType: "Track",
+				EntityId:   trackID,
+				Action:     "Create",
+				Metadata:   metadata,
+			},
+		},
+	}
+}
+
+func marshalManageEntitySignedTransactions(t *testing.T, txs ...*v1.SignedTransaction) [][]byte {
+	t.Helper()
+
+	txBytes := make([][]byte, 0, len(txs))
+	for _, tx := range txs {
+		b, err := proto.Marshal(tx)
+		require.NoError(t, err)
+		txBytes = append(txBytes, b)
+	}
+	return txBytes
+}
+
+func setupManageEntityConsensusTestDB(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+
+	_, err := pool.Exec(context.Background(), `
+		CREATE TABLE IF NOT EXISTS sound_recordings(
+			id serial primary key,
+			sound_recording_id text not null,
+			track_id text not null,
+			cid text not null unique,
+			encoding_details text
+		);
+		CREATE TABLE IF NOT EXISTS management_keys(
+			id serial primary key,
+			track_id text not null,
+			pub_key text not null
+		);
+		TRUNCATE sound_recordings, management_keys;
+	`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `
+			DROP TABLE IF EXISTS management_keys;
+			DROP TABLE IF EXISTS sound_recordings;
+		`)
+	})
+}


### PR DESCRIPTION
## Summary
- add a consensus regression for two accepted Track `ManageEntity` txs sharing the same `track_cid`
- keep Track metadata side writes best-effort by running them inside a nested Postgres transaction/savepoint
- roll back only those side writes when metadata processing hits a DB error, instead of leaving the whole block transaction aborted

## What stalled consensus
`finalizeManageEntity` intentionally logs Track metadata-processing failures and keeps the tx successful. But those writes happen inside the block transaction. A duplicate `sound_recordings.cid` error marks the Postgres transaction aborted; because the error is ignored, `FinalizeBlock` still returns tx code 0 and the later commit fails with `commit unexpectedly resulted in rollback`.

## TDD / fuzz evidence
- Red targeted regression: `TestFinalizeBlockManageEntityMetadataErrorDoesNotPoisonCommit` failed with `commit unexpectedly resulted in rollback`
- Scratch fuzz target exposed the same seed case: `FuzzFinalizeBlockManageEntityTrackMetadata/seed#0`
- Green after savepoint fix

## Test Plan
- `TEST_DB_URL=postgres://localhost:55437/openaudio_test?host=/tmp/openaudio-ddex-pr-pg.UWFaMS go test ./pkg/core/server -run TestFinalizeBlockManageEntityMetadataErrorDoesNotPoisonCommit -count=1 -v`
- `TEST_DB_URL=postgres://localhost:55437/openaudio_test?host=/tmp/openaudio-ddex-pr-pg.UWFaMS go test ./pkg/core/server -count=1`
- `TEST_DB_URL=postgres://localhost:55437/openaudio_test?host=/tmp/openaudio-ddex-pr-pg.UWFaMS go test ./pkg/core/... -count=1`