### PR TITLE
chore: quiet mediorum upload logs

### DIFF
--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -378,7 +378,11 @@ func New(lc *lifecycle.Lifecycle, logger *zap.Logger, config MediorumConfig, pos
 	echoServer.Debug = true
 
 	echoServer.Use(middleware.Recover())
-	echoServer.Use(middleware.Logger())
+	echoServer.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Skipper: func(c echo.Context) bool {
+			return strings.HasPrefix(c.Request().URL.Path, "/files/")
+		},
+	}))
 	echoServer.Use(common.CORS())
 	echoServer.Use(timingMiddleware)
 

--- a/pkg/mediorum/server/tusd.go
+++ b/pkg/mediorum/server/tusd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tus/tusd/v2/pkg/handler"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
+	"golang.org/x/exp/slog"
 )
 
 func (ss *MediorumServer) setupTusdHandler() (*handler.Handler, error) {
@@ -40,6 +41,7 @@ func (ss *MediorumServer) setupTusdHandler() (*handler.Handler, error) {
 		BasePath:                "/files/",
 		StoreComposer:           composer,
 		DisableDownload:         true,
+		Logger:                  slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})),
 		NotifyCreatedUploads:    true,
 		NotifyCompleteUploads:   true,
 		RespectForwardedHeaders: true,


### PR DESCRIPTION
## Summary
- skip Echo access logs for tusd `/files/` upload traffic
- set the embedded tusd logger to error level so request/progress/deadline chatter stays out of stdout

## Testing
- `go test -c -o /tmp/mediorum-server.test ./pkg/mediorum/server`
- `go test ./pkg/mediorum/server` (blocked locally: Postgres on `:5454` is not running)